### PR TITLE
Subscriptions performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.28",
+ "syn 2.0.32",
  "xz2",
 ]
 
@@ -577,7 +577,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -934,6 +934,7 @@ dependencies = [
  "rangemap",
  "rcgen",
  "rusqlite",
+ "seahash",
  "serde",
  "serde_json",
  "serde_with",
@@ -945,9 +946,11 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "tripwire",
  "uhlc",
  "uuid",
+ "yaque",
 ]
 
 [[package]]
@@ -975,7 +978,7 @@ dependencies = [
  "hyper",
  "metrics",
  "metrics-exporter-prometheus",
- "notify",
+ "notify 6.0.1",
  "notify-debouncer-mini",
  "once_cell",
  "opentelemetry",
@@ -1114,7 +1117,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1131,7 +1134,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1307,7 +1310,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1545,7 +1548,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1705,15 +1708,6 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -2095,9 +2089,9 @@ checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2132,7 +2126,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2276,7 +2270,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2384,6 +2378,24 @@ dependencies = [
 
 [[package]]
 name = "notify"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "notify"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
@@ -2406,7 +2418,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55ee272914f4563a2f8b8553eb6811f3c0caea81c756346bad15b7e3ef969f0"
 dependencies = [
- "notify",
+ "notify 6.0.1",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2451,11 +2472,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "libc",
 ]
 
@@ -2479,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl-probe"
@@ -2611,15 +2632,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.4.1",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -3065,6 +3086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,7 +3402,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3576,7 +3606,7 @@ checksum = "7d395866cb6778625150f77a430cc0af764ce0300f6a3d3413477785fa34b6c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3741,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3766,6 +3796,20 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -3834,7 +3878,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3955,7 +3999,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4169,7 +4213,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4533,7 +4577,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -4555,7 +4599,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4848,6 +4892,21 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yaque"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1a92dacd945cc5bc78a8193cc00b9a2cce3c07746ca51533f513843f40d2"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "log",
+ "notify 5.2.0",
+ "rand",
+ "semver",
+ "sysinfo",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbc8dd22992b785a0375e7065168b3a3b95599d3ffe2cf3d5d4a752278fdaba"
 dependencies = [
+ "indexmap",
  "memoffset 0.8.0",
  "smallvec",
  "speedy-derive",
@@ -938,6 +939,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "spawn",
  "sqlite-pool",
  "sqlite3-parser",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,6 @@ dependencies = [
  "tripwire",
  "uhlc",
  "uuid",
- "yaque",
 ]
 
 [[package]]
@@ -978,7 +977,7 @@ dependencies = [
  "hyper",
  "metrics",
  "metrics-exporter-prometheus",
- "notify 6.0.1",
+ "notify",
  "notify-debouncer-mini",
  "once_cell",
  "opentelemetry",
@@ -2378,24 +2377,6 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
-dependencies = [
- "bitflags 1.3.2",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "mio",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "notify"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
@@ -2418,16 +2399,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55ee272914f4563a2f8b8553eb6811f3c0caea81c756346bad15b7e3ef969f0"
 dependencies = [
- "notify 6.0.1",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
+ "notify",
 ]
 
 [[package]]
@@ -3799,20 +3771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4892,21 +4850,6 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "yaque"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1a92dacd945cc5bc78a8193cc00b9a2cce3c07746ca51533f513843f40d2"
-dependencies = [
- "futures",
- "lazy_static",
- "log",
- "notify 5.2.0",
- "rand",
- "semver",
- "sysinfo",
-]
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ name = "corro-pg"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "compact_str 0.7.0",
  "corro-tests",
  "corro-types",
@@ -843,7 +844,6 @@ dependencies = [
  "sqlparser",
  "tempfile",
  "thiserror",
- "time",
  "tokio",
  "tokio-postgres",
  "tokio-util",
@@ -3172,6 +3172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
  "bitflags 2.3.2",
+ "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde = "1.0.159"
 serde_json = { version = "1.0.95", features = ["raw_value"] }
 serde_with = "2.3.2"
 smallvec = { version = "1.11.0", features = ["serde", "write", "union"] }
-speedy = { version = "0.8.7", features = ["uuid", "smallvec"], package = "corro-speedy" }
+speedy = { version = "0.8.7", features = ["uuid", "smallvec", "indexmap"], package = "corro-speedy" }
 sqlite3-parser = "0.8.0"
 strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 rangemap = { version = "1.3.0" }
 rcgen = { version = "0.11.1", features = ["x509-parser"] }
 rhai = { version = "1.15.1", features = ["sync"] }
-rusqlite = { version = "0.29.0", features = ["serde_json", "time", "bundled", "uuid", "array", "load_extension", "column_decltype", "vtab", "functions"] }
+rusqlite = { version = "0.29.0", features = ["serde_json", "time", "bundled", "uuid", "array", "load_extension", "column_decltype", "vtab", "functions", "chrono"] }
 rustls = { version = "0.21.0", features = ["dangerous_configuration", "quic"] }
 rustls-pemfile = "1.0.2"
 seahash = "4.1.0"

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -5,7 +5,7 @@ use bytes::{BufMut, BytesMut};
 use compact_str::ToCompactString;
 use corro_types::{
     agent::{Agent, ChangeError, KnownDbVersion},
-    api::{row_to_change, ExecResponse, ExecResult, QueryEvent, Statement},
+    api::{row_to_change, ExecResponse, ExecResult, QueryEvent, Statement, ColumnName},
     broadcast::{ChangeV1, Changeset, Timestamp},
     change::{ChunkedChanges, SqliteValue, MAX_CHANGES_BYTE_SIZE},
     schema::{apply_schema, parse_sql},
@@ -354,7 +354,7 @@ async fn build_query_rows_response(
                 prepped
                     .columns()
                     .into_iter()
-                    .map(|col| col.name().to_compact_string())
+                    .map(|col| ColumnName(col.name().to_compact_string()))
                     .collect(),
             )) {
                 error!("could not send back columns: {e}");

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -5,7 +5,7 @@ use bytes::{BufMut, BytesMut};
 use compact_str::ToCompactString;
 use corro_types::{
     agent::{Agent, ChangeError, KnownDbVersion},
-    api::{row_to_change, ExecResponse, ExecResult, QueryEvent, Statement, ColumnName},
+    api::{row_to_change, ColumnName, ExecResponse, ExecResult, QueryEvent, Statement},
     broadcast::{ChangeV1, Changeset, Timestamp},
     change::{ChunkedChanges, SqliteValue, MAX_CHANGES_BYTE_SIZE},
     schema::{apply_schema, parse_sql},
@@ -26,8 +26,6 @@ use tokio::{
 use tracing::{debug, error, info, trace};
 
 use corro_types::broadcast::{BroadcastInput, BroadcastV1};
-
-use crate::agent::process_subs;
 
 pub mod pubsub;
 
@@ -112,6 +110,9 @@ where
             start.elapsed()
         };
 
+        // change the current db version, so that subscribers can catch up
+        agent.change_db_version(db_version);
+
         trace!("committed tx, db_version: {db_version}, last_seq: {last_seq:?}");
 
         book_writer.insert(
@@ -148,7 +149,6 @@ where
                             {
                                 counter!("corro.changes.committed", count as u64, "table" => table_name.to_string(), "source" => "local");
                             }
-                            process_subs(&agent, &changes);
 
                             trace!("broadcasting changes: {changes:?} for seq: {seqs:?}");
 

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -476,7 +476,20 @@ pub async fn catch_up_sub(
         }
     };
 
-    if let Some((_buf, change_id)) = events_buf.get(0) {
+    let last_received_change_id = match events_buf.get(0) {
+        Some((_buf, change_id)) => Some(*change_id),
+        None => {
+            let last_change_id_sent = matcher.last_change_id_sent();
+            if last_change_id_sent.0 <= last_change_id.0 {
+                None
+            } else {
+                Some(last_change_id_sent)
+            }
+        }
+    };
+
+    if let Some(change_id) = last_received_change_id {
+        debug!(sub_id = %matcher.id(), "got a change to check: {change_id:?}");
         for _ in 0..5 {
             if change_id.0 > last_change_id.0 + 1 {
                 // missed some updates!

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -175,14 +175,14 @@ pub async fn process_sub_channel(
         if is_still_active {
             deadline = None;
         } else {
-            warn!(sub_id = %id, "no active listeners to receive subscription event: {query_evt:?}");
+            debug!(sub_id = %id, "no active listeners to receive subscription event: {query_evt:?}");
             if deadline.is_none() {
                 deadline = Some(Box::pin(tokio::time::sleep(MAX_UNSUB_TIME)));
             }
         }
     }
 
-    debug!("subscription query channel done");
+    warn!(sub_id = %id, "subscription query channel done");
 
     // remove and get handle from the agent's "matchers"
     let handle = match subs.remove(&id) {
@@ -716,6 +716,7 @@ async fn forward_sub_to_sender(
     mut sub_rx: broadcast::Receiver<(Bytes, QueryEventMeta)>,
     tx: mpsc::Sender<Bytes>,
 ) {
+    info!(%sub_id, "forwarding subscription events to a sender");
     while let Ok((event_buf, _meta)) = sub_rx.recv().await {
         if let Err(e) = tx.send(event_buf).await {
             warn!(%sub_id, "could not send subscription event to channel: {e}");

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashMap,
     fmt::{self, Write},
     hash::Hash,
-    ops::Deref,
+    ops::{AddAssign, Deref},
 };
 
 use compact_str::CompactString;
@@ -131,6 +131,34 @@ impl FromSql for ChangeId {
 impl ToSql for ChangeId {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         self.0.to_sql()
+    }
+}
+
+impl AddAssign<i64> for ChangeId {
+    fn add_assign(&mut self, rhs: i64) {
+        self.0 += rhs
+    }
+}
+
+impl AddAssign<Self> for ChangeId {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl std::ops::Add<i64> for ChangeId {
+    type Output = ChangeId;
+
+    fn add(self, rhs: i64) -> Self::Output {
+        ChangeId(self.0 + rhs)
+    }
+}
+
+impl std::ops::Add<Self> for ChangeId {
+    type Output = ChangeId;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        ChangeId(self.0 + rhs.0)
     }
 }
 

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -1,11 +1,12 @@
 use std::{
+    borrow::Borrow,
     collections::HashMap,
     fmt::{self, Write},
     hash::Hash,
     ops::Deref,
 };
 
-use compact_str::{CompactString, ToCompactString};
+use compact_str::CompactString;
 use rusqlite::{
     types::{FromSql, FromSqlError, ToSqlOutput, Value, ValueRef},
     Row, ToSql,
@@ -21,7 +22,7 @@ pub mod sqlite;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryEvent {
-    Columns(Vec<CompactString>),
+    Columns(Vec<ColumnName>),
     Row(RowId, Vec<SqliteValue>),
     #[serde(rename = "eoq")]
     EndOfQuery {
@@ -55,7 +56,9 @@ pub enum QueryEventMeta {
 }
 
 /// RowId newtype to differentiate from ChangeId
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, Readable, Writable, PartialEq, Eq, Ord, PartialOrd,
+)]
 #[serde(transparent)]
 pub struct RowId(pub i64);
 
@@ -87,7 +90,20 @@ impl ToSql for RowId {
 }
 
 /// ChangeId newtype to differentiate from RowId
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Readable,
+    Writable,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+)]
 #[serde(transparent)]
 pub struct ChangeId(pub i64);
 
@@ -206,56 +222,58 @@ pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
     })
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum SqliteValueRef<'a> {
-    Null,
-    Integer(i64),
-    Real(f64),
-    Text(&'a str),
-    Blob(&'a [u8]),
-}
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct SqliteValueRef<'a>(pub ValueRef<'a>);
 
 impl<'a> SqliteValueRef<'a> {
     pub fn is_null(&self) -> bool {
-        matches!(self, SqliteValueRef::Null)
+        matches!(self.0, ValueRef::Null)
     }
 
-    pub fn as_integer(&self) -> Option<&i64> {
-        match self {
-            SqliteValueRef::Integer(i) => Some(i),
-            _ => None,
-        }
+    pub fn as_integer(&self) -> Option<i64> {
+        self.0.as_i64().ok()
     }
 
-    pub fn as_real(&self) -> Option<&f64> {
-        match self {
-            SqliteValueRef::Real(f) => Some(f),
-            _ => None,
-        }
+    pub fn as_real(&self) -> Option<f64> {
+        self.0.as_f64().ok()
     }
 
     pub fn as_text(&self) -> Option<&str> {
-        match self {
-            SqliteValueRef::Text(s) => Some(s),
-            _ => None,
-        }
+        self.0.as_str().ok()
     }
 
     pub fn as_blob(&self) -> Option<&[u8]> {
-        match self {
-            SqliteValueRef::Blob(b) => Some(b),
-            _ => None,
-        }
+        self.0.as_blob().ok()
     }
 
     pub fn to_owned(&self) -> SqliteValue {
-        match self {
-            SqliteValueRef::Null => SqliteValue::Null,
-            SqliteValueRef::Integer(v) => SqliteValue::Integer(*v),
-            SqliteValueRef::Real(v) => SqliteValue::Real(Real(*v)),
-            SqliteValueRef::Text(v) => SqliteValue::Text((*v).to_compact_string()),
-            SqliteValueRef::Blob(v) => SqliteValue::Blob(v.to_smallvec()),
+        match self.0 {
+            ValueRef::Null => SqliteValue::Null,
+            ValueRef::Integer(v) => SqliteValue::Integer(v),
+            ValueRef::Real(v) => SqliteValue::Real(Real(v)),
+            ValueRef::Text(v) => SqliteValue::Text(CompactString::from_utf8_lossy(v)),
+            ValueRef::Blob(v) => SqliteValue::Blob(v.to_smallvec()),
+        }
+    }
+}
+
+impl<'a> Hash for SqliteValueRef<'a> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        core::mem::discriminant(&self.0).hash(state);
+        match self.0 {
+            ValueRef::Null => {}
+            ValueRef::Integer(v) => {
+                v.hash(state);
+            }
+            ValueRef::Real(v) => {
+                integer_decode(v).hash(state);
+            }
+            ValueRef::Text(v) => {
+                v.hash(state);
+            }
+            ValueRef::Blob(v) => {
+                v.hash(state);
+            }
         }
     }
 }
@@ -369,13 +387,13 @@ impl ToSql for SqliteParam {
 
 impl<'a> ToSql for SqliteValueRef<'a> {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'a>> {
-        Ok(match self {
-            SqliteValueRef::Null => ToSqlOutput::Owned(Value::Null),
-            SqliteValueRef::Integer(i) => ToSqlOutput::Owned(Value::Integer(*i)),
-            SqliteValueRef::Real(f) => ToSqlOutput::Owned(Value::Real(*f)),
-            SqliteValueRef::Text(t) => ToSqlOutput::Borrowed(ValueRef::Text(t.as_bytes())),
-            SqliteValueRef::Blob(b) => ToSqlOutput::Borrowed(ValueRef::Blob(b)),
-        })
+        Ok(ToSqlOutput::Borrowed(self.0))
+    }
+}
+
+impl<'a> From<ValueRef<'a>> for SqliteValueRef<'a> {
+    fn from(value: ValueRef<'a>) -> Self {
+        Self(value)
     }
 }
 
@@ -476,11 +494,11 @@ impl SqliteValue {
 
     pub fn as_ref(&self) -> SqliteValueRef {
         match self {
-            SqliteValue::Null => SqliteValueRef::Null,
-            SqliteValue::Integer(i) => SqliteValueRef::Integer(*i),
-            SqliteValue::Real(r) => SqliteValueRef::Real(r.0),
-            SqliteValue::Text(s) => SqliteValueRef::Text(s.as_str()),
-            SqliteValue::Blob(v) => SqliteValueRef::Blob(v.as_slice()),
+            SqliteValue::Null => SqliteValueRef(ValueRef::Null),
+            SqliteValue::Integer(i) => SqliteValueRef(ValueRef::Integer(*i)),
+            SqliteValue::Real(r) => SqliteValueRef(ValueRef::Real(r.0)),
+            SqliteValue::Text(s) => SqliteValueRef(ValueRef::Text(s.as_bytes())),
+            SqliteValue::Blob(v) => SqliteValueRef(ValueRef::Blob(v.as_slice())),
         }
     }
 
@@ -643,6 +661,45 @@ where
     }
 }
 
+impl<'a, C> Writable<C> for SqliteValueRef<'a>
+where
+    C: Context,
+{
+    #[inline]
+    fn write_to<T: ?Sized + Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
+        match self {
+            SqliteValueRef(ValueRef::Null) => writer.write_u8(0),
+            SqliteValueRef(ValueRef::Integer(i)) => {
+                1u8.write_to(writer)?;
+                i.write_to(writer)
+            }
+            SqliteValueRef(ValueRef::Real(f)) => {
+                2u8.write_to(writer)?;
+                f.write_to(writer)
+            }
+            SqliteValueRef(ValueRef::Text(s)) => {
+                3u8.write_to(writer)?;
+                (*s).write_to(writer)
+            }
+            SqliteValueRef(ValueRef::Blob(b)) => {
+                4u8.write_to(writer)?;
+                (*b).write_to(writer)
+            }
+        }
+    }
+
+    #[inline]
+    fn bytes_needed(&self) -> Result<usize, C::Error> {
+        Ok(1 + match self {
+            SqliteValueRef(ValueRef::Null) => 0,
+            SqliteValueRef(ValueRef::Integer(i)) => <i64 as Writable<C>>::bytes_needed(i)?,
+            SqliteValueRef(ValueRef::Real(f)) => <f64 as Writable<C>>::bytes_needed(f)?,
+            SqliteValueRef(ValueRef::Text(s)) => <[u8] as Writable<C>>::bytes_needed(s)?,
+            SqliteValueRef(ValueRef::Blob(b)) => <[u8] as Writable<C>>::bytes_needed(b)?,
+        })
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct TableName(pub CompactString);
@@ -650,6 +707,25 @@ pub struct TableName(pub CompactString);
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct ColumnName(pub CompactString);
+
+impl Borrow<str> for ColumnName {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for ColumnName {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl From<&str> for ColumnName {
+    fn from(value: &str) -> Self {
+        ColumnName(value.into())
+    }
+}
 
 impl Deref for TableName {
     type Target = CompactString;

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -704,6 +704,25 @@ where
 #[serde(transparent)]
 pub struct TableName(pub CompactString);
 
+impl fmt::Display for TableName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Borrow<str> for TableName {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<&str> for TableName {
+    fn from(value: &str) -> Self {
+        TableName(value.into())
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct ColumnName(pub CompactString);

--- a/crates/corro-api-types/src/sqlite.rs
+++ b/crates/corro-api-types/src/sqlite.rs
@@ -1,7 +1,10 @@
 use rusqlite::types::{FromSql, FromSqlError};
 use serde::{Deserialize, Serialize};
+use speedy::{Readable, Writable};
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, strum::FromRepr)]
+#[derive(
+    Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Readable, Writable, strum::FromRepr,
+)]
 #[serde(rename_all = "snake_case")]
 #[repr(u8)]
 pub enum ChangeType {

--- a/crates/corro-api-types/src/sqlite.rs
+++ b/crates/corro-api-types/src/sqlite.rs
@@ -1,4 +1,7 @@
-use rusqlite::types::{FromSql, FromSqlError};
+use rusqlite::{
+    types::{FromSql, FromSqlError},
+    ToSql,
+};
 use serde::{Deserialize, Serialize};
 use speedy::{Readable, Writable};
 
@@ -22,5 +25,13 @@ impl FromSql for ChangeType {
             .ok_or_else(|| FromSqlError::OutOfRange(i))?),
             _ => Err(FromSqlError::InvalidType),
         }
+    }
+}
+
+impl ToSql for ChangeType {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(rusqlite::types::ToSqlOutput::Owned(
+            rusqlite::types::Value::Integer((*self as u8) as i64),
+        ))
     }
 }

--- a/crates/corro-pg/Cargo.toml
+++ b/crates/corro-pg/Cargo.toml
@@ -19,12 +19,12 @@ spawn = { path = "../spawn" }
 sqlite3-parser = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-time = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tripwire = { path = "../tripwire" }
 sqlparser = { version = "0.39.0" }
+chrono = { version = "0.4.31" }
 
 [dev-dependencies]
 corro-tests = { path = "../corro-tests" }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2989,7 +2989,7 @@ mod tests {
             println!("t2text: {:?}", row.try_get::<_, String>(2));
 
             let now: DateTime<Utc> = Utc::now();
-            let now = NaiveDateTime::new(now.date_naive(), now.time());
+            let now = NaiveDateTime::from_timestamp_micros(now.timestamp_micros()).unwrap();
             println!("NOW: {now:?}");
 
             let row = client

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -729,13 +729,13 @@ pub async fn start(
                                             .filter_map(|oid| Type::from_oid(*oid))
                                             .collect();
 
-                                        println!("params? {param_types:?}");
+                                        debug!("params types {param_types:?}");
 
                                         if param_types.len() != prepped.parameter_count() {
                                             param_types = parameter_types(&schema, &parsed_cmd)
                                                 .into_iter()
                                                 .map(|param| {
-                                                    println!("got param: {param:?}");
+                                                    trace!("got param: {param:?}");
                                                     match param {
                                                         (SqliteType::Null, _) => unreachable!(),
                                                         (SqliteType::Text, src) => match src {
@@ -1033,7 +1033,7 @@ pub async fn start(
                                             prepped.parameter_count()
                                         );
 
-                                        trace!("param types: {param_types:?}");
+                                        debug!("bind param types: {param_types:?}");
 
                                         let mut format_codes = match bind
                                             .parameter_format_codes()
@@ -2177,7 +2177,7 @@ fn name_to_type(name: &str) -> Result<Type, UnsupportedSqliteToPostgresType> {
 }
 
 fn handle_commit(agent: &Agent, conn: &Connection) -> rusqlite::Result<()> {
-    println!("HANDLE COMMIT");
+    trace!("HANDLE COMMIT");
     let actor_id = agent.actor_id();
 
     let ts = Timestamp::from(agent.clock().new_timestamp());

--- a/crates/corro-tpl/src/lib.rs
+++ b/crates/corro-tpl/src/lib.rs
@@ -7,10 +7,10 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
-use compact_str::CompactString;
 use compact_str::ToCompactString;
 use corro_client::sub::SubscriptionStream;
 use corro_client::CorrosionApiClient;
+use corro_types::api::ColumnName;
 use corro_types::api::QueryEvent;
 use corro_types::api::SqliteParam;
 use corro_types::api::Statement;
@@ -109,7 +109,7 @@ impl IntoIterator for QueryResponse {
 struct Row {
     #[allow(dead_code)]
     id: i64,
-    columns: Arc<IndexMap<CompactString, u16>>,
+    columns: Arc<IndexMap<ColumnName, u16>>,
     cells: Arc<Vec<SqliteValue>>,
 }
 
@@ -223,7 +223,7 @@ struct QueryResponseIter {
     body: OnceCell<SubscriptionStream>,
     handle: tokio::runtime::Handle,
     done: bool,
-    columns: Option<Arc<IndexMap<CompactString, u16>>>,
+    columns: Option<Arc<IndexMap<ColumnName, u16>>>,
 }
 
 impl QueryResponseIter {
@@ -665,7 +665,7 @@ fn write_json_rows_as_object<W: Write, F: Formatter>(
             .iter()
             .enumerate()
             .filter_map(|(i, (col, _))| row.cells.get(i).map(|value| (col, value)))
-            .collect::<IndexMap<&CompactString, &SqliteValue>>();
+            .collect::<IndexMap<&ColumnName, &SqliteValue>>();
 
         seq.serialize_element(&map)
             .map_err(|e| Box::new(EvalAltResult::from(e.to_string())))?;

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 [dependencies]
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
-deadpool = { workspace = true }
 bytes = { workspace = true }
 camino = { workspace = true }
 circular-buffer = "0.1.3"
@@ -16,6 +15,7 @@ compact_str = { workspace = true }
 config = { workspace = true }
 consul-client = { version = "0.1.0-alpha.0", path = "../consul-client" }
 corro-api-types = { version = "0.1.0-alpha.1", path = "../corro-api-types" }
+deadpool = { workspace = true }
 enquote = { workspace = true }
 fallible-iterator = { workspace = true }
 foca = { workspace = true } 
@@ -34,7 +34,9 @@ seahash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+spawn = { path = "../spawn" }
 speedy = { workspace = true }
+sqlite-pool = { path = "../sqlite-pool" }
 sqlite3-parser = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true } 
@@ -45,7 +47,6 @@ tracing = { workspace = true }
 tripwire = { version = "0.1.0-alpha.0", path = "../tripwire" }
 uhlc = { workspace = true }
 uuid = { workspace = true }
-sqlite-pool = { path = "../sqlite-pool" }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -46,7 +46,6 @@ tripwire = { version = "0.1.0-alpha.0", path = "../tripwire" }
 uhlc = { workspace = true }
 uuid = { workspace = true }
 sqlite-pool = { path = "../sqlite-pool" }
-yaque = { version = "0.6.6" }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -30,6 +30,7 @@ rand = { workspace = true }
 rangemap = { workspace = true }
 rcgen = { workspace = true }
 rusqlite = { workspace = true }
+seahash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
@@ -45,3 +46,7 @@ tripwire = { version = "0.1.0-alpha.0", path = "../tripwire" }
 uhlc = { workspace = true }
 uuid = { workspace = true }
 sqlite-pool = { path = "../sqlite-pool" }
+yaque = { version = "0.6.6" }
+
+[dev-dependencies]
+tracing-subscriber = { workspace = true }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -311,13 +311,14 @@ fn v0_2_0_migration(tx: &Transaction) -> rusqlite::Result<()> {
 
 fn v0_2_0_1_migration(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(
-        "
+        r#"
         -- where subscriptions are stored
         CREATE TABLE __corro_subs (
             id BLOB PRIMARY KEY NOT NULL,
-            sql TEXT NOT NULL
+            sql TEXT NOT NULL,
+            state TEXT NOT NULL DEFAULT 'created'
         ) WITHOUT ROWID;
-    ",
+    "#,
     )
 }
 

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -68,7 +68,7 @@ pub struct DbConfig {
 }
 
 impl DbConfig {
-    pub fn subscriptions_db_path(&self) -> Utf8PathBuf {
+    pub fn subscriptions_path(&self) -> Utf8PathBuf {
         self.subscriptions_path
             .as_ref()
             .cloned()

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -75,8 +75,8 @@ impl DbConfig {
             .unwrap_or_else(|| {
                 self.path
                     .parent()
-                    .map(|parent| parent.join("subscriptions.db"))
-                    .unwrap_or_else(|| "/subscriptions.db".into())
+                    .map(|parent| parent.join("subscriptions"))
+                    .unwrap_or_else(|| "/subscriptions".into())
             })
     }
 }

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -530,6 +530,9 @@ impl Matcher {
         sql: &str,
     ) -> Result<(Matcher, MatcherHandle), MatcherError> {
         let sub_path = subs_path.join(id.as_simple().to_string());
+
+        info!("Initializing subscription at {sub_path}");
+
         std::fs::create_dir_all(&sub_path)?;
 
         let sub_db_path = sub_path.join(SUB_DB_PATH);

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -2186,6 +2186,11 @@ mod tests {
 
             println!("got change (B)");
 
+            // process the same and check that it doesn't produce a change again!
+            matcher.process_changeset(changes.as_slice()).unwrap();
+
+            assert_eq!(rx.try_recv(), Err(mpsc::error::TryRecvError::Empty));
+
             // lots of operations
 
             let range = 4u32..1000u32;

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -2016,6 +2016,7 @@ mod tests {
     use corro_api_types::row_to_change;
     use rusqlite::params;
     use spawn::wait_for_all_pending_handles;
+    use tokio::sync::Semaphore;
 
     use crate::{
         agent::migrate,
@@ -2041,7 +2042,8 @@ mod tests {
         let subscriptions_path: Utf8PathBuf =
             tmpdir.path().join("subs").display().to_string().into();
 
-        let pool = SplitPool::create(db_path, tripwire.clone()).await?;
+        let pool =
+            SplitPool::create(db_path, Arc::new(Semaphore::new(1)), tripwire.clone()).await?;
         {
             let mut conn = pool.write_priority().await?;
             setup_conn(&mut conn)?;
@@ -2162,7 +2164,9 @@ mod tests {
         let subscriptions_path: Utf8PathBuf =
             tmpdir.path().join("subs").display().to_string().into();
 
-        let pool = SplitPool::create(&db_path, tripwire.clone()).await.unwrap();
+        let pool = SplitPool::create(&db_path, Arc::new(Semaphore::new(1)), tripwire.clone())
+            .await
+            .unwrap();
         let mut conn = pool.write_priority().await.unwrap();
 
         {

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -1224,6 +1224,7 @@ impl Matcher {
                         ON CONFLICT({conflict_clause})
                             DO UPDATE SET
                                 {excluded}
+                            WHERE {excluded_not_same}
                         RETURNING __corro_rowid,{return_cols}",
                     // insert into
                     insert_cols = tmp_cols.join(","),
@@ -1237,6 +1238,10 @@ impl Matcher {
                         .map(|i| format!("col_{i} = excluded.col_{i}"))
                         .collect::<Vec<_>>()
                         .join(","),
+                    excluded_not_same = (0..(self.parsed.columns.len()))
+                        .map(|i| format!("col_{i} IS NOT excluded.col_{i}"))
+                        .collect::<Vec<_>>()
+                        .join(" OR "),
                     return_cols = actual_cols.join(",")
                 );
 

--- a/crates/corro-types/src/schema.rs
+++ b/crates/corro-types/src/schema.rs
@@ -351,7 +351,7 @@ pub fn apply_schema(
                 schema_to_merge.tables.insert(name.clone(), parsed_table);
             }
 
-            tx.execute_batch(&format!("SELECT crsql_as_crr('{name}');"))?;
+            tx.execute_batch(&format!("SELECT crsql_as_crr('{name}'); CREATE INDEX IF NOT EXISTS corro_{name}__crsql_clock_site_id_dbv ON {name}__crsql_clock (site_id, db_version);"))?;
 
             if schema_to_merge.tables.contains_key(name) {
                 // just merged!


### PR DESCRIPTION
Subscriptions were affecting the main database because there was only 1 subscriptions database and it was being `ATTACH`ed. Any writes to either would lock both.

These changes greatly improve subscriptions performances by:
- Using a dedicated SQLite database per subscription
- Never writing to the main database or to the subscription database when attached (therefore preventing any write locks from occurring)