### PR TITLE
fly.io example updates

### DIFF
--- a/examples/fly/Dockerfile
+++ b/examples/fly/Dockerfile
@@ -25,24 +25,25 @@ RUN --mount=type=cache,target=/usr/local/cargo,from=rust:latest,source=/usr/loca
     cargo build --release && mv target/release/corrosion ./
 
 # Runtime image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
+RUN apt update && apt install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/bin/nperf /usr/local/bin/nperf
 
 # Run as "corrosion" user
 RUN useradd -ms /bin/bash corrosion
 
-COPY examples/fly/entrypoint.sh /entrypoint
+COPY examples/fly/entrypoint.sh /entrypoint.sh
 
-USER corrosion
-WORKDIR /app
+# USER corrosion
+# WORKDIR /app
 
-COPY examples/fly/config.toml /app/config.toml
-COPY examples/fly/schemas /app/schemas
+COPY examples/fly/config.toml /etc/corrosion/config.toml
+COPY examples/fly/schemas /etc/corrosion/schemas
 
 # Get compiled binaries from builder's cargo install directory
-COPY --from=builder /usr/src/app/corrosion /app/corrosion
+COPY --from=builder /usr/src/app/corrosion /usr/bin/corrosion
 
-ENTRYPOINT ["/entrypoint"]
+ENTRYPOINT ["/entrypoint.sh"]
 # Run the app
-CMD ["/app/corrosion", "agent", "-c", "/app/config.toml"]
+CMD ["corrosion", "agent"]

--- a/examples/fly/config.toml
+++ b/examples/fly/config.toml
@@ -1,7 +1,7 @@
 [db]
 path = "/var/lib/corrosion/state.db"
-schema_paths = ["/app/schemas"]
-
+schema_paths = ["/etc/corrosion/schemas"]
+    
 [gossip]
 # addr and bootstrap for Fly.io deployment example are written 
 # on startup by entrypoint script

--- a/examples/fly/entrypoint.sh
+++ b/examples/fly/entrypoint.sh
@@ -3,6 +3,8 @@
 # Add gossip and bootstrap addresses to Corrosion config file before 
 # starting agent with Dockerfile CMD
 sed -i 's/\[gossip\]/&\naddr = "['${FLY_PRIVATE_IP}']:8787"\
-bootstrap = ["'${FLY_APP_NAME}'.internal:8787"]/' /app/config.toml
+bootstrap = ["'${FLY_APP_NAME}'.internal:8787"]/' /etc/corrosion/config.toml
+
+su - corrosion
 
 exec "$@"

--- a/examples/fly/fly.toml
+++ b/examples/fly/fly.toml
@@ -1,4 +1,4 @@
-app = "corrosion2"
+app = "corrosion"
 
 [env]
 RUST_BACKTRACE="1"

--- a/examples/fly/schemas/tests.sql
+++ b/examples/fly/schemas/tests.sql
@@ -1,1 +1,0 @@
-CREATE TABLE tests (id BIGINT PRIMARY KEY, foo TEXT);

--- a/examples/fly/schemas/todo.sql
+++ b/examples/fly/schemas/todo.sql
@@ -1,0 +1,5 @@
+CREATE TABLE todos (
+    id BLOB PRIMARY KEY,
+    title TEXT NOT NULL DEFAULT '',
+    completed_at INTEGER
+);


### PR DESCRIPTION
* Dockerfile:
  * add sqlite3 so generic exercises in the quick-start doc work
  * put files into conventional locations on the Machine: not so many flags needed and corrosion binary is in PATH
  * don't switch users yet, so root can run entrypoint script and edit the config file in /etc
* Matching changes to entrypoint.sh and config.toml
* Change app name to corrosion in fly.toml
* Replace schema with the todo example from docs

