### PR TITLE
Clustering tweaks

### DIFF
--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -81,7 +81,7 @@ fn build_quinn_transport_config(config: &GossipConfig) -> quinn::TransportConfig
 
     // max idle timeout
     transport_config.max_idle_timeout(Some(
-        Duration::from_secs(std::cmp::min(config.idle_timeout_secs as u64, 10))
+        Duration::from_secs(config.idle_timeout_secs as u64)
             .try_into()
             .unwrap(),
     ));

--- a/crates/corro-agent/src/transport.rs
+++ b/crates/corro-agent/src/transport.rs
@@ -51,13 +51,11 @@ impl Transport {
                 debug!("sent datagram to {addr}");
                 return Ok(send);
             }
-            Err(e @ SendDatagramError::ConnectionLost(ConnectionError::VersionMismatch)) => {
-                return Err(e.into());
-            }
             Err(SendDatagramError::ConnectionLost(e)) => {
                 debug!("retryable error attempting to open unidirectional stream: {e}");
             }
             Err(e) => {
+                increment_counter!("corro.transport.send_datagram.errors", "addr" => addr.to_string(), "error" => e.to_string());
                 return Err(e.into());
             }
         }
@@ -129,11 +127,11 @@ impl Transport {
             let start = Instant::now();
             let conn = match self.0.endpoint.connect(addr, server_name.as_str())?.await {
                 Ok(conn) => {
-                    histogram!("corro.transport.connect.time.seconds", start.elapsed().as_secs_f64(), "ip" => server_name);
+                    histogram!("corro.transport.connect.time.seconds", start.elapsed().as_secs_f64(), "addr" => server_name);
                     conn
                 }
                 Err(e) => {
-                    increment_counter!("corro.transport.connect.errors", "ip" => server_name, "error" => e.to_string());
+                    increment_counter!("corro.transport.connect.errors", "addr" => server_name, "error" => e.to_string());
                     return Err(e.into());
                 }
             };

--- a/crates/corro-agent/src/transport.rs
+++ b/crates/corro-agent/src/transport.rs
@@ -1,6 +1,12 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use bytes::Bytes;
+use metrics::histogram;
 use quinn::{
     ApplicationClose, Connection, ConnectionError, Endpoint, RecvStream, SendDatagramError,
     SendStream,
@@ -120,7 +126,9 @@ impl Transport {
                 }
             }
 
+            let start = Instant::now();
             let conn = self.0.endpoint.connect(addr, server_name.as_str())?.await?;
+            histogram!("corro.transport.connect.time.seconds", start.elapsed().as_secs_f64(), "ip" => server_name);
             if let Err(e) = self.0.rtt_tx.try_send((addr, conn.rtt())) {
                 debug!("could not send RTT for connection through sender: {e}");
             }

--- a/crates/corro-agent/src/transport.rs
+++ b/crates/corro-agent/src/transport.rs
@@ -52,7 +52,7 @@ impl Transport {
                 return Ok(send);
             }
             Err(SendDatagramError::ConnectionLost(e)) => {
-                debug!("retryable error attempting to open unidirectional stream: {e}");
+                debug!("retryable error attempting to send datagram: {e}");
             }
             Err(e) => {
                 increment_counter!("corro.transport.send_datagram.errors", "addr" => addr.to_string(), "error" => e.to_string());

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -4,7 +4,7 @@ use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_GOSSIP_PORT: u16 = 4001;
-const DEFAULT_GOSSIP_IDLE_TIMEOUT: u32 = 30;
+const DEFAULT_GOSSIP_IDLE_TIMEOUT: u32 = 60;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {


### PR DESCRIPTION
Changes:
- Keep connections open longer to improve the cluster's reliability and speed.
- Add a few more connection-related metrics
- Had forgotten to process changes for subscribers in the case of applying buffered changes, this is now fixed.
