### PR TITLE
Improve SQLite-typed input for API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "hex",
  "rusqlite",
  "serde",
+ "serde_json",
  "smallvec",
  "strum",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rustls = { version = "0.21.0", features = ["dangerous_configuration", "quic"] }
 rustls-pemfile = "1.0.2"
 seahash = "4.1.0"
 serde = "1.0.159"
-serde_json = "1.0.95"
+serde_json = { version = "1.0.95", features = ["raw_value"] }
 serde_with = "2.3.2"
 smallvec = { version = "1.11.0", features = ["serde", "write", "union"] }
 speedy = { version = "0.8.7", features = ["uuid", "smallvec"], package = "corro-speedy" }

--- a/crates/corro-api-types/Cargo.toml
+++ b/crates/corro-api-types/Cargo.toml
@@ -13,6 +13,7 @@ compact_str = { workspace = true }
 hex = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 smallvec = { workspace = true }
 speedy = { workspace = true }
 strum = { workspace = true }

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -12,7 +12,7 @@ use command::{
     tls::{generate_ca, generate_client_cert, generate_server_cert},
     tpl::TemplateFlags,
 };
-use corro_api_types::SqliteValue;
+use corro_api_types::{SqliteParam, SqliteValue};
 use corro_client::CorrosionApiClient;
 use corro_types::{
     api::{ExecResult, QueryEvent, Statement},
@@ -301,7 +301,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             } else {
                 Statement::WithParams(
                     query.clone(),
-                    param.iter().map(|p| SqliteValue::Text(p.into())).collect(),
+                    param.iter().map(|p| SqliteParam::Text(p.into())).collect(),
                 )
             };
 
@@ -359,7 +359,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             } else {
                 Statement::WithParams(
                     query.clone(),
-                    param.iter().map(|p| SqliteValue::Text(p.into())).collect(),
+                    param.iter().map(|p| SqliteParam::Text(p.into())).collect(),
                 )
             };
 


### PR DESCRIPTION
It's now possible to accept an object w/ the fields defined specifically (query, params, named_params) and to use booleans and JSON objects as input.