### PR TITLE
Remove possible blockages

### DIFF
--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -2340,7 +2340,12 @@ async fn sync_loop(
                         warn!("aborted sync by tripwire");
                         break;
                     }
-                    tripwire::Outcome::Completed(_res) => {}
+                    tripwire::Outcome::Completed(res) => {
+                        if res.is_err() {
+                            // keep syncing until we successfully sync
+                            continue;
+                        }
+                    }
                 }
                 next_sync_at
                     .as_mut()

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -1103,7 +1103,7 @@ async fn clear_overwritten_versions(agent: Agent) {
 
                     if res.is_ok() {
                         // give it a break...
-                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        tokio::time::sleep(Duration::from_millis(500)).await;
                     }
 
                     res

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -1040,7 +1040,7 @@ async fn clear_overwritten_versions(agent: Agent) {
 
                     let mut bookedw = booked.write().await;
 
-                    let db_versions: Vec<i64> = chunked_db_version.iter().copied().filter(|v|bookedw.contains_current(v)).collect();
+                    let db_versions: Vec<i64> = chunked_db_version.iter().copied().filter(|db_v| versions.get(db_v).map(|v| bookedw.contains_current(v)).unwrap_or(false)).collect();
                     if db_versions.is_empty() {
                         info!(%actor_id, "no versions in range {chunked_db_version:?}, skipping!");
                         return Ok(delta);

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -969,8 +969,15 @@ async fn require_authz<B>(
 async fn clear_overwritten_versions(agent: Agent) {
     let pool = agent.pool();
     let bookie = agent.bookie();
+
+    let mut interval = Duration::new(0, 0);
+
     loop {
-        sleep(COMPACT_BOOKED_INTERVAL).await;
+        sleep(interval).await;
+
+        if interval != COMPACT_BOOKED_INTERVAL {
+            interval = COMPACT_BOOKED_INTERVAL;
+        }
 
         info!("starting compaction...");
 

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -772,7 +772,7 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     };
 
     if !states.is_empty() {
-        let mut foca_states = Vec::with_capacity(states.len());
+        // let mut foca_states = Vec::with_capacity(states.len());
 
         {
             // block to drop the members write lock
@@ -787,11 +787,11 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
                 if matches!(foca_state.state(), foca::State::Suspect) {
                     continue;
                 }
-                foca_states.push(foca_state);
+                // foca_states.push(foca_state);
             }
         }
 
-        foca_tx.send(FocaInput::ApplyMany(foca_states)).await.ok();
+        // foca_tx.send(FocaInput::ApplyMany(foca_states)).await.ok();
     }
 
     let api = Router::new()

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -10,7 +10,7 @@ use std::{
 
 use arc_swap::ArcSwap;
 use camino::Utf8PathBuf;
-use metrics::{gauge, histogram, increment_counter};
+use metrics::{gauge, histogram};
 use parking_lot::RwLock;
 use rangemap::{RangeInclusiveMap, RangeInclusiveSet};
 use rusqlite::{Connection, InterruptHandle};
@@ -29,7 +29,7 @@ use tokio::{
     task::block_in_place,
 };
 use tokio_util::sync::{CancellationToken, DropGuard};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info};
 use tripwire::Tripwire;
 
 use crate::{
@@ -370,8 +370,8 @@ impl SplitPool {
 
 async fn timeout_wait(
     token: CancellationToken,
-    handle: InterruptHandle,
-    timeout: Duration,
+    _handle: InterruptHandle,
+    _timeout: Duration,
     queue: &'static str,
 ) {
     let start = Instant::now();
@@ -562,6 +562,10 @@ impl<'a> BookWriter<'a> {
             },
             None => self.0.contains_key(&version),
         }
+    }
+
+    pub fn contains_current(&self, version: &i64) -> bool {
+        matches!(self.0.get(version), Some(KnownDbVersion::Current { .. }))
     }
 
     pub fn contains_all(

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -375,19 +375,21 @@ async fn timeout_wait(
     queue: &'static str,
 ) {
     let start = Instant::now();
-    tokio::select! {
-        biased;
-        _ = token.cancelled() => {
-            trace!("conn dropped before timeout");
-            histogram!("corro.sqlite.pool.execution.seconds", start.elapsed().as_secs_f64(), "queue" => queue);
-            return;
-        },
-        _ = tokio::time::sleep(timeout) => {
-            warn!("conn execution timed out, interrupting!");
-        }
-    }
-    handle.interrupt();
-    increment_counter!("corro.sqlite.pool.execution.timeout");
+    token.cancelled().await;
+    histogram!("corro.sqlite.pool.execution.seconds", start.elapsed().as_secs_f64(), "queue" => queue);
+    // tokio::select! {
+    //     biased;
+    //     _ = token.cancelled() => {
+    //         trace!("conn dropped before timeout");
+    //         histogram!("corro.sqlite.pool.execution.seconds", start.elapsed().as_secs_f64(), "queue" => queue);
+    //         return;
+    //     },
+    //     _ = tokio::time::sleep(timeout) => {
+    //         warn!("conn execution timed out, interrupting!");
+    //     }
+    // }
+    // handle.interrupt();
+    // increment_counter!("corro.sqlite.pool.execution.timeout");
     // FIXME: do we need to cancel the token?
 }
 


### PR DESCRIPTION
This aims at reducing the possibilities of stalling w/ the following:
- Don't interrupt long-running SQLite executions. They're pretty much always necessary. The only way that would be problematic is if we have a deadlock in Corrosion within a transaction.
- Rewrite the compaction logic to do a single-ish query to get all cleared versions
- Keep synchronizing in a loop until a synchronization completes successfully.
