### PR TITLE
Batch insertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,9 +1360,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foca"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73879bd4f1b8e2a1a39886488ac24641b20ade95238726325d516ae98d1ed00a"
+checksum = "1ae5801563a919f58548b626bbf37ab589cfbf8c18007ddae589207338abd05e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3877,18 +3877,17 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uhlc"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
+checksum = "d1eadef1fa26cbbae1276c46781e8f4d888bdda434779c18ae6c2a0e69991885"
 dependencies = [
  "defmt",
- "hex",
  "humantime",
  "lazy_static",
  "log",
+ "rand",
  "serde",
  "spin 0.9.8",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ crc32fast = "1.3.2"
 enquote = "1.1.0"
 eyre = "0.6.8"
 fallible-iterator = "0.2.0"
-foca = { version = "0.15.0", features = ["std", "tracing", "bincode-codec", "serde"] }
+foca = { version = "0.16.0", features = ["std", "tracing", "bincode-codec", "serde"] }
 futures = "0.3.28"
 futures-util = "0.3.28"
 hex = "0.4.3"
@@ -69,7 +69,7 @@ tracing = "0.1.37"
 tracing-filter = { version = "0.1.0-alpha.2", features = ["smallvec"] }
 tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 trust-dns-resolver = "0.22.0"
-uhlc = { version = "0.5.2", features = ["defmt"] }
+uhlc = { version = "0.6.3", features = ["defmt"] }
 uuid = { version = "1.3.1", features = ["v4", "serde"] }
 webpki = { version = "0.22.0", features = ["std"] }
 http = { version = "0.2.9" }

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -1745,10 +1745,8 @@ async fn process_fully_buffered_changes(
             debug!("db version: {db_version}");
 
             let end_seq: i64 = tx
-                .prepare_cached(
-                    "SELECT MAX(seq) FROM crsql_changes WHERE db_version = crsql_next_db_version()",
-                )?
-                .query_row((), |row| row.get(0))?;
+                .prepare_cached("SELECT MAX(seq) FROM crsql_changes WHERE db_version = ?")?
+                .query_row([db_version], |row| row.get(0))?;
 
             tx.prepare_cached("
                 INSERT INTO __corro_bookkeeping (actor_id, start_version, db_version, start_seq, end_seq, last_seq, ts)
@@ -2220,10 +2218,8 @@ fn process_complete_version(
         (KnownDbVersion::Cleared, Changeset::Empty { versions })
     } else {
         let end_seq: i64 = tx
-            .prepare_cached(
-                "SELECT MAX(seq) FROM crsql_changes WHERE db_version = crsql_next_db_version()",
-            )?
-            .query_row((), |row| row.get(0))?;
+            .prepare_cached("SELECT MAX(seq) FROM crsql_changes WHERE db_version = ?")?
+            .query_row([db_version], |row| row.get(0))?;
         (
             KnownDbVersion::Current {
                 db_version,

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -2194,13 +2194,12 @@ fn process_complete_version(
         last_rows_impacted = rows_impacted;
     }
 
-    let db_version: i64 = tx
-        .prepare_cached("SELECT crsql_next_db_version()")?
-        .query_row((), |row| row.get(0))?;
-
     let (known_version, new_changeset) = if impactful_changeset.is_empty() {
         (KnownDbVersion::Cleared, Changeset::Empty { versions })
     } else {
+        let db_version: i64 = tx
+            .prepare_cached("SELECT crsql_next_db_version()")?
+            .query_row((), |row| row.get(0))?;
         let end_seq: i64 = tx
             .prepare_cached("SELECT MAX(seq) FROM crsql_changes WHERE db_version = ?")?
             .query_row([db_version], |row| row.get(0))?;
@@ -2856,6 +2855,7 @@ pub mod tests {
 
         println!("body: {body:?}");
 
+        #[allow(clippy::type_complexity)]
         let bk: Vec<(ActorId, i64, Option<i64>, i64, Option<i64>, Option<i64>, Option<i64>)> = ta1
             .agent
             .pool()

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -2814,12 +2814,12 @@ pub mod tests {
         println!("body: {body:?}");
 
         #[allow(clippy::type_complexity)]
-        let bk: Vec<(ActorId, i64, Option<i64>, i64, Option<i64>, Option<i64>, Option<i64>)> = ta1
+        let bk: Vec<(ActorId, i64, Option<i64>, i64, Option<i64>)> = ta1
             .agent
             .pool()
             .read()
             .await?
-            .prepare("SELECT actor_id, start_version, end_version, db_version, start_seq, end_seq, last_seq FROM __corro_bookkeeping")?
+            .prepare("SELECT actor_id, start_version, end_version, db_version, last_seq FROM __corro_bookkeeping")?
             .query_map((), |row| {
                 Ok((
                     row.get::<_, ActorId>(0)?,
@@ -2827,8 +2827,6 @@ pub mod tests {
                     row.get::<_, Option<i64>>(2)?,
                     row.get::<_, i64>(3)?,
                     row.get::<_, Option<i64>>(4)?,
-                    row.get::<_, Option<i64>>(5)?,
-                    row.get::<_, Option<i64>>(6)?,
                 ))
             })?
             .collect::<rusqlite::Result<_>>()?;
@@ -2836,8 +2834,8 @@ pub mod tests {
         assert_eq!(
             bk,
             vec![
-                (ta1.agent.actor_id(), 1, None, 1, Some(0), Some(0), Some(0)),
-                (ta1.agent.actor_id(), 2, None, 2, Some(0), Some(0), Some(0))
+                (ta1.agent.actor_id(), 1, None, 1, Some(0)),
+                (ta1.agent.actor_id(), 2, None, 2, Some(0))
             ]
         );
 

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -926,7 +926,7 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     tokio::spawn(metrics_loop(agent.clone()));
 
     let gossip_chunker =
-        ReceiverStream::new(bcast_rx).chunks_timeout(10, Duration::from_millis(500));
+        ReceiverStream::new(bcast_rx).chunks_timeout(50, Duration::from_millis(500));
     tokio::pin!(gossip_chunker);
 
     loop {

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -248,7 +248,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
 
     let clock = Arc::new(
         uhlc::HLCBuilder::default()
-            .with_id(actor_id.into())
+            .with_id(actor_id.try_into().unwrap())
             .with_max_delta(Duration::from_millis(300))
             .build(),
     );
@@ -373,7 +373,11 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     let (member_events_tx, member_events_rx) = tokio::sync::broadcast::channel::<MemberEvent>(512);
 
     runtime_loop(
-        Actor::new(actor_id, agent.gossip_addr()),
+        Actor::new(
+            actor_id,
+            agent.gossip_addr(),
+            agent.clock().new_timestamp().into(),
+        ),
         agent.clone(),
         transport.clone(),
         foca_rx,

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -1781,14 +1781,6 @@ async fn process_fully_buffered_changes(
         } else {
             store_empty_changeset(&tx, actor_id, version..=version)?;
 
-            // if inserted > 0 {
-            //     info!(%actor_id, version, "inserted CLEARED bookkeeping row after buffered insert");
-            //     Some(KnownDbVersion::Cleared)
-            // } else {
-            //     warn!(%actor_id, version, "bookkeeping row already existed, it shouldn't matter but it would be nice to fix this issue");
-            //     None
-            // }
-
             info!(%actor_id, version, "inserted CLEARED bookkeeping row after buffered insert");
             Some(KnownDbVersion::Cleared)
         };
@@ -1977,22 +1969,14 @@ pub async fn process_multiple_changes(
                         let version = versions.start();
                         debug!(%actor_id, self_actor_id = %agent.actor_id(), version, "inserting bookkeeping row db_version: {db_version}, ts: {ts:?}");
                         tx.prepare_cached("
-                            INSERT INTO __corro_bookkeeping (actor_id, start_version, db_version, start_seq, end_seq, last_seq, ts)
-                                VALUES (
-                                    :actor_id,
-                                    :version,
-                                    :db_version,
-                                    :start_seq,
-                                    :end_seq,
-                                    :last_seq,
-                                    :ts
-                                );")?
+                            INSERT INTO __corro_bookkeeping ( actor_id,  start_version,  db_version,  start_seq,  end_seq,  last_seq,  ts)
+                                                    VALUES  (:actor_id, :start_version, :db_version, :start_seq, :end_seq, :last_seq, :ts);")?
                             .execute(named_params!{
                                 ":actor_id": actor_id,
-                                ":version": *version,
+                                ":start_version": *version,
                                 ":db_version": *db_version,
                                 ":start_seq": *start_seq,
-                                ":start_seq": *end_seq,
+                                ":end_seq": *end_seq,
                                 ":last_seq": *last_seq,
                                 ":ts": *ts
                             })?;

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -777,7 +777,7 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     };
 
     if !states.is_empty() {
-        // let mut foca_states = Vec::with_capacity(states.len());
+        let mut foca_states = Vec::with_capacity(states.len());
 
         {
             // block to drop the members write lock
@@ -792,11 +792,11 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
                 if matches!(foca_state.state(), foca::State::Suspect) {
                     continue;
                 }
-                // foca_states.push(foca_state);
+                foca_states.push(foca_state);
             }
         }
 
-        // foca_tx.send(FocaInput::ApplyMany(foca_states)).await.ok();
+        foca_tx.send(FocaInput::ApplyMany(foca_states)).await.ok();
     }
 
     let api = Router::new()

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -917,7 +917,6 @@ pub async fn bidirectional_sync(
                         }
                     },
                     _ = check_buf.tick() => {
-                        println!("checking if buf is not empty and sending if necessary, len: {}", send_buf.len());
                         if !send_buf.is_empty() {
                             write_sync_buf(&mut send_buf, &mut write).await?;
                         }

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -406,7 +406,7 @@ fn handle_known_version(
     ts: Timestamp,
     sender: &Sender<SyncMessage>,
 ) -> eyre::Result<()> {
-    trace!(%actor_id, %version, "handle known version! known: {init_known:?}, seqs_needed: {seqs_needed:?}");
+    debug!(%actor_id, %version, "handle known version! known: {init_known:?}, seqs_needed: {seqs_needed:?}");
     let mut seqs_iter = seqs_needed.into_iter();
     while let Some(range_needed) = seqs_iter.by_ref().next() {
         match &init_known {
@@ -773,7 +773,7 @@ async fn process_sync(
             .last()
             .unwrap_or(0);
 
-        debug!(actor_id = %local_actor_id, "their last version: {their_last_version} vs ours: {our_last_version}");
+        trace!(actor_id = %local_actor_id, "their last version: {their_last_version} vs ours: {our_last_version}");
 
         if their_last_version >= our_last_version {
             // nothing to teach the other node!

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -12,7 +12,7 @@ use corro_types::{
     api::{row_to_change, ExecResponse, ExecResult, QueryEvent, Statement},
     broadcast::{ChangeV1, Changeset, Timestamp},
     change::SqliteValue,
-    schema::{make_schema_inner, parse_sql},
+    schema::{apply_schema, parse_sql},
     sqlite::SqlitePoolError,
 };
 use hyper::StatusCode;
@@ -646,7 +646,7 @@ async fn execute_schema(agent: &Agent, statements: Vec<String>) -> eyre::Result<
     block_in_place(|| {
         let tx = conn.transaction()?;
 
-        make_schema_inner(&tx, &schema_write, &mut new_schema)?;
+        apply_schema(&tx, &schema_write, &mut new_schema)?;
 
         for tbl_name in partial_schema.tables.keys() {
             tx.execute("DELETE FROM __corro_schema WHERE tbl_name = ?", [tbl_name])?;

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -9,7 +9,7 @@ use bytes::{BufMut, BytesMut};
 use compact_str::ToCompactString;
 use corro_types::{
     agent::{Agent, ChangeError, KnownDbVersion},
-    api::{row_to_change_no_sub, ExecResponse, ExecResult, QueryEvent, Statement},
+    api::{row_to_change, ExecResponse, ExecResult, QueryEvent, Statement},
     broadcast::{ChangeV1, Changeset, Timestamp},
     change::SqliteValue,
     schema::{make_schema_inner, parse_sql},
@@ -18,7 +18,7 @@ use corro_types::{
 use hyper::StatusCode;
 use itertools::Itertools;
 use metrics::counter;
-use rusqlite::{named_params, params, params_from_iter, ToSql, Transaction};
+use rusqlite::{named_params, params_from_iter, ToSql, Transaction};
 use spawn::spawn_counted;
 use tokio::{
     sync::{
@@ -255,7 +255,7 @@ where
                           AND db_version = ?
                         ORDER BY seq ASC
                 "#)?;
-                let rows = prepped.query_map([db_version], row_to_change_no_sub)?;
+                let rows = prepped.query_map([db_version], row_to_change)?;
                 let chunked = ChunkedChanges::new(rows, 0, last_seq, MAX_CHANGES_BYTE_SIZE);
                 for changes_seqs in chunked {
                     match changes_seqs {

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -363,7 +363,7 @@ pub fn runtime_loop(
                                 let foca_state = {
                                     // need to bind this...
                                     let foca_state = foca
-                                        .iter_members()
+                                        .iter_membership_state()
                                         .find(|member| member.id().id() == actor.id())
                                         .and_then(|member| match serde_json::to_string(member) {
                                             Ok(foca_state) => Some(foca_state),

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -419,12 +419,12 @@ pub fn runtime_loop(
                                     );
 
                                     let upserted = tx.prepare_cached("INSERT INTO __corro_members (actor_id, address, state, foca_state, rtts)
-                                                VALUES (?, ?, ?, ?, ?)
-                                            ON CONFLICT (actor_id) DO UPDATE SET
-                                                address = excluded.address,
-                                                state = excluded.state,
-                                                foca_state = excluded.foca_state,
-                                                rtts = excluded.rtts;")?
+                                            VALUES (?, ?, ?, ?, ?)
+                                        ON CONFLICT (actor_id) DO UPDATE SET
+                                            address = excluded.address,
+                                            state = excluded.state,
+                                            foca_state = excluded.foca_state,
+                                            rtts = excluded.rtts;")?
                                     .execute(params![
                                         id,
                                         address.to_string(),

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -175,7 +175,7 @@ impl Change {
     }
 }
 
-pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
+pub fn row_to_change_no_sub(row: &Row) -> Result<Change, rusqlite::Error> {
     Ok(Change {
         table: row.get(0)?,
         pk: row.get(1)?,
@@ -186,6 +186,13 @@ pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
         seq: row.get(6)?,
         site_id: row.get(7)?,
         cl: row.get(8)?,
+    })
+}
+
+pub fn row_to_change(row: &Row, sub: i64) -> Result<Change, rusqlite::Error> {
+    row_to_change_no_sub(row).map(|mut change| {
+        change.seq -= sub;
+        change
     })
 }
 

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -175,7 +175,7 @@ impl Change {
     }
 }
 
-pub fn row_to_change_no_sub(row: &Row) -> Result<Change, rusqlite::Error> {
+pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
     Ok(Change {
         table: row.get(0)?,
         pk: row.get(1)?,
@@ -186,13 +186,6 @@ pub fn row_to_change_no_sub(row: &Row) -> Result<Change, rusqlite::Error> {
         seq: row.get(6)?,
         site_id: row.get(7)?,
         cl: row.get(8)?,
-    })
-}
-
-pub fn row_to_change(row: &Row, sub: i64) -> Result<Change, rusqlite::Error> {
-    row_to_change_no_sub(row).map(|mut change| {
-        change.seq -= sub;
-        change
     })
 }
 

--- a/crates/corro-types/src/actor.rs
+++ b/crates/corro-types/src/actor.rs
@@ -162,7 +162,7 @@ impl Actor {
 
 impl From<SocketAddr> for Actor {
     fn from(value: SocketAddr) -> Self {
-        Self::new(ActorId(Uuid::nil()), value, Timestamp(0))
+        Self::new(ActorId(Uuid::nil()), value, Timestamp::zero())
     }
 }
 

--- a/crates/corro-types/src/actor.rs
+++ b/crates/corro-types/src/actor.rs
@@ -1,4 +1,10 @@
-use std::{fmt, hash::Hash, net::SocketAddr, ops::Deref};
+use std::{
+    fmt,
+    hash::Hash,
+    net::SocketAddr,
+    ops::Deref,
+    time::{Duration, SystemTime},
+};
 
 use corro_api_types::SqliteValue;
 use foca::Identity;
@@ -8,7 +14,10 @@ use rusqlite::{
 };
 use serde::{Deserialize, Serialize};
 use speedy::{Context, Readable, Reader, Writable, Writer};
+use uhlc::NTP64;
 use uuid::Uuid;
+
+use crate::broadcast::Timestamp;
 
 #[derive(
     Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize,
@@ -30,9 +39,11 @@ impl ActorId {
     }
 }
 
-impl From<ActorId> for uhlc::ID {
-    fn from(val: ActorId) -> Self {
-        val.0.into()
+impl TryFrom<ActorId> for uhlc::ID {
+    type Error = uhlc::SizeError;
+
+    fn try_from(value: ActorId) -> Result<Self, Self::Error> {
+        value.as_bytes().try_into()
     }
 }
 
@@ -123,8 +134,7 @@ impl FromSql for ActorId {
 pub struct Actor {
     id: ActorId,
     addr: SocketAddr,
-    // An extra field to allow fast rejoin
-    bump: u16,
+    ts: Timestamp,
 }
 
 impl Hash for Actor {
@@ -135,12 +145,8 @@ impl Hash for Actor {
 }
 
 impl Actor {
-    pub fn new(id: ActorId, addr: SocketAddr) -> Self {
-        Self {
-            id,
-            addr,
-            bump: rand::random(),
-        }
+    pub fn new(id: ActorId, addr: SocketAddr, ts: Timestamp) -> Self {
+        Self { id, addr, ts }
     }
 
     pub fn id(&self) -> ActorId {
@@ -149,11 +155,14 @@ impl Actor {
     pub fn addr(&self) -> SocketAddr {
         self.addr
     }
+    pub fn ts(&self) -> Timestamp {
+        self.ts
+    }
 }
 
 impl From<SocketAddr> for Actor {
     fn from(value: SocketAddr) -> Self {
-        Self::new(ActorId(Uuid::nil()), value)
+        Self::new(ActorId(Uuid::nil()), value, Timestamp(0))
     }
 }
 
@@ -179,7 +188,13 @@ impl Identity for Actor {
         Some(Self {
             id: self.id,
             addr: self.addr,
-            bump: self.bump.wrapping_add(1),
+            ts: NTP64::from(duration_since_epoch()).into(),
         })
     }
+}
+
+fn duration_since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("could not generate duration since unix epoch")
 }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -535,7 +535,7 @@ pub struct CountedOwnedTokioRwLockWriteGuard<T> {
     _tracker: LockTracker,
 }
 
-impl<'a, T> Deref for CountedOwnedTokioRwLockWriteGuard<T> {
+impl<T> Deref for CountedOwnedTokioRwLockWriteGuard<T> {
     type Target = OwnedTokioRwLockWriteGuard<T>;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -4,16 +4,22 @@ use std::{
     net::SocketAddr,
     ops::{Deref, DerefMut, RangeInclusive},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
 use arc_swap::ArcSwap;
 use camino::Utf8PathBuf;
+use compact_str::CompactString;
+use indexmap::IndexMap;
 use metrics::{gauge, histogram};
 use parking_lot::RwLock;
 use rangemap::{RangeInclusiveMap, RangeInclusiveSet};
 use rusqlite::{Connection, InterruptHandle};
+use serde::{Deserialize, Serialize};
 use tokio::{
     runtime::Handle,
     sync::{
@@ -397,7 +403,7 @@ async fn timeout_wait(
     //     }
     // }
     // handle.interrupt();
-    // increment_counter!("corro.sqlite.pool.execution.timeout");
+    // increment_tracker!("corro.sqlite.pool.execution.timeout");
     // FIXME: do we need to cancel the token?
 }
 
@@ -452,55 +458,216 @@ impl KnownDbVersion {
     }
 }
 
-pub type BookedVersions = RangeInclusiveMap<i64, KnownDbVersion>;
-pub type BookedInner = Arc<TokioRwLock<BookedVersions>>;
+pub struct CountedTokioRwLock<T> {
+    registry: LockRegistry,
+    lock: TokioRwLock<T>,
+}
 
-#[derive(Default, Clone)]
-pub struct Booked(BookedInner);
-
-impl Booked {
-    pub fn new(inner: BookedInner) -> Self {
-        Self(inner)
-    }
-
-    pub async fn contains(&self, version: i64, seqs: Option<&RangeInclusive<i64>>) -> bool {
-        match seqs {
-            Some(check_seqs) => {
-                let read = self.0.read().await;
-                match read.get(&version) {
-                    Some(known) => match known {
-                        KnownDbVersion::Partial { seqs, .. } => {
-                            check_seqs.clone().all(|seq| seqs.contains(&seq))
-                        }
-                        KnownDbVersion::Current { .. } | KnownDbVersion::Cleared => true,
-                    },
-                    None => false,
-                }
-            }
-            None => self.0.read().await.contains_key(&version),
+impl<T> CountedTokioRwLock<T> {
+    fn new(registry: LockRegistry, value: T) -> Self {
+        Self {
+            registry,
+            lock: TokioRwLock::new(value),
         }
     }
 
-    pub async fn last(&self) -> Option<i64> {
-        self.0.read().await.iter().map(|(k, _v)| *k.end()).max()
+    pub async fn write<C: Into<CompactString>>(
+        &self,
+        label: C,
+    ) -> CountedTokioRwLockWriteGuard<'_, T> {
+        self.registry.acquire_write(label, &self.lock).await
     }
 
-    pub async fn read(&self) -> BookReader {
-        BookReader(self.0.read().await)
+    pub fn blocking_write<C: Into<CompactString>>(
+        &self,
+        label: C,
+    ) -> CountedTokioRwLockWriteGuard<'_, T> {
+        self.registry.acquire_blocking_write(label, &self.lock)
     }
 
-    pub async fn write(&self) -> BookWriter {
-        BookWriter(self.0.write().await)
-    }
-
-    pub fn blocking_write(&self) -> BookWriter {
-        BookWriter(self.0.blocking_write())
+    pub async fn read<C: Into<CompactString>>(
+        &self,
+        label: C,
+    ) -> CountedTokioRwLockReadGuard<'_, T> {
+        self.registry.acquire_read(label, &self.lock).await
     }
 }
 
-pub struct BookReader<'a>(TokioRwLockReadGuard<'a, BookedVersions>);
+pub struct CountedTokioRwLockWriteGuard<'a, T> {
+    lock: TokioRwLockWriteGuard<'a, T>,
+    _tracker: LockTracker,
+}
 
-impl<'a> BookReader<'a> {
+impl<'a, T> Deref for CountedTokioRwLockWriteGuard<'a, T> {
+    type Target = TokioRwLockWriteGuard<'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.lock
+    }
+}
+
+impl<'a, T> DerefMut for CountedTokioRwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lock
+    }
+}
+
+pub struct CountedTokioRwLockReadGuard<'a, T> {
+    lock: TokioRwLockReadGuard<'a, T>,
+    _tracker: LockTracker,
+}
+
+impl<'a, T> Deref for CountedTokioRwLockReadGuard<'a, T> {
+    type Target = TokioRwLockReadGuard<'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.lock
+    }
+}
+
+impl<'a, T> DerefMut for CountedTokioRwLockReadGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lock
+    }
+}
+
+type LockId = usize;
+
+#[derive(Debug, Clone)]
+pub struct LockMeta {
+    pub label: CompactString,
+    pub kind: LockKind,
+    pub state: LockState,
+    pub started_at: Instant,
+}
+
+#[derive(Default, Clone)]
+pub struct LockRegistry {
+    id_gen: Arc<AtomicUsize>,
+    pub map: Arc<RwLock<IndexMap<LockId, LockMeta>>>,
+}
+
+impl LockRegistry {
+    fn remove(&self, id: &LockId) {
+        self.map.write().remove(id);
+    }
+
+    async fn acquire_write<'a, T, C: Into<CompactString>>(
+        &self,
+        label: C,
+        lock: &'a TokioRwLock<T>,
+    ) -> CountedTokioRwLockWriteGuard<'a, T> {
+        let id = self.gen_id();
+        self.insert_lock(
+            id,
+            LockMeta {
+                label: label.into(),
+                kind: LockKind::Write,
+                state: LockState::Acquiring,
+                started_at: Instant::now(),
+            },
+        );
+        let _tracker = LockTracker {
+            id,
+            registry: self.clone(),
+        };
+        let w = lock.write().await;
+        self.set_lock_state(&id, LockState::Locked);
+        CountedTokioRwLockWriteGuard { lock: w, _tracker }
+    }
+
+    fn acquire_blocking_write<'a, T, C: Into<CompactString>>(
+        &self,
+        label: C,
+        lock: &'a TokioRwLock<T>,
+    ) -> CountedTokioRwLockWriteGuard<'a, T> {
+        let id = self.gen_id();
+        self.insert_lock(
+            id,
+            LockMeta {
+                label: label.into(),
+                kind: LockKind::Write,
+                state: LockState::Acquiring,
+                started_at: Instant::now(),
+            },
+        );
+        let _tracker = LockTracker {
+            id,
+            registry: self.clone(),
+        };
+        let w = lock.blocking_write();
+        self.set_lock_state(&id, LockState::Locked);
+        CountedTokioRwLockWriteGuard { lock: w, _tracker }
+    }
+
+    async fn acquire_read<'a, T, C: Into<CompactString>>(
+        &self,
+        label: C,
+        lock: &'a TokioRwLock<T>,
+    ) -> CountedTokioRwLockReadGuard<'a, T> {
+        let id = self.gen_id();
+        self.insert_lock(
+            id,
+            LockMeta {
+                label: label.into(),
+                kind: LockKind::Read,
+                state: LockState::Acquiring,
+                started_at: Instant::now(),
+            },
+        );
+        let _tracker = LockTracker {
+            id,
+            registry: self.clone(),
+        };
+        let w = lock.read().await;
+        self.set_lock_state(&id, LockState::Locked);
+        CountedTokioRwLockReadGuard { lock: w, _tracker }
+    }
+
+    fn set_lock_state(&self, id: &LockId, state: LockState) {
+        if let Some(meta) = self.map.write().get_mut(id) {
+            meta.state = state
+        }
+    }
+
+    fn insert_lock(&self, id: LockId, meta: LockMeta) {
+        self.map.write().insert(id, meta);
+    }
+
+    fn gen_id(&self) -> LockId {
+        self.id_gen.fetch_add(1, Ordering::Release) + 1
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockState {
+    Acquiring,
+    Locked,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockKind {
+    Read,
+    Write,
+}
+
+struct LockTracker {
+    id: LockId,
+    registry: LockRegistry,
+}
+
+impl Drop for LockTracker {
+    fn drop(&mut self) {
+        self.registry.remove(&self.id)
+    }
+}
+
+#[derive(Default)]
+pub struct BookedVersions(pub RangeInclusiveMap<i64, KnownDbVersion>);
+
+impl BookedVersions {
     pub fn contains(&self, version: i64, seqs: Option<&RangeInclusive<i64>>) -> bool {
         match seqs {
             Some(check_seqs) => match self.0.get(&version) {
@@ -524,6 +691,10 @@ impl<'a> BookReader<'a> {
         versions.all(|version| self.contains(version, seqs))
     }
 
+    pub fn contains_current(&self, version: &i64) -> bool {
+        matches!(self.0.get(version), Some(KnownDbVersion::Current { .. }))
+    }
+
     pub fn current_versions(&self) -> BTreeMap<i64, i64> {
         self.0
             .iter()
@@ -536,19 +707,11 @@ impl<'a> BookReader<'a> {
             })
             .collect()
     }
-}
 
-impl<'a> Deref for BookReader<'a> {
-    type Target = TokioRwLockReadGuard<'a, BookedVersions>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn last(&self) -> Option<i64> {
+        self.0.iter().map(|(k, _v)| *k.end()).max()
     }
-}
 
-pub struct BookWriter<'a>(TokioRwLockWriteGuard<'a, BookedVersions>);
-
-impl<'a> BookWriter<'a> {
     pub fn insert(&mut self, version: i64, known_version: KnownDbVersion) {
         self.insert_many(version..=version, known_version);
     }
@@ -556,111 +719,116 @@ impl<'a> BookWriter<'a> {
     pub fn insert_many(&mut self, versions: RangeInclusive<i64>, known_version: KnownDbVersion) {
         self.0.insert(versions, known_version);
     }
-
-    pub fn contains(&self, version: i64, seqs: Option<&RangeInclusive<i64>>) -> bool {
-        match seqs {
-            Some(check_seqs) => match self.0.get(&version) {
-                Some(known) => match known {
-                    KnownDbVersion::Partial { seqs, .. } => {
-                        check_seqs.clone().all(|seq| seqs.contains(&seq))
-                    }
-                    KnownDbVersion::Current { .. } | KnownDbVersion::Cleared => true,
-                },
-                None => false,
-            },
-            None => self.0.contains_key(&version),
-        }
-    }
-
-    pub fn contains_current(&self, version: &i64) -> bool {
-        matches!(self.0.get(version), Some(KnownDbVersion::Current { .. }))
-    }
-
-    pub fn contains_all(
-        &self,
-        mut versions: RangeInclusive<i64>,
-        seqs: Option<&RangeInclusive<i64>>,
-    ) -> bool {
-        versions.all(|version| self.contains(version, seqs))
-    }
-
-    pub fn last(&self) -> Option<i64> {
-        self.0.iter().map(|(k, _v)| *k.end()).max()
-    }
-
-    pub fn current_versions(&self) -> BTreeMap<i64, i64> {
-        self.0
-            .iter()
-            .filter_map(|(range, known)| {
-                if let KnownDbVersion::Current { db_version, .. } = known {
-                    Some((*db_version, *range.start()))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
-    pub fn inner(&self) -> &TokioRwLockWriteGuard<'a, BookedVersions> {
-        &self.0
-    }
-
-    pub fn inner_mut(&mut self) -> &mut TokioRwLockWriteGuard<'a, BookedVersions> {
-        &mut self.0
-    }
 }
 
-impl<'a> Deref for BookWriter<'a> {
-    type Target = TokioRwLockWriteGuard<'a, BookedVersions>;
+impl Deref for BookedVersions {
+    type Target = RangeInclusiveMap<i64, KnownDbVersion>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-pub type BookieInner = Arc<TokioRwLock<HashMap<ActorId, Booked>>>;
+pub type BookedInner = Arc<CountedTokioRwLock<BookedVersions>>;
 
-#[derive(Default, Clone)]
-pub struct Bookie(BookieInner);
+#[derive(Clone)]
+pub struct Booked(BookedInner);
+
+impl Booked {
+    fn new(versions: BookedVersions, registry: LockRegistry) -> Self {
+        Self(Arc::new(CountedTokioRwLock::new(registry, versions)))
+    }
+
+    pub async fn read<L: Into<CompactString>>(
+        &self,
+        label: L,
+    ) -> CountedTokioRwLockReadGuard<'_, BookedVersions> {
+        self.0.read(label).await
+    }
+
+    pub async fn write<L: Into<CompactString>>(
+        &self,
+        label: L,
+    ) -> CountedTokioRwLockWriteGuard<'_, BookedVersions> {
+        self.0.write(label).await
+    }
+
+    pub fn blocking_write<L: Into<CompactString>>(
+        &self,
+        label: L,
+    ) -> CountedTokioRwLockWriteGuard<'_, BookedVersions> {
+        self.0.blocking_write(label)
+    }
+}
+
+#[derive(Default)]
+pub struct BookieInner {
+    map: HashMap<ActorId, Booked>,
+    registry: LockRegistry,
+}
+
+impl BookieInner {
+    pub fn for_actor(&mut self, actor_id: ActorId) -> Booked {
+        self.map
+            .entry(actor_id)
+            .or_insert_with(|| {
+                Booked(Arc::new(CountedTokioRwLock::new(
+                    self.registry.clone(),
+                    Default::default(),
+                )))
+            })
+            .clone()
+    }
+
+    pub fn registry(&self) -> &LockRegistry {
+        &self.registry
+    }
+}
+
+impl Deref for BookieInner {
+    type Target = HashMap<ActorId, Booked>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+#[derive(Clone)]
+pub struct Bookie(Arc<CountedTokioRwLock<BookieInner>>);
 
 impl Bookie {
-    pub fn new(inner: BookieInner) -> Self {
-        Self(inner)
+    pub fn new(map: HashMap<ActorId, BookedVersions>) -> Self {
+        let registry = LockRegistry::default();
+        Self(Arc::new(CountedTokioRwLock::new(
+            registry.clone(),
+            BookieInner {
+                map: map
+                    .into_iter()
+                    .map(|(k, v)| (k, Booked::new(v, registry.clone())))
+                    .collect(),
+                registry,
+            },
+        )))
     }
 
-    pub async fn for_actor(&self, actor_id: ActorId) -> Booked {
-        let mut w = self.0.write().await;
-        w.entry(actor_id).or_default().clone()
-    }
-
-    pub fn for_actor_blocking(&self, actor_id: ActorId) -> Booked {
-        let mut w = self.0.blocking_write();
-        w.entry(actor_id).or_default().clone()
-    }
-
-    pub async fn contains(
+    pub async fn read<L: Into<CompactString>>(
         &self,
-        actor_id: &ActorId,
-        mut versions: RangeInclusive<i64>,
-        seqs: Option<&RangeInclusive<i64>>,
-    ) -> bool {
-        if let Some(booked) = self.0.read().await.get(actor_id) {
-            let read = booked.read().await;
-            versions.all(|v| read.contains(v, seqs))
-        } else {
-            false
-        }
+        label: L,
+    ) -> CountedTokioRwLockReadGuard<BookieInner> {
+        self.0.read(label).await
     }
 
-    pub async fn last(&self, actor_id: &ActorId) -> Option<i64> {
-        if let Some(booked) = self.0.read().await.get(actor_id) {
-            booked.last().await
-        } else {
-            None
-        }
+    pub async fn write<L: Into<CompactString>>(
+        &self,
+        label: L,
+    ) -> CountedTokioRwLockWriteGuard<BookieInner> {
+        self.0.write(label).await
     }
 
-    pub async fn read(&self) -> TokioRwLockReadGuard<HashMap<ActorId, Booked>> {
-        self.0.read().await
+    pub fn blocking_write<L: Into<CompactString>>(
+        &self,
+        label: L,
+    ) -> CountedTokioRwLockWriteGuard<BookieInner> {
+        self.0.blocking_write(label)
     }
 }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -450,10 +450,6 @@ pub enum KnownDbVersion {
     Current {
         // cr-sqlite db version
         db_version: i64,
-        // start sequence, can be > 0 if we inserted the change w/ others
-        start_seq: i64,
-        // end sequence, can be different than last_seq
-        end_seq: i64,
         // actual last sequence originally produced
         last_seq: i64,
         // timestamp when the change was produced by the source

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -40,7 +40,7 @@ use tripwire::Tripwire;
 
 use crate::{
     actor::ActorId,
-    broadcast::{BroadcastInput, Timestamp},
+    broadcast::{BroadcastInput, ChangeSource, ChangeV1, Timestamp},
     config::Config,
     pubsub::MatcherHandle,
     schema::NormalizedSchema,
@@ -67,6 +67,7 @@ pub struct AgentConfig {
     pub tx_bcast: Sender<BroadcastInput>,
     pub tx_apply: Sender<(ActorId, i64)>,
     pub tx_empty: Sender<(ActorId, RangeInclusive<i64>)>,
+    pub tx_changes: Sender<(ChangeV1, ChangeSource)>,
 
     pub schema: RwLock<NormalizedSchema>,
     pub tripwire: Tripwire,
@@ -85,6 +86,7 @@ pub struct AgentInner {
     tx_bcast: Sender<BroadcastInput>,
     tx_apply: Sender<(ActorId, i64)>,
     tx_empty: Sender<(ActorId, RangeInclusive<i64>)>,
+    tx_changes: Sender<(ChangeV1, ChangeSource)>,
     schema: RwLock<NormalizedSchema>,
 }
 
@@ -103,6 +105,7 @@ impl Agent {
             tx_bcast: config.tx_bcast,
             tx_apply: config.tx_apply,
             tx_empty: config.tx_empty,
+            tx_changes: config.tx_changes,
             schema: config.schema,
         }))
     }
@@ -137,6 +140,10 @@ impl Agent {
 
     pub fn tx_apply(&self) -> &Sender<(ActorId, i64)> {
         &self.0.tx_apply
+    }
+
+    pub fn tx_changes(&self) -> &Sender<(ChangeV1, ChangeSource)> {
+        &self.0.tx_changes
     }
 
     pub fn tx_empty(&self) -> &Sender<(ActorId, RangeInclusive<i64>)> {

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -63,6 +63,12 @@ pub enum BroadcastV1 {
     Change(ChangeV1),
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum ChangeSource {
+    Broadcast,
+    Sync,
+}
+
 // TODO: shrink this by mapping primary keys to integers instead of repeating them
 #[derive(Debug, Clone, PartialEq, Readable, Writable)]
 pub struct ChangeV1 {

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -202,7 +202,17 @@ pub enum TimestampParseError {
 }
 
 #[derive(
-    Debug, Default, Clone, Copy, Serialize, Deserialize, Readable, Writable, PartialEq, Eq,
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Readable,
+    Writable,
+    PartialEq,
+    Eq,
+    PartialOrd,
 )]
 #[serde(transparent)]
 pub struct Timestamp(pub u64);
@@ -228,6 +238,12 @@ impl fmt::Display for Timestamp {
 impl From<uhlc::Timestamp> for Timestamp {
     fn from(ts: uhlc::Timestamp) -> Self {
         Self(ts.get_time().as_u64())
+    }
+}
+
+impl From<NTP64> for Timestamp {
+    fn from(ntp64: NTP64) -> Self {
+        Self(ntp64.as_u64())
     }
 }
 

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -64,7 +64,7 @@ pub enum BroadcastV1 {
 }
 
 // TODO: shrink this by mapping primary keys to integers instead of repeating them
-#[derive(Debug, Clone, Readable, Writable)]
+#[derive(Debug, Clone, PartialEq, Readable, Writable)]
 pub struct ChangeV1 {
     pub actor_id: ActorId,
     pub changeset: Changeset,
@@ -78,7 +78,7 @@ impl Deref for ChangeV1 {
     }
 }
 
-#[derive(Debug, Clone, Readable, Writable)]
+#[derive(Debug, Clone, PartialEq, Readable, Writable)]
 pub enum Changeset {
     Empty {
         versions: RangeInclusive<i64>,

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -14,7 +14,7 @@ use rusqlite::{
     ToSql,
 };
 use serde::{Deserialize, Serialize};
-use speedy::{Readable, Writable};
+use speedy::{Context, Readable, Reader, Writable, Writer};
 use time::OffsetDateTime;
 use tokio::sync::mpsc::Sender;
 use tracing::{error, trace};
@@ -207,49 +207,48 @@ pub enum TimestampParseError {
     Parse(ParseNTP64Error),
 }
 
-#[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    Readable,
-    Writable,
-    PartialEq,
-    Eq,
-    PartialOrd,
-)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd)]
 #[serde(transparent)]
-pub struct Timestamp(pub u64);
+pub struct Timestamp(pub NTP64);
 
 impl Timestamp {
     pub fn to_time(&self) -> OffsetDateTime {
-        let t = NTP64(self.0);
-        OffsetDateTime::from_unix_timestamp(t.as_secs() as i64).unwrap()
-            + time::Duration::nanoseconds(t.subsec_nanos() as i64)
+        OffsetDateTime::from_unix_timestamp(self.0.as_secs() as i64).unwrap()
+            + time::Duration::nanoseconds(self.0.subsec_nanos() as i64)
     }
 
     pub fn to_ntp64(&self) -> NTP64 {
-        NTP64(self.0)
+        self.0
+    }
+
+    pub fn zero() -> Self {
+        Timestamp(NTP64(0))
+    }
+}
+
+impl Deref for Timestamp {
+    type Target = NTP64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        NTP64(self.0).fmt(f)
+        self.0.fmt(f)
     }
 }
 
 impl From<uhlc::Timestamp> for Timestamp {
     fn from(ts: uhlc::Timestamp) -> Self {
-        Self(ts.get_time().as_u64())
+        Self(*ts.get_time())
     }
 }
 
 impl From<NTP64> for Timestamp {
     fn from(ntp64: NTP64) -> Self {
-        Self(ntp64.as_u64())
+        Self(ntp64)
     }
 }
 
@@ -258,7 +257,7 @@ impl FromSql for Timestamp {
         match value {
             rusqlite::types::ValueRef::Text(b) => match std::str::from_utf8(b) {
                 Ok(s) => match s.parse::<NTP64>() {
-                    Ok(ntp) => Ok(Timestamp(ntp.as_u64())),
+                    Ok(ntp) => Ok(Timestamp(ntp)),
                     Err(e) => Err(FromSqlError::Other(Box::new(TimestampParseError::Parse(e)))),
                 },
                 Err(e) => Err(FromSqlError::Other(Box::new(e))),
@@ -271,8 +270,38 @@ impl FromSql for Timestamp {
 impl ToSql for Timestamp {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
         Ok(rusqlite::types::ToSqlOutput::Owned(
-            rusqlite::types::Value::Text(NTP64(self.0).to_string()),
+            rusqlite::types::Value::Text(self.0.to_string()),
         ))
+    }
+}
+
+impl<'a, C> Readable<'a, C> for Timestamp
+where
+    C: Context,
+{
+    #[inline]
+    fn read_from<R: Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+        Ok(Timestamp(NTP64(u64::read_from(reader)?)))
+    }
+
+    #[inline]
+    fn minimum_bytes_needed() -> usize {
+        std::mem::size_of::<u64>()
+    }
+}
+
+impl<C> Writable<C> for Timestamp
+where
+    C: Context,
+{
+    #[inline]
+    fn write_to<T: ?Sized + Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
+        self.0 .0.write_to(writer)
+    }
+
+    #[inline]
+    fn bytes_needed(&self) -> Result<usize, C::Error> {
+        <u64 as speedy::Writable<C>>::bytes_needed(&self.0 .0)
     }
 }
 

--- a/crates/corro-types/src/members.rs
+++ b/crates/corro-types/src/members.rs
@@ -58,7 +58,7 @@ impl Members {
 
         trace!("member: {member:?}");
 
-        if actor.ts() < member.ts {
+        if actor.ts().to_time() < member.ts.to_time() {
             debug!("older timestamp, ignoring");
             return false;
         }

--- a/crates/corro-types/src/members.rs
+++ b/crates/corro-types/src/members.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, net::SocketAddr, ops::Range, time::Duration};
 
 use circular_buffer::CircularBuffer;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use crate::{
     actor::{Actor, ActorId},

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -1367,7 +1367,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use camino::Utf8PathBuf;
-    use corro_api_types::row_to_change;
+    use corro_api_types::{row_to_change, row_to_change_no_sub};
     use rusqlite::params;
 
     use crate::{
@@ -1589,7 +1589,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([1], row_to_change).unwrap();
+                let rows = prepped.query_map([1], row_to_change_no_sub).unwrap();
 
                 let mut changes = vec![];
 
@@ -1671,7 +1671,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([2], row_to_change).unwrap();
+                let rows = prepped.query_map([2], row_to_change_no_sub).unwrap();
 
                 let mut changes = vec![];
 
@@ -1705,7 +1705,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([3], row_to_change).unwrap();
+                let rows = prepped.query_map([3], row_to_change_no_sub).unwrap();
 
                 let mut changes = vec![];
 
@@ -1737,7 +1737,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([4], row_to_change).unwrap();
+                let rows = prepped.query_map([4], row_to_change_no_sub).unwrap();
 
                 let mut changes = vec![];
 
@@ -1800,7 +1800,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([5], row_to_change).unwrap();
+                let rows = prepped.query_map([5], row_to_change_no_sub).unwrap();
 
                 let mut changes = vec![];
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -1461,7 +1461,7 @@ mod tests {
     use rusqlite::params;
 
     use crate::{
-        schema::{make_schema_inner, parse_sql},
+        schema::{apply_schema, parse_sql},
         sqlite::{setup_conn, CrConn},
     };
 
@@ -1499,7 +1499,7 @@ mod tests {
 
         {
             let tx = conn.transaction()?;
-            make_schema_inner(&tx, &NormalizedSchema::default(), &mut schema)?;
+            apply_schema(&tx, &NormalizedSchema::default(), &mut schema)?;
             tx.commit()?;
         }
 
@@ -1631,7 +1631,7 @@ mod tests {
 
         {
             let tx = conn.transaction().unwrap();
-            make_schema_inner(&tx, &NormalizedSchema::default(), &mut schema).unwrap();
+            apply_schema(&tx, &NormalizedSchema::default(), &mut schema).unwrap();
             tx.commit().unwrap();
         }
 
@@ -1673,7 +1673,7 @@ mod tests {
 
             {
                 let tx = conn2.transaction().unwrap();
-                make_schema_inner(&tx, &NormalizedSchema::default(), &mut schema).unwrap();
+                apply_schema(&tx, &NormalizedSchema::default(), &mut schema).unwrap();
                 tx.commit().unwrap();
             }
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -1367,7 +1367,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use camino::Utf8PathBuf;
-    use corro_api_types::{row_to_change, row_to_change_no_sub};
+    use corro_api_types::row_to_change_no_sub;
     use rusqlite::params;
 
     use crate::{

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -116,7 +116,7 @@ pub fn pack_columns(args: &[SqliteValue]) -> Result<Vec<u8>, PackError> {
                     let type_byte = num_bytes_for_len << 3 | (ColumnType::Blob as u8);
                     buf.put_u8(type_byte);
                     buf.put_int(len as i64, num_bytes_for_len as usize);
-                    buf.put_slice(&value);
+                    buf.put_slice(value);
                 }
             }
         }
@@ -128,29 +128,29 @@ pub fn pack_columns(args: &[SqliteValue]) -> Result<Vec<u8>, PackError> {
 
 fn num_bytes_needed_i64(val: i64) -> u8 {
     if val & 0xFF00000000000000u64 as i64 != 0 {
-        return 8;
+        8
     } else if val & 0x00FF000000000000 != 0 {
-        return 7;
+        7
     } else if val & 0x0000FF0000000000 != 0 {
-        return 6;
+        6
     } else if val & 0x000000FF00000000 != 0 {
-        return 5;
+        5
     } else {
-        return num_bytes_needed_i32(val as i32);
+        num_bytes_needed_i32(val as i32)
     }
 }
 
 fn num_bytes_needed_i32(val: i32) -> u8 {
     if val & 0xFF000000u32 as i32 != 0 {
-        return 4;
+        4
     } else if val & 0x00FF0000 != 0 {
-        return 3;
+        3
     } else if val & 0x0000FF00 != 0 {
-        return 2;
+        2
     } else if val * 0x000000FF != 0 {
-        return 1;
+        1
     } else {
-        return 0;
+        0
     }
 }
 
@@ -1457,7 +1457,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use camino::Utf8PathBuf;
-    use corro_api_types::row_to_change_no_sub;
+    use corro_api_types::row_to_change;
     use rusqlite::params;
 
     use crate::{
@@ -1679,7 +1679,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([1], row_to_change_no_sub).unwrap();
+                let rows = prepped.query_map([1], row_to_change).unwrap();
 
                 let mut changes = vec![];
 
@@ -1761,7 +1761,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([2], row_to_change_no_sub).unwrap();
+                let rows = prepped.query_map([2], row_to_change).unwrap();
 
                 let mut changes = vec![];
 
@@ -1795,7 +1795,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([3], row_to_change_no_sub).unwrap();
+                let rows = prepped.query_map([3], row_to_change).unwrap();
 
                 let mut changes = vec![];
 
@@ -1827,7 +1827,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([4], row_to_change_no_sub).unwrap();
+                let rows = prepped.query_map([4], row_to_change).unwrap();
 
                 let mut changes = vec![];
 
@@ -1890,7 +1890,7 @@ mod tests {
 
             let changes = {
                 let mut prepped = conn.prepare_cached(r#"SELECT "table", pk, cid, val, col_version, db_version, seq, COALESCE(site_id, crsql_site_id()), cl FROM crsql_changes WHERE site_id IS NULL AND db_version = ? ORDER BY seq ASC"#).unwrap();
-                let rows = prepped.query_map([5], row_to_change_no_sub).unwrap();
+                let rows = prepped.query_map([5], row_to_change).unwrap();
 
                 let mut changes = vec![];
 

--- a/crates/corro-types/src/schema.rs
+++ b/crates/corro-types/src/schema.rs
@@ -178,7 +178,7 @@ pub fn init_schema(conn: &Connection) -> Result<NormalizedSchema, SchemaError> {
 }
 
 #[allow(clippy::result_large_err)]
-pub fn make_schema_inner(
+pub fn apply_schema(
     tx: &Transaction,
     schema: &NormalizedSchema,
     new_schema: &mut NormalizedSchema,

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -11,19 +11,19 @@ use crate::{
     broadcast::{ChangeV1, Timestamp},
 };
 
-#[derive(Debug, Clone, Readable, Writable)]
+#[derive(Debug, Clone, PartialEq, Readable, Writable)]
 pub enum SyncMessage {
     V1(SyncMessageV1),
 }
 
-#[derive(Debug, Clone, Readable, Writable)]
+#[derive(Debug, Clone, PartialEq, Readable, Writable)]
 pub enum SyncMessageV1 {
     State(SyncStateV1),
     Changeset(ChangeV1),
     Clock(Timestamp),
 }
 
-#[derive(Debug, Default, Clone, Readable, Writable, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Readable, Writable, Serialize, Deserialize)]
 pub struct SyncStateV1 {
     pub actor_id: ActorId,
     pub heads: HashMap<ActorId, i64>,

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -83,7 +83,7 @@ pub async fn generate_sync(bookie: &Bookie, actor_id: ActorId) -> SyncStateV1 {
 
     let actors: Vec<(ActorId, Booked)> = {
         bookie
-            .read()
+            .read("generate_sync")
             .await
             .iter()
             .map(|(k, v)| (*k, v.clone()))
@@ -91,19 +91,32 @@ pub async fn generate_sync(bookie: &Bookie, actor_id: ActorId) -> SyncStateV1 {
     };
 
     for (actor_id, booked) in actors {
-        let last_version = match booked.last().await {
+        let last_version = match {
+            booked
+                .read(format!("generate_sync(last):{}", actor_id.as_simple()))
+                .await
+                .last()
+        } {
             Some(v) => v,
             None => continue,
         };
 
-        let need: Vec<_> = { booked.read().await.gaps(&(1..=last_version)).collect() };
+        let need: Vec<_> = {
+            booked
+                .read(format!("generate_sync(need):{}", actor_id.as_simple()))
+                .await
+                .gaps(&(1..=last_version))
+                .collect()
+        };
 
         if !need.is_empty() {
             state.need.insert(actor_id, need);
         }
 
         {
-            let read = booked.read().await;
+            let read = booked
+                .read(format!("generate_sync(partials):{}", actor_id.as_simple()))
+                .await;
             for (range, known) in read.iter() {
                 if let KnownDbVersion::Partial { seqs, last_seq, .. } = known {
                     if seqs.gaps(&(0..=*last_seq)).count() == 0 {

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -320,6 +320,11 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             ))
             .await?;
         }
+        Command::Locks { top } => {
+            let mut conn = AdminConn::connect(cli.admin_path()).await?;
+            conn.send_command(corro_admin::Command::Locks { top: *top })
+                .await?;
+        }
         Command::Template { template, flags } => {
             command::tpl::run(cli.api_addr()?, template, flags).await?;
         }
@@ -427,7 +432,9 @@ enum Command {
     Agent,
 
     /// Backup the Corrosion DB
-    Backup { path: String },
+    Backup {
+        path: String,
+    },
 
     /// Restore the Corrosion DB from a backup
     Restore {
@@ -467,6 +474,10 @@ enum Command {
     /// Sync-related commands
     #[command(subcommand)]
     Sync(SyncCommand),
+
+    Locks {
+        top: usize,
+    },
 
     Template {
         template: Vec<String>,


### PR DESCRIPTION
This PR brings back a previously failed attempt at batch inserting many multiple changesets in the same transaction.

An issue happened where sometimes we'd get the same `db_version` for different changesets from the same Corrosion node. This is now fixed w/ a workaround (but reported to cr-sqlite) by incrementing the `crsql_db_version` by 1 more on each changeset.

This PR also batch inserts empty changesets, they're stored in-memory right away, but we can delay inserting.

For debugging purposes, we've also added a way to track lock durations by label. This helped debug deadlocks. In a future release these should be removed.