### PR TITLE
Persistent subscriptions weren't resumed properly

### DIFF
--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -528,6 +528,7 @@ async fn build_query_rows_response(
 
             _ = data_tx.blocking_send(QueryEvent::EndOfQuery {
                 time: elapsed.as_secs_f64(),
+                change_id: None,
             });
         });
     });
@@ -692,7 +693,9 @@ pub async fn api_v1_db_schema(
 mod tests {
     use arc_swap::ArcSwap;
     use bytes::Bytes;
-    use corro_types::{actor::ActorId, agent::SplitPool, config::Config, schema::SqliteType, api::RowId};
+    use corro_types::{
+        actor::ActorId, agent::SplitPool, api::RowId, config::Config, schema::SqliteType,
+    };
     use futures::Stream;
     use http_body::{combinators::UnsyncBoxBody, Body};
     use tokio::sync::mpsc::{channel, error::TryRecvError};

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -25,6 +25,8 @@ pub enum QueryEvent {
     #[serde(rename = "eoq")]
     EndOfQuery {
         time: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        change_id: Option<ChangeId>,
     },
     Change(ChangeType, RowId, Vec<SqliteValue>, ChangeId),
     Error(CompactString),

--- a/crates/corro-client/src/sub.rs
+++ b/crates/corro-client/src/sub.rs
@@ -133,8 +133,11 @@ impl SubscriptionStream {
         match res {
             Some(Ok(b)) => match serde_json::from_slice(&b) {
                 Ok(evt) => {
-                    if let QueryEvent::EndOfQuery { .. } = &evt {
+                    if let QueryEvent::EndOfQuery { change_id, .. } = &evt {
                         self.observed_eoq = true;
+                        if let Some(change_id) = change_id {
+                            self.last_change_id = *change_id;
+                        }
                     }
                     if let QueryEvent::Change(_, _, _, change_id) = &evt {
                         if self.last_change_id.0 + 1 != change_id.0 {

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -181,6 +181,10 @@ impl MatcherHandle {
         Ok(())
     }
 
+    pub fn id(&self) -> Uuid {
+        self.0.id
+    }
+
     pub fn table_name(&self) -> &str {
         &self.0.qualified_table_name
     }
@@ -562,7 +566,7 @@ impl Matcher {
 
                         let deleted = tx
                             .prepare_cached(&format!(
-                                "DELETE FROM {} WHERE id < (SELECT MAX(id) - 500 FROM {})",
+                                "DELETE FROM {} WHERE id < (SELECT COALESCE(MAX(id),0) - 500 FROM {})",
                                 self.qualified_changes_table_name,
                                 self.qualified_changes_table_name
                             ))?
@@ -680,6 +684,7 @@ impl Matcher {
                     .evt_tx
                     .send(QueryEvent::EndOfQuery {
                         time: elapsed.as_secs_f64(),
+                        change_id: Some(ChangeId(0)),
                     })
                     .await
                 {

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -203,7 +203,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
                                 .join("|")
                         );
                     }
-                    QueryEvent::EndOfQuery { time } => {
+                    QueryEvent::EndOfQuery { time, .. } => {
                         if *timer {
                             println!("time: {time}s");
                         }

--- a/doc/api/subscriptions.md
+++ b/doc/api/subscriptions.md
@@ -169,10 +169,18 @@ It is encouraged to provide a seamless experience in the event of network errors
 
 Retrying in a loop w/ a backoff is encouraged, as long as the client gives up after a while and return an error actionable by programs or users.
 
-# Integration guide
+# Usage guide
 
 ## Reactivity
 
 Mapping data by row ID (often referred to as `rowid`) is ideal. When receiving changes, they refer to the affected rowid so a consumer can proceed with modifying data with minimal memory usage.
 
 In many cases, it may not be necessary to store each row's cells and instead just a reference to their position in a document or a cheap-to-clone type.
+
+## Caveats
+
+### Row ordering is not preserved
+
+Root-level ORDER BY won't be honored for changes. Meaning new rows will be out of order relative to previously returned rows. Ordering is only kept for a full set of changes (equivalent to creating a transaction).
+
+"Inner" ordering should work just fine as each query result is re-computed when there are changes. That means if you have a a subquery in your query, its ordering will be honored.


### PR DESCRIPTION
A few untested cases caused issues, fixed and:
- Added a `change_id` property on End Of Query which makes clients more efficient.
- Added more docs for completeness.