### PR TITLE
Fix high-frequency changes skips on re-subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,9 +2052,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2343,14 +2343,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2963,7 +2963,7 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "tracing",
  "windows-sys 0.48.0",
 ]
@@ -3555,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -3925,9 +3925,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3937,7 +3937,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -3954,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3965,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b2fc67d5dec41db679b9b052eb572269616926040b7831e32c8a152df77b84"
+checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -3995,7 +3995,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "tokio",
  "tokio-util",
  "whoami",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
 	"crates/*",
 	"integration-tests"
 ]
+resolver = "2"
 
 [workspace.dependencies]
 arc-swap = { version = "1.6.0" }
@@ -63,7 +64,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 time = { version = "0.3.15", features = ["macros", "serde-well-known"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.34", features = ["full"] }
 tokio-metrics = "0.3.0"
 tokio-serde = { version = "0.8", features = ["json"] }
 tokio-stream = { version = "0.1.12", features = ["sync"] }

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -783,7 +783,11 @@ async fn forward_bytes_to_body_sender(
                     QueryEventMeta::EndOfQuery(Some(change_id)) |
                     QueryEventMeta::Change(change_id) => {
                         if !last_change_id.is_zero() && change_id > last_change_id + 1 {
-                            warn!(%sub_id, "non-contiguous change id received: {change_id:?}, last seen: {last_change_id:?}");
+                            warn!(%sub_id, "non-contiguous change id (> + 1) received: {change_id:?}, last seen: {last_change_id:?}");
+                        } else if !last_change_id.is_zero() && change_id == last_change_id {
+                            warn!(%sub_id, "duplicate change id received: {change_id:?}, last seen: {last_change_id:?}");
+                        } else if change_id < last_change_id {
+                            warn!(%sub_id, "smaller change id received: {change_id:?}, last seen: {last_change_id:?}");
                         }
                         last_change_id = change_id;
                     },

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -39,7 +39,7 @@ impl QueryEvent {
         match self {
             QueryEvent::Columns(_) => QueryEventMeta::Columns,
             QueryEvent::Row(rowid, _) => QueryEventMeta::Row(*rowid),
-            QueryEvent::EndOfQuery { .. } => QueryEventMeta::EndOfQuery,
+            QueryEvent::EndOfQuery { change_id, .. } => QueryEventMeta::EndOfQuery(*change_id),
             QueryEvent::Change(_, _, _, id) => QueryEventMeta::Change(*id),
             QueryEvent::Error(_) => QueryEventMeta::Error,
         }
@@ -50,7 +50,7 @@ impl QueryEvent {
 pub enum QueryEventMeta {
     Columns,
     Row(RowId),
-    EndOfQuery,
+    EndOfQuery(Option<ChangeId>),
     Change(ChangeId),
     Error,
 }
@@ -106,6 +106,12 @@ impl ToSql for RowId {
 )]
 #[serde(transparent)]
 pub struct ChangeId(pub i64);
+
+impl ChangeId {
+    pub fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+}
 
 impl fmt::Display for ChangeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Corrosion was not waiting for the rows channel to fully drain before starting to send changes.

Fixes #89

