### PR TITLE
Use `u64` newtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "fallible-iterator 0.3.0",
  "foca",
  "futures",
+ "hex",
  "indexmap 2.1.0",
  "itertools",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,9 +793,30 @@ dependencies = [
  "async-trait",
  "camino",
  "compact_str 0.7.0",
+ "corro-base-types",
  "corro-speedy",
  "deadpool",
  "hex",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "strum",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "corro-base-types"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "async-trait",
+ "camino",
+ "compact_str 0.7.0",
+ "corro-speedy",
+ "deadpool",
+ "hex",
+ "rangemap",
  "rusqlite",
  "serde",
  "serde_json",
@@ -922,6 +943,7 @@ dependencies = [
  "config",
  "consul-client",
  "corro-api-types",
+ "corro-base-types",
  "corro-speedy",
  "deadpool",
  "enquote",

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -1671,7 +1671,7 @@ async fn process_fully_buffered_changes(
 
         info!(%actor_id, version, "Processing buffered changes to crsql_changes (actor: {actor_id}, version: {version}, last_seq: {last_seq})");
 
-        let max_db_version: Option<Option<i64>> = tx.prepare_cached("SELECT MAX(db_version) FROM __corro_buffered_changes WHERE site_id = ? AND version = ?")?.query_row(params![actor_id.as_bytes(), version], |row| row.get(0)).optional()?;
+        let max_db_version: Option<Option<CrsqlDbVersion>> = tx.prepare_cached("SELECT MAX(db_version) FROM __corro_buffered_changes WHERE site_id = ? AND version = ?")?.query_row(params![actor_id.as_bytes(), version], |row| row.get(0)).optional()?;
 
         let start = Instant::now();
 

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -138,7 +138,8 @@ where
                         ORDER BY seq ASC
                 "#)?;
                 let rows = prepped.query_map([db_version], row_to_change)?;
-                let chunked = ChunkedChanges::new(rows, 0, last_seq, MAX_CHANGES_BYTE_SIZE);
+                let chunked =
+                    ChunkedChanges::new(rows, CrsqlSeq(0), last_seq, MAX_CHANGES_BYTE_SIZE);
                 for changes_seqs in chunked {
                     match changes_seqs {
                         Ok((changes, seqs)) => {
@@ -613,7 +614,7 @@ pub async fn api_v1_db_schema(
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use corro_types::{api::RowId, config::Config, schema::SqliteType};
+    use corro_types::{api::RowId, config::Config, schema::SqliteType, base::Version};
     use futures::Stream;
     use http_body::{combinators::UnsyncBoxBody, Body};
     use tokio::sync::mpsc::error::TryRecvError;
@@ -688,7 +689,10 @@ mod tests {
         assert!(matches!(
             msg,
             BroadcastInput::AddBroadcast(BroadcastV1::Change(ChangeV1 {
-                changeset: Changeset::Full { version: 1, .. },
+                changeset: Changeset::Full {
+                    version: Version(1),
+                    ..
+                },
                 ..
             }))
         ));
@@ -702,7 +706,7 @@ mod tests {
                 .read("test")
                 .await
                 .last(),
-            Some(1)
+            Some(Version(1))
         );
 
         println!("second req...");

--- a/crates/corro-agent/src/lib.rs
+++ b/crates/corro-agent/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(step_trait)]
 pub mod agent;
 pub mod api;
 pub mod broadcast;

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -218,8 +218,10 @@ pub struct Change {
     pub cid: ColumnName,
     pub val: SqliteValue,
     pub col_version: i64,
-    pub db_version: i64,
-    pub seq: i64,
+    // TODO: use CrsqlDbVersion
+    pub db_version: u64,
+    // TODO: use CrsqlSeq
+    pub seq: u64,
     pub site_id: [u8; 16],
     pub cl: i64,
 }

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use compact_str::CompactString;
+use corro_base_types::{CrsqlDbVersion, CrsqlSeq};
 use rusqlite::{
     types::{FromSql, FromSqlError, ToSqlOutput, Value, ValueRef},
     Row, ToSql,
@@ -212,10 +213,8 @@ pub struct Change {
     pub cid: ColumnName,
     pub val: SqliteValue,
     pub col_version: i64,
-    // TODO: use CrsqlDbVersion
-    pub db_version: u64,
-    // TODO: use CrsqlSeq
-    pub seq: u64,
+    pub db_version: CrsqlDbVersion,
+    pub seq: CrsqlSeq,
     pub site_id: [u8; 16],
     pub cl: i64,
 }

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -60,7 +60,7 @@ pub enum QueryEventMeta {
     Debug, Clone, Copy, Serialize, Deserialize, Readable, Writable, PartialEq, Eq, Ord, PartialOrd,
 )]
 #[serde(transparent)]
-pub struct RowId(pub i64);
+pub struct RowId(pub u64);
 
 impl fmt::Display for RowId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -68,18 +68,15 @@ impl fmt::Display for RowId {
     }
 }
 
-impl From<i64> for RowId {
-    fn from(value: i64) -> Self {
+impl From<u64> for RowId {
+    fn from(value: u64) -> Self {
         Self(value)
     }
 }
 
 impl FromSql for RowId {
     fn column_result(value: ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        match value {
-            ValueRef::Integer(i) => Ok(i.into()),
-            _ => Err(FromSqlError::InvalidType),
-        }
+        u64::column_result(value).map(Self)
     }
 }
 
@@ -105,7 +102,7 @@ impl ToSql for RowId {
     PartialOrd,
 )]
 #[serde(transparent)]
-pub struct ChangeId(pub i64);
+pub struct ChangeId(pub u64);
 
 impl ChangeId {
     pub fn is_zero(&self) -> bool {
@@ -119,18 +116,15 @@ impl fmt::Display for ChangeId {
     }
 }
 
-impl From<i64> for ChangeId {
-    fn from(value: i64) -> Self {
+impl From<u64> for ChangeId {
+    fn from(value: u64) -> Self {
         Self(value)
     }
 }
 
 impl FromSql for ChangeId {
     fn column_result(value: ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        match value {
-            ValueRef::Integer(i) => Ok(i.into()),
-            _ => Err(FromSqlError::InvalidType),
-        }
+        u64::column_result(value).map(Self)
     }
 }
 
@@ -140,8 +134,8 @@ impl ToSql for ChangeId {
     }
 }
 
-impl AddAssign<i64> for ChangeId {
-    fn add_assign(&mut self, rhs: i64) {
+impl AddAssign<u64> for ChangeId {
+    fn add_assign(&mut self, rhs: u64) {
         self.0 += rhs
     }
 }
@@ -152,10 +146,10 @@ impl AddAssign<Self> for ChangeId {
     }
 }
 
-impl std::ops::Add<i64> for ChangeId {
+impl std::ops::Add<u64> for ChangeId {
     type Output = ChangeId;
 
-    fn add(self, rhs: i64) -> Self::Output {
+    fn add(self, rhs: u64) -> Self::Output {
         ChangeId(self.0 + rhs)
     }
 }

--- a/crates/corro-base-types/Cargo.toml
+++ b/crates/corro-base-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "corro-api-types"
+name = "corro-base-types"
 version = "0.1.0-alpha.1"
 edition = "2021"
 description = "common API types for corrosion"
@@ -19,4 +19,4 @@ speedy = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true } 
 tokio = { workspace = true }
-corro-base-types = { path = "../corro-base-types" }
+rangemap = { workspace = true }

--- a/crates/corro-base-types/src/lib.rs
+++ b/crates/corro-base-types/src/lib.rs
@@ -1,0 +1,267 @@
+#![feature(step_trait)]
+
+use std::{
+    fmt,
+    iter::Step,
+    ops::{Add, Sub},
+};
+
+use rangemap::StepLite;
+use rusqlite::{types::FromSql, ToSql};
+use serde::{Deserialize, Serialize};
+use speedy::{Context, Readable, Writable};
+
+#[derive(
+    Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct Version(pub u64);
+
+impl Step for Version {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u64::steps_between(&start.0, &end.0)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::forward_checked(start.0, count).map(Self)
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::backward_checked(start.0, count).map(Self)
+    }
+}
+
+impl StepLite for Version {
+    fn add_one(&self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    fn sub_one(&self) -> Self {
+        Self(self.0 - 1)
+    }
+}
+
+impl ToSql for Version {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for Version {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        u64::column_result(value).map(Self)
+    }
+}
+
+impl Add<u64> for Version {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0.add(rhs))
+    }
+}
+
+impl Sub<u64> for Version {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0.sub(rhs))
+    }
+}
+
+impl<'a, C> Readable<'a, C> for Version
+where
+    C: Context,
+{
+    fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, <C as Context>::Error> {
+        u64::read_from(reader).map(Self)
+    }
+}
+
+impl<C> Writable<C> for Version
+where
+    C: Context,
+{
+    fn write_to<T: ?Sized + speedy::Writer<C>>(
+        &self,
+        writer: &mut T,
+    ) -> Result<(), <C as Context>::Error> {
+        self.0.write_to(writer)
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(
+    Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct CrsqlDbVersion(pub u64);
+
+impl Step for CrsqlDbVersion {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u64::steps_between(&start.0, &end.0)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::forward_checked(start.0, count).map(Self)
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::backward_checked(start.0, count).map(Self)
+    }
+}
+
+impl StepLite for CrsqlDbVersion {
+    fn add_one(&self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    fn sub_one(&self) -> Self {
+        Self(self.0 - 1)
+    }
+}
+
+impl ToSql for CrsqlDbVersion {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for CrsqlDbVersion {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        u64::column_result(value).map(Self)
+    }
+}
+
+impl Add<u64> for CrsqlDbVersion {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0.add(rhs))
+    }
+}
+
+impl Sub<u64> for CrsqlDbVersion {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0.sub(rhs))
+    }
+}
+
+impl<'a, C> Readable<'a, C> for CrsqlDbVersion
+where
+    C: Context,
+{
+    fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, <C as Context>::Error> {
+        u64::read_from(reader).map(Self)
+    }
+}
+
+impl<C> Writable<C> for CrsqlDbVersion
+where
+    C: Context,
+{
+    fn write_to<T: ?Sized + speedy::Writer<C>>(
+        &self,
+        writer: &mut T,
+    ) -> Result<(), <C as Context>::Error> {
+        self.0.write_to(writer)
+    }
+}
+
+impl fmt::Display for CrsqlDbVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(
+    Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct CrsqlSeq(pub u64);
+
+impl Step for CrsqlSeq {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u64::steps_between(&start.0, &end.0)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::forward_checked(start.0, count).map(Self)
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        u64::backward_checked(start.0, count).map(Self)
+    }
+}
+
+impl StepLite for CrsqlSeq {
+    fn add_one(&self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    fn sub_one(&self) -> Self {
+        Self(self.0 - 1)
+    }
+}
+
+impl ToSql for CrsqlSeq {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl FromSql for CrsqlSeq {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        u64::column_result(value).map(Self)
+    }
+}
+
+impl Add<u64> for CrsqlSeq {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0.add(rhs))
+    }
+}
+
+impl Sub<u64> for CrsqlSeq {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0.sub(rhs))
+    }
+}
+
+impl<'a, C> Readable<'a, C> for CrsqlSeq
+where
+    C: Context,
+{
+    fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, <C as Context>::Error> {
+        u64::read_from(reader).map(Self)
+    }
+}
+
+impl<C> Writable<C> for CrsqlSeq
+where
+    C: Context,
+{
+    fn write_to<T: ?Sized + speedy::Writer<C>>(
+        &self,
+        writer: &mut T,
+    ) -> Result<(), <C as Context>::Error> {
+        self.0.write_to(writer)
+    }
+}
+
+impl fmt::Display for CrsqlSeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2364,7 +2364,8 @@ fn handle_commit(agent: &Agent, conn: &Connection) -> rusqlite::Result<()> {
                     ORDER BY seq ASC
             "#)?;
                 let rows = prepped.query_map([db_version], row_to_change)?;
-                let chunked = ChunkedChanges::new(rows, 0, last_seq, MAX_CHANGES_BYTE_SIZE);
+                let chunked =
+                    ChunkedChanges::new(rows, CrsqlSeq(0), last_seq, MAX_CHANGES_BYTE_SIZE);
                 for changes_seqs in chunked {
                     match changes_seqs {
                         Ok((changes, seqs)) => {

--- a/crates/corro-tpl/src/lib.rs
+++ b/crates/corro-tpl/src/lib.rs
@@ -11,6 +11,7 @@ use compact_str::ToCompactString;
 use corro_client::sub::SubscriptionStream;
 use corro_client::{CorrosionApiClient, QueryEvent};
 use corro_types::api::ColumnName;
+use corro_types::api::RowId;
 use corro_types::api::SqliteParam;
 use corro_types::api::Statement;
 use corro_types::change::SqliteValue;
@@ -107,7 +108,7 @@ impl IntoIterator for QueryResponse {
 #[derive(Clone)]
 struct Row {
     #[allow(dead_code)]
-    id: i64,
+    id: RowId,
     columns: Arc<IndexMap<ColumnName, u16>>,
     cells: Arc<Vec<SqliteValue>>,
 }
@@ -295,7 +296,7 @@ impl QueryResponseIter {
                         match self.columns.as_ref() {
                             Some(columns) => {
                                 return Some(Ok(Row {
-                                    id: rowid.0,
+                                    id: rowid,
                                     columns: columns.clone(),
                                     cells: Arc::new(cells),
                                 }));

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -20,6 +20,7 @@ enquote = { workspace = true }
 fallible-iterator = { workspace = true }
 foca = { workspace = true } 
 futures = { workspace = true }
+hex = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -15,6 +15,7 @@ compact_str = { workspace = true }
 config = { workspace = true }
 consul-client = { version = "0.1.0-alpha.0", path = "../consul-client" }
 corro-api-types = { version = "0.1.0-alpha.1", path = "../corro-api-types" }
+corro-base-types = { version = "0.1.0-alpha.1", path = "../corro-base-types" }
 deadpool = { workspace = true }
 enquote = { workspace = true }
 fallible-iterator = { workspace = true }

--- a/crates/corro-types/src/base.rs
+++ b/crates/corro-types/src/base.rs
@@ -1,0 +1,5 @@
+// can't do newtype until Step is stabilized...
+
+pub type Version = u64;
+pub type CrsqlDbVersion = u64;
+pub type CrsqlSeq = u64;

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -160,7 +160,9 @@ impl Changeset {
     pub fn is_complete(&self) -> bool {
         match self {
             Changeset::Empty { .. } => true,
-            Changeset::Full { seqs, last_seq, .. } => *seqs.start() == 0 && seqs.end() == last_seq,
+            Changeset::Full { seqs, last_seq, .. } => {
+                *seqs.start() == CrsqlSeq(0) && seqs.end() == last_seq
+            }
         }
     }
 

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -24,7 +24,7 @@ where
         Self {
             iter: iter.peekable(),
             changes: vec![],
-            last_pushed_seq: 0,
+            last_pushed_seq: CrsqlSeq(0),
             last_start_seq: start_seq,
             last_seq,
             max_buf_size,
@@ -122,12 +122,15 @@ mod tests {
     #[test]
     fn test_change_chunker() {
         // empty interator
-        let mut chunker = ChunkedChanges::new(vec![].into_iter(), 0, 100, 50);
+        let mut chunker = ChunkedChanges::new(vec![].into_iter(), CrsqlSeq(0), CrsqlSeq(100), 50);
 
-        assert_eq!(chunker.next(), Some(Ok((vec![], 0..=100))));
+        assert_eq!(
+            chunker.next(),
+            Some(Ok((vec![], CrsqlSeq(0)..=CrsqlSeq(100))))
+        );
         assert_eq!(chunker.next(), None);
 
-        let changes: Vec<Change> = (0..100)
+        let changes: Vec<Change> = (CrsqlSeq(0)..CrsqlSeq(100))
             .map(|seq| Change {
                 seq,
                 ..Default::default()
@@ -142,70 +145,50 @@ mod tests {
                 Ok(changes[2].clone()),
             ]
             .into_iter(),
-            0,
-            100,
+            CrsqlSeq(0),
+            CrsqlSeq(100),
             changes[0].estimated_byte_size() + changes[1].estimated_byte_size(),
         );
 
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[0].clone(), changes[1].clone()], 0..=1)))
+            Some(Ok((
+                vec![changes[0].clone(), changes[1].clone()],
+                CrsqlSeq(0)..=CrsqlSeq(1)
+            )))
         );
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[2].clone()], 2..=100)))
+            Some(Ok((vec![changes[2].clone()], CrsqlSeq(2)..=CrsqlSeq(100))))
         );
         assert_eq!(chunker.next(), None);
 
         let mut chunker = ChunkedChanges::new(
             vec![Ok(changes[0].clone()), Ok(changes[1].clone())].into_iter(),
-            0,
-            0,
+            CrsqlSeq(0),
+            CrsqlSeq(0),
             changes[0].estimated_byte_size(),
         );
 
-        assert_eq!(chunker.next(), Some(Ok((vec![changes[0].clone()], 0..=0))));
+        assert_eq!(
+            chunker.next(),
+            Some(Ok((vec![changes[0].clone()], CrsqlSeq(0)..=CrsqlSeq(0))))
+        );
         assert_eq!(chunker.next(), None);
 
         // gaps
         let mut chunker = ChunkedChanges::new(
             vec![Ok(changes[0].clone()), Ok(changes[2].clone())].into_iter(),
-            0,
-            100,
+            CrsqlSeq(0),
+            CrsqlSeq(100),
             changes[0].estimated_byte_size() + changes[2].estimated_byte_size(),
         );
 
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[0].clone(), changes[2].clone()], 0..=100)))
-        );
-
-        assert_eq!(chunker.next(), None);
-
-        // gaps
-        let mut chunker = ChunkedChanges::new(
-            vec![
-                Ok(changes[2].clone()),
-                Ok(changes[4].clone()),
-                Ok(changes[7].clone()),
-                Ok(changes[8].clone()),
-            ]
-            .into_iter(),
-            0,
-            100,
-            100000, // just send them all!
-        );
-
-        assert_eq!(
-            chunker.next(),
             Some(Ok((
-                vec![
-                    changes[2].clone(),
-                    changes[4].clone(),
-                    changes[7].clone(),
-                    changes[8].clone()
-                ],
-                0..=100
+                vec![changes[0].clone(), changes[2].clone()],
+                CrsqlSeq(0)..=CrsqlSeq(100)
             )))
         );
 
@@ -220,19 +203,54 @@ mod tests {
                 Ok(changes[8].clone()),
             ]
             .into_iter(),
-            0,
-            10,
+            CrsqlSeq(0),
+            CrsqlSeq(100),
+            100000, // just send them all!
+        );
+
+        assert_eq!(
+            chunker.next(),
+            Some(Ok((
+                vec![
+                    changes[2].clone(),
+                    changes[4].clone(),
+                    changes[7].clone(),
+                    changes[8].clone()
+                ],
+                CrsqlSeq(0)..=CrsqlSeq(100)
+            )))
+        );
+
+        assert_eq!(chunker.next(), None);
+
+        // gaps
+        let mut chunker = ChunkedChanges::new(
+            vec![
+                Ok(changes[2].clone()),
+                Ok(changes[4].clone()),
+                Ok(changes[7].clone()),
+                Ok(changes[8].clone()),
+            ]
+            .into_iter(),
+            CrsqlSeq(0),
+            CrsqlSeq(10),
             changes[2].estimated_byte_size() + changes[4].estimated_byte_size(),
         );
 
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[2].clone(), changes[4].clone(),], 0..=4)))
+            Some(Ok((
+                vec![changes[2].clone(), changes[4].clone(),],
+                CrsqlSeq(0)..=CrsqlSeq(4)
+            )))
         );
 
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[7].clone(), changes[8].clone(),], 5..=10)))
+            Some(Ok((
+                vec![changes[7].clone(), changes[8].clone(),],
+                CrsqlSeq(5)..=CrsqlSeq(10)
+            )))
         );
 
         assert_eq!(chunker.next(), None);

--- a/crates/corro-types/src/lib.rs
+++ b/crates/corro-types/src/lib.rs
@@ -2,7 +2,6 @@
 pub mod actor;
 pub mod agent;
 pub mod api;
-pub mod base;
 pub mod broadcast;
 pub mod change;
 pub mod config;
@@ -12,3 +11,4 @@ pub mod schema;
 pub mod sqlite;
 pub mod sync;
 pub mod tls;
+pub use corro_base_types as base;

--- a/crates/corro-types/src/lib.rs
+++ b/crates/corro-types/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod actor;
 pub mod agent;
 pub mod api;
+pub mod base;
 pub mod broadcast;
 pub mod change;
 pub mod config;

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -484,7 +484,7 @@ pub struct Matcher {
     pub parsed: ParsedSelect,
     pub evt_tx: mpsc::Sender<QueryEvent>,
     pub col_names: Vec<ColumnName>,
-    pub last_rowid: i64,
+    pub last_rowid: u64,
     conn: Connection,
     base_path: Utf8PathBuf,
     cancel: CancellationToken,

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -161,7 +161,7 @@ impl SubsManager {
 
     pub fn match_changes(&self, changes: &[Change], db_version: CrsqlDbVersion) {
         trace!(
-            db_version,
+            %db_version,
             "trying to match changes to subscribers, len: {}",
             changes.len()
         );
@@ -177,7 +177,7 @@ impl SubsManager {
         };
 
         for (id, handle) in handles.iter() {
-            trace!(sub_id = %id, db_version, "attempting to match changes to a subscription");
+            trace!(sub_id = %id, %db_version, "attempting to match changes to a subscription");
             let mut candidates = MatchCandidates::new();
             let mut match_count = 0;
             for change in changes.iter().map(MatchableChange::from) {
@@ -191,7 +191,7 @@ impl SubsManager {
                 counter!("corro.subs.changes.matched.count", pks.len() as u64, "sql_hash" => handle.inner.hash.clone(), "table" => table.to_string());
             }
 
-            trace!(sub_id = %id, db_version, "found {match_count} candidates");
+            trace!(sub_id = %id, %db_version, "found {match_count} candidates");
 
             if let Err(e) = handle.inner.changes_tx.try_send((candidates, db_version)) {
                 error!(sub_id = %id, "could not send change candidates to subscription handler: {e}");
@@ -2558,7 +2558,7 @@ mod tests {
             }
 
             println!("processing change...");
-            filter_changes_from_db(&matcher, &conn, None, 2).unwrap();
+            filter_changes_from_db(&matcher, &conn, None, CrsqlDbVersion(2)).unwrap();
             println!("processed changes");
 
             let cells = vec![SqliteValue::Text("{\"targets\":[\"127.0.0.1:1\"],\"labels\":{\"__metrics_path__\":\"/1\",\"app\":null,\"vm_account_id\":null,\"instance\":\"m-3\"}}".into())];
@@ -2579,7 +2579,7 @@ mod tests {
                 tx.commit().unwrap();
             }
 
-            filter_changes_from_db(&matcher, &conn, None, 3).unwrap();
+            filter_changes_from_db(&matcher, &conn, None, CrsqlDbVersion(3)).unwrap();
 
             let cells = vec![SqliteValue::Text("{\"targets\":[\"127.0.0.1:1\"],\"labels\":{\"__metrics_path__\":\"/1\",\"app\":null,\"vm_account_id\":null,\"instance\":\"m-1\"}}".into())];
 
@@ -2602,7 +2602,7 @@ mod tests {
                 tx.commit().unwrap();
             }
 
-            filter_changes_from_db(&matcher, &conn, None, 4).unwrap();
+            filter_changes_from_db(&matcher, &conn, None, CrsqlDbVersion(4)).unwrap();
 
             let cells = vec![SqliteValue::Text("{\"targets\":[\"127.0.0.2:1\"],\"labels\":{\"__metrics_path__\":\"/1\",\"app\":null,\"vm_account_id\":null,\"instance\":\"m-3\"}}".into())];
 
@@ -2661,7 +2661,7 @@ mod tests {
                 tx.commit().unwrap();
             }
 
-            filter_changes_from_db(&matcher, &conn, None, 5).unwrap();
+            filter_changes_from_db(&matcher, &conn, None, CrsqlDbVersion(5)).unwrap();
 
             let start = Instant::now();
             for _ in range {

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -104,7 +104,7 @@ fn init_cr_conn(conn: &mut Connection) -> Result<(), rusqlite::Error> {
     Ok(())
 }
 
-pub(crate) fn setup_conn(conn: &mut Connection) -> Result<(), rusqlite::Error> {
+pub fn setup_conn(conn: &mut Connection) -> Result<(), rusqlite::Error> {
     // WAL journal mode and synchronous NORMAL for best performance / crash resilience compromise
     conn.execute_batch(
         r#"

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -236,7 +236,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
                 };
 
                 let site_id: [u8; 16] = {
-                    let conn = Connection::open(&db_path)?;
+                    let conn = Connection::open(db_path)?;
                     conn.query_row(
                         "SELECT site_id FROM crsql_site_id WHERE ordinal = 0;",
                         [],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchain.channel = "stable"
+toolchain.channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,2 @@
-toolchain.channel = "nightly"
+[toolchain]
+channel = "nightly-2023-12-03"


### PR DESCRIPTION
This should prevent any confusing when passing around similar integer types.

It will also create hard errors when loading non-u64 from SQLite when they should always be non-negative.

This change requires moving to nightly in order to implement the `std::iter::Step` trait for use to iterate on newtypes' ranges.

It might be possible to feature-gate it, but I haven't bothered for now.