### PR TITLE
Bundle consul services and checks in the same transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `corrosion consul sync` will now bundle services and checks in a single transaction (changeset) ([#73](../../pull/73))
 - (**BREAKING**) Persist subscriptions across reboots, including many reliability improvements ([#69](../../pull/69))
 - Support existing tables being added to the schema ([#64](../../pull/64))
 


### PR DESCRIPTION
This should improve consul data consistency as changes won't be applied until both services and checks data are received. Matching checks should have the right state for the current services.