### PR TITLE
Allow the first change set in a sub to be non-contiguous

### DIFF
--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -105,7 +105,6 @@ impl CorrosionApiClient {
 
         Ok(SubscriptionStream::new(
             id,
-            from,
             self.api_client.clone(),
             self.api_addr,
             res.into_body(),
@@ -147,7 +146,6 @@ impl CorrosionApiClient {
 
         Ok(SubscriptionStream::new(
             id,
-            from,
             self.api_client.clone(),
             self.api_addr,
             res.into_body(),

--- a/crates/corro-client/src/sub.rs
+++ b/crates/corro-client/src/sub.rs
@@ -86,7 +86,6 @@ pub enum SubscriptionError {
 impl SubscriptionStream {
     pub fn new(
         id: Uuid,
-        last_change_id: Option<ChangeId>,
         client: hyper::Client<HttpConnector, Body>,
         api_addr: SocketAddr,
         body: hyper::Body,
@@ -96,7 +95,7 @@ impl SubscriptionStream {
             client,
             api_addr,
             observed_eoq: false,
-            last_change_id,
+            last_change_id: None,
             stream: Some(FramedRead::new(
                 StreamReader::new(IoBodyStream { body }),
                 LinesBytesCodec::default(),


### PR DESCRIPTION
This may happen while re-subscribing with a known change ID that's already
become stale. In this case, allow the very first change set in the newly
created subscription to be non-contiguous and enfore the rule for all
subsequent change sets.
