### PR TITLE
Use the write semaphore in subscription logic

### DIFF
--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -2469,7 +2469,7 @@ async fn handle_changes(
             // drain and process current changes!
             #[allow(clippy::drain_collect)]
             if let Err(e) = process_multiple_changes(&agent, buf.drain(..).collect()).await {
-                error!("could not process multiple changes: {e}");
+                error!("could not process last multiple changes: {e}");
             }
 
             // reset count

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -400,6 +400,7 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
                 &agent.schema().read(),
                 agent.pool(),
                 rx_db_version.clone(),
+                agent.write_sema().clone(),
                 tripwire.clone(),
             ) {
                 Ok(res) => res,
@@ -431,6 +432,7 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
                     id,
                     Matcher::sub_path(agent.config().db.subscriptions_path().as_path(), id),
                     &conn,
+                    None,
                 )?;
             }
         }

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -427,7 +427,7 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
                 let path_str = entry.path().display().to_string();
                 info!("Looking at possibly cleaning up subscription {path_str}");
                 if let Some(sub_id_str) = path_str.strip_prefix(subs_path.as_str()) {
-                    if let Ok(sub_id) = sub_id_str.parse() {
+                    if let Ok(sub_id) = sub_id_str.trim_matches('/').parse() {
                         if restored.contains(&sub_id) {
                             continue;
                         }

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -425,12 +425,12 @@ pub async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
         if let Ok(mut dir) = tokio::fs::read_dir(&subs_path).await {
             while let Ok(Some(entry)) = dir.next_entry().await {
                 let path_str = entry.path().display().to_string();
-                info!("Looking at possibly cleaning up subscription {path_str}");
                 if let Some(sub_id_str) = path_str.strip_prefix(subs_path.as_str()) {
                     if let Ok(sub_id) = sub_id_str.trim_matches('/').parse() {
                         if restored.contains(&sub_id) {
                             continue;
                         }
+                        info!("Found defunct subscription at {path_str}");
                         to_cleanup.push(sub_id);
                     }
                 }

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -110,9 +110,6 @@ where
             start.elapsed()
         };
 
-        // change the current db version, so that subscribers can catch up
-        agent.change_db_version(db_version);
-
         trace!("committed tx, db_version: {db_version}, last_seq: {last_seq:?}");
 
         book_writer.insert(
@@ -151,6 +148,8 @@ where
                             }
 
                             trace!("broadcasting changes: {changes:?} for seq: {seqs:?}");
+
+                            agent.subs_manager().match_changes(&changes, db_version);
 
                             let tx_bcast = agent.tx_bcast().clone();
                             tokio::spawn(async move {

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -34,12 +34,12 @@ pub struct SubParams {
 }
 
 pub async fn api_v1_sub_by_id(
-    Extension(subs): Extension<SubsManager>,
+    Extension(agent): Extension<Agent>,
     Extension(bcast_cache): Extension<SharedMatcherBroadcastCache>,
     axum::extract::Path(id): axum::extract::Path<Uuid>,
     axum::extract::Query(params): axum::extract::Query<SubParams>,
 ) -> impl IntoResponse {
-    sub_by_id(&subs, id, params, &bcast_cache).await
+    sub_by_id(agent.subs_manager(), id, params, &bcast_cache).await
 }
 
 async fn sub_by_id(
@@ -627,7 +627,6 @@ pub async fn upsert_sub(
 
 pub async fn api_v1_subs(
     Extension(agent): Extension<Agent>,
-    Extension(subs): Extension<SubsManager>,
     Extension(bcast_cache): Extension<SharedMatcherBroadcastCache>,
     Extension(tripwire): Extension<Tripwire>,
     axum::extract::Query(params): axum::extract::Query<SubParams>,
@@ -639,6 +638,8 @@ pub async fn api_v1_subs(
     };
 
     let mut bcast_write = bcast_cache.write().await;
+
+    let subs = agent.subs_manager();
 
     let upsert_res = subs.get_or_insert(
         &stmt,
@@ -826,13 +827,11 @@ mod tests {
 
         assert!(body.0.results.len() == 2);
 
-        let subs = SubsManager::default();
         let bcast_cache: SharedMatcherBroadcastCache = Default::default();
 
         {
             let mut res = api_v1_subs(
                 Extension(agent.clone()),
-                Extension(subs.clone()),
                 Extension(bcast_cache.clone()),
                 Extension(tripwire.clone()),
                 axum::extract::Query(SubParams::default()),
@@ -922,7 +921,6 @@ mod tests {
 
             let mut res = api_v1_subs(
                 Extension(agent.clone()),
-                Extension(subs.clone()),
                 Extension(bcast_cache.clone()),
                 Extension(tripwire.clone()),
                 axum::extract::Query(SubParams {
@@ -984,7 +982,6 @@ mod tests {
 
             let mut res = api_v1_subs(
                 Extension(agent.clone()),
-                Extension(subs.clone()),
                 Extension(bcast_cache.clone()),
                 Extension(tripwire.clone()),
                 axum::extract::Query(SubParams::default()),
@@ -1054,7 +1051,6 @@ mod tests {
 
         let mut res = api_v1_subs(
             Extension(agent.clone()),
-            Extension(subs.clone()),
             Extension(bcast_cache.clone()),
             Extension(tripwire.clone()),
             axum::extract::Query(SubParams {
@@ -1104,7 +1100,6 @@ mod tests {
 
         let mut res = api_v1_subs(
             Extension(agent.clone()),
-            Extension(subs.clone()),
             Extension(bcast_cache.clone()),
             Extension(tripwire.clone()),
             axum::extract::Query(SubParams {
@@ -1155,7 +1150,6 @@ mod tests {
 
         let mut res = api_v1_subs(
             Extension(agent.clone()),
-            Extension(subs.clone()),
             Extension(bcast_cache.clone()),
             Extension(tripwire.clone()),
             axum::extract::Query(SubParams {

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -665,7 +665,7 @@ pub async fn api_v1_subs(
     let matcher_id = match upsert_sub(
         handle,
         maybe_created,
-        &subs,
+        subs,
         &mut bcast_write,
         params,
         forward_tx,
@@ -761,7 +761,7 @@ async fn forward_bytes_to_body_sender(
     }
     if !buf.is_empty() {
         if let Err(e) = tx.send_data(buf.freeze()).await {
-            warn!(%sub_id, "could not forward subscription query event to receiver: {e}");
+            warn!(%sub_id, "could not forward last subscription query event to receiver: {e}");
         }
     }
 }

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -646,6 +646,7 @@ pub async fn api_v1_subs(
         &agent.schema().read(),
         agent.pool(),
         agent.rx_db_version(),
+        agent.write_sema().clone(),
         tripwire,
     );
 

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -637,6 +637,8 @@ pub async fn api_v1_subs(
         Err(e) => return hyper::Response::<hyper::Body>::from(e),
     };
 
+    info!("Received subscription request for query: {stmt}");
+
     let mut bcast_write = bcast_cache.write().await;
 
     let subs = agent.subs_manager();

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -645,7 +645,6 @@ pub async fn api_v1_subs(
         &agent.config().db.subscriptions_path(),
         &agent.schema().read(),
         agent.pool(),
-        agent.rx_db_version(),
         agent.write_sema().clone(),
         tripwire,
     );

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -108,7 +108,7 @@ fn make_query_event_bytes(
     Ok((buf.split().freeze(), query_evt.meta()))
 }
 
-const MAX_UNSUB_TIME: Duration = Duration::from_secs(300);
+const MAX_UNSUB_TIME: Duration = Duration::from_secs(120);
 // this should be a fraction of the MAX_UNSUB_TIME
 const RECEIVERS_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -754,6 +754,12 @@ impl From<&str> for TableName {
 #[serde(transparent)]
 pub struct ColumnName(pub CompactString);
 
+impl ColumnName {
+    pub fn is_crsql_sentinel(&self) -> bool {
+        self.0 == "-1"
+    }
+}
+
 impl Borrow<str> for ColumnName {
     #[inline]
     fn borrow(&self) -> &str {

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2375,6 +2375,8 @@ fn handle_commit(agent: &Agent, conn: &Connection) -> rusqlite::Result<()> {
 
                             trace!("broadcasting changes: {changes:?} for seq: {seqs:?}");
 
+                            agent.subs_manager().match_changes(&changes, db_version);
+
                             let tx_bcast = agent.tx_bcast().clone();
                             tokio::spawn(async move {
                                 if let Err(e) = tx_bcast
@@ -2408,8 +2410,6 @@ fn handle_commit(agent: &Agent, conn: &Connection) -> rusqlite::Result<()> {
             Ok::<_, BoxError>(())
         }
     });
-
-    agent.change_db_version(db_version);
 
     Ok(())
 }

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -1550,8 +1550,8 @@ impl Matcher {
                 ))?;
 
                 for (mut change_type, mut prepped) in [
-                    (Some(ChangeType::Delete), delete_prepped), // start w/ deletions
                     (None, insert_prepped),
+                    (Some(ChangeType::Delete), delete_prepped),
                 ] {
                     let col_count = prepped.column_count();
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -684,6 +684,8 @@ impl Matcher {
             r#"
                 PRAGMA journal_mode = WAL;
                 PRAGMA synchronous = NORMAL;
+                PRAGMA mmap_size = 536870912;
+                PRAGMA temp_store = memory;
             "#,
         )?;
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -296,9 +296,12 @@ impl SubsManager {
             Ok(handle) => handle,
             Err(e) => {
                 let conn = pool.client_dedicated()?;
-                if let Err(e) =
-                    Matcher::cleanup(id, subs_path.join(id.to_string()), &conn, Some(write_sema))
-                {
+                if let Err(e) = Matcher::cleanup(
+                    id,
+                    Matcher::sub_path(subs_path, id),
+                    &conn,
+                    Some(write_sema),
+                ) {
                     error!("could not cleanup subscription: {e}");
                 }
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -1073,13 +1073,17 @@ impl Matcher {
             // let _permit = write_sema.clone().acquire_owned().await;
 
             info!(sub_id = %self.id, "Attaching __corro_sub to state db");
-            if let Err(e) = state_conn.execute_batch(&format!(
-                "ATTACH DATABASE {} AS __corro_sub",
-                enquote::enquote('\'', self.base_path.join(SUB_DB_PATH).as_str()),
-            )) {
+            if let Err(e) = state_conn
+                .execute_batch(&format!(
+                    "ATTACH DATABASE {} AS __corro_sub",
+                    enquote::enquote('\'', self.base_path.join(SUB_DB_PATH).as_str()),
+                ))
+                .and_then(|_| state_conn.execute_batch("PRAGMA __corro_sub.mmap_size = 536870912;"))
+            {
                 error!(sub_id = %self.id, "could not ATTACH sub db as __corro_sub on state db: {e}");
                 return;
             }
+
             info!(sub_id = %self.id, "Attached __corro_sub to state db");
         }
 


### PR DESCRIPTION
Some operations may return a "database locked" error from the main connection if we're not using the write semaphore to acquire a permit first.

This PR also batches changes to reduce I/O for subscriptions.