### PR TITLE
Create index to store empty versions faster

### DIFF
--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -2735,7 +2735,7 @@ async fn process_completed_empties(
     for (actor_id, empties) in empties {
         let v = empties.into_iter().collect::<Vec<_>>();
 
-        for ranges in v.chunks(20) {
+        for ranges in v.chunks(40) {
             let mut conn = agent.pool().write_low().await?;
             let res = block_in_place(|| {
                 let tx = conn.immediate_transaction()?;
@@ -2753,7 +2753,7 @@ async fn process_completed_empties(
 
                 tx.commit()?;
 
-                info!(%actor_id, "affected {affected} rows while storing cleared versions in {:?}", start.elapsed());
+                debug!(%actor_id, "affected {affected} rows while storing cleared versions in {:?}", start.elapsed());
 
                 Ok::<_, eyre::Report>(())
             });
@@ -2761,9 +2761,6 @@ async fn process_completed_empties(
             if let Err(e) = res {
                 error!("could not insert empty changesets: {e}");
             }
-
-            // let the pool breath a little
-            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -2510,7 +2510,7 @@ async fn write_empties_loop(
                     break;
                 }
             },
-            _ = &mut next_empties_check => {
+            _ = &mut next_empties_check, if agent.bookie().is_ready() => {
                 next_empties_check.as_mut().reset(tokio::time::Instant::now() + CHECK_EMPTIES_TO_INSERT_AFTER);
                 if empties.is_empty() {
                     continue;

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -205,10 +205,10 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
                         }
                     }
 
-                    let mut bookiew = bookie.write("init actor bookkeeping").await;
-                    let booked = bookiew.for_actor(actor_id);
-                    let mut bookedw = booked.write("insert init").await;
-                    **bookedw = bv;
+                    bookie
+                        .write("replace_actor")
+                        .await
+                        .replace_actor(actor_id, bv);
                 }
 
                 Ok::<_, eyre::Report>(())

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -3650,7 +3650,7 @@ pub mod tests {
             let tx = conn.transaction()?;
             assert_eq!(
                 store_empty_changeset(&tx, actor_id, Version(1)..=Version(2))?,
-                1
+                2
             );
             tx.commit()?;
         }
@@ -3733,7 +3733,7 @@ pub mod tests {
             let tx = conn.transaction()?;
             assert_eq!(
                 store_empty_changeset(&tx, actor_id, Version(3)..=Version(6))?,
-                1
+                4
             );
             tx.commit()?;
         }
@@ -3771,7 +3771,7 @@ pub mod tests {
             let tx = conn.transaction()?;
             assert_eq!(
                 store_empty_changeset(&tx, actor_id, Version(1)..=Version(10))?,
-                1
+                2
             );
             tx.commit()?;
         }
@@ -3813,7 +3813,7 @@ pub mod tests {
             let tx = conn.transaction()?;
             assert_eq!(
                 store_empty_changeset(&tx, actor_id, Version(1)..=Version(11))?,
-                1
+                2
             );
             tx.commit()?;
         }
@@ -3919,7 +3919,7 @@ pub mod tests {
             let tx = conn.transaction()?;
             assert_eq!(
                 store_empty_changeset(&tx, actor_id, Version(12)..=Version(14))?,
-                1
+                5
             );
             tx.commit()?;
         }
@@ -3961,7 +3961,7 @@ pub mod tests {
             let tx = conn.transaction()?;
             assert_eq!(
                 store_empty_changeset(&tx, actor_id, Version(15)..=Version(15))?,
-                1
+                4
             );
             tx.commit()?;
         }

--- a/crates/corro-agent/src/agent.rs
+++ b/crates/corro-agent/src/agent.rs
@@ -146,9 +146,11 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
 
     let bk = {
         debug!("getting read-only conn for pull bookkeeping rows");
-        let conn = pool.write_priority().await?;
+        let mut conn = pool.write_priority().await?;
 
         debug!("getting bookkept rows");
+
+        let mut cleared_rows: BTreeMap<ActorId, usize> = BTreeMap::new();
 
         let bk = {
             let actor_ids: Vec<ActorId> = conn
@@ -161,6 +163,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
                 async move {
                     tokio::spawn(async move {
                         let mut bv = BookedVersions::default();
+                        let mut cleared = 0;
                         let conn = pool.read().await?;
 
                         block_in_place(|| {
@@ -187,14 +190,17 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
                                                         ts: row.get(4)?,
                                                     })
                                                 }
-                                                None => KnownDbVersion::Cleared,
+                                                None => {
+                                                    cleared += 1;
+                                                    KnownDbVersion::Cleared
+                                                }
                                             },
                                         );
                                     }
                                 }
                             }
 
-                            Ok::<_, eyre::Report>((actor_id, bv))
+                            Ok::<_, eyre::Report>((actor_id, bv, cleared))
                         })
                     })
                     .await?
@@ -204,8 +210,9 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
 
             let mut bk = HashMap::<ActorId, BookedVersions>::new();
 
-            while let Some((actor_id, bv)) = TryStreamExt::try_next(&mut buf).await? {
+            while let Some((actor_id, bv, cleared)) = TryStreamExt::try_next(&mut buf).await? {
                 bk.insert(actor_id, bv);
+                cleared_rows.insert(actor_id, cleared);
             }
 
             let mut partials: HashMap<
@@ -271,22 +278,25 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
             bk
         };
 
-        // for (actor_id, booked) in bk.iter() {
-        //     if let Some(clear_count) = cleared_rows.get(actor_id).copied() {
-        //         if clear_count > booked.cleared.len() {
-        //             warn!(%actor_id, "cleared bookkept rows count ({clear_count}) in DB was bigger than in-memory entries count ({}), compacting...", booked.cleared.len());
-        //             let tx = conn.immediate_transaction()?;
-        //             let deleted = tx.execute("DELETE FROM __corro_bookkeeping WHERE actor_id = ? AND end_version IS NOT NULL", [actor_id])?;
-        //             info!("deleted {deleted} rows that had an end_version");
-        //             let mut inserted = 0;
-        //             for range in booked.cleared.iter() {
-        //                 inserted += tx.execute("INSERT INTO __corro_bookkeeping (actor_id, start_version, end_version) VALUES (?, ?, ?)", params![actor_id, range.start(), range.end()])?;
-        //             }
-        //             info!("inserted {inserted} cleared version rows");
-        //             tx.commit()?;
-        //         }
-        //     }
-        // }
+        for (actor_id, booked) in bk.iter() {
+            if let Some(clear_count) = cleared_rows.get(actor_id).copied() {
+                if clear_count > booked.cleared.len() {
+                    warn!(%actor_id, "cleared bookkept rows count ({clear_count}) in DB was bigger than in-memory entries count ({}), compacting...", booked.cleared.len());
+                    let tx = conn.immediate_transaction()?;
+                    let start = Instant::now();
+                    let deleted = tx.execute("DELETE FROM __corro_bookkeeping WHERE actor_id = ? AND end_version IS NOT NULL", [actor_id])?;
+                    info!(%actor_id, "deleted {deleted} rows that had an end_version in {:?}", start.elapsed());
+                    let mut inserted = 0;
+
+                    let start = Instant::now();
+                    for range in booked.cleared.iter() {
+                        inserted += tx.prepare_cached("INSERT INTO __corro_bookkeeping (actor_id, start_version, end_version) VALUES (?, ?, ?)")?.execute(params![actor_id, range.start(), range.end()])?;
+                    }
+                    info!(%actor_id, "inserted {inserted} cleared version rows in {:?}", start.elapsed());
+                    tx.commit()?;
+                }
+            }
+        }
 
         bk
     };

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -1128,7 +1128,7 @@ pub async fn parallel_sync(
                 if needs.is_empty() {
                     continue;
                 }
-                for (actor_id, need) in needs.drain(0..cmp::min(10, needs.len())) {
+                for (actor_id, need) in needs.drain(needs.len().saturating_sub(10)..) {
                     let actual_needs = match need {
                         SyncNeedV1::Full { versions } => {
                             let range = req_full.entry(actor_id).or_default();

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -1231,7 +1231,7 @@ impl BookieInner {
     }
 
     fn check_notify_ready(&self) {
-        if dbg!(self.ready_count == self.map.len()) {
+        if self.ready_count == self.map.len() {
             self.is_ready.store(true, Ordering::Release);
             self.ready_notify.notify_waiters();
         }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -994,7 +994,7 @@ impl BookedVersions {
         }
 
         let mut prepped = conn.prepare_cached(
-            "SELECT version, start_seq, end_seq, last_seq, ts FROM __corro_bookkeeping WHERE site_id = ?",
+            "SELECT version, start_seq, end_seq, last_seq, ts FROM __corro_seq_bookkeeping WHERE site_id = ?",
         )?;
         let mut rows = prepped.query([actor_id])?;
 
@@ -1203,7 +1203,7 @@ impl BookieInner {
                         .insert(Booked(Arc::new(CountedTokioRwLock::new(
                             self.registry.clone(),
                             BookedVersions {
-                                is_ready: true,
+                                is_ready: true, // set this to true, it's a new actor and we don't have anything on them
                                 ..Default::default()
                             },
                         ))))
@@ -1235,10 +1235,6 @@ impl BookieInner {
             self.is_ready.store(true, Ordering::Release);
             self.ready_notify.notify_waiters();
         }
-    }
-
-    pub fn is_ready(&self) -> bool {
-        self.ready_count == self.map.len()
     }
 }
 

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -224,6 +224,7 @@ pub fn migrate(conn: &mut Connection) -> rusqlite::Result<()> {
         Box::new(v0_2_0_migration as fn(&Transaction) -> rusqlite::Result<()>),
         Box::new(v0_2_0_1_migration as fn(&Transaction) -> rusqlite::Result<()>),
         Box::new(v0_2_0_2_migration as fn(&Transaction) -> rusqlite::Result<()>),
+        Box::new(v0_2_0_3_migration as fn(&Transaction) -> rusqlite::Result<()>),
     ];
 
     crate::sqlite::migrate(conn, migrations)
@@ -345,6 +346,16 @@ fn v0_2_0_2_migration(tx: &Transaction) -> rusqlite::Result<()> {
         ALTER TABLE __corro_members ADD COLUMN rtt_min INTEGER;
         -- add updated_at
         ALTER TABLE __corro_members ADD COLUMN updated_at DATETIME NOT NULL DEFAULT 0;
+    "#,
+    )
+}
+
+fn v0_2_0_3_migration(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        r#"
+        DROP TABLE __corro_subs;
+
+        CREATE INDEX __corro_bookkeeping_actor_id_start_end_version ON __corro_bookkeeping (actor_id, start_version, end_version);
     "#,
     )
 }

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -72,6 +72,8 @@ pub type SyncRequestV1 = Vec<(ActorId, Vec<SyncNeedV1>)>;
 pub enum SyncRejectionV1 {
     #[error("max concurrency reached")]
     MaxConcurrencyReached,
+    #[error("not ready")]
+    NotReady,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Readable, Writable, Serialize, Deserialize)]

--- a/crates/sqlite-pool/src/lib.rs
+++ b/crates/sqlite-pool/src/lib.rs
@@ -102,8 +102,9 @@ where
         let recycle_count = self.recycle_count.fetch_add(1, Ordering::Relaxed);
         let n: usize = block_in_place(|| {
             conn.conn()
-                .query_row("SELECT $1", [recycle_count], |row| row.get(0))
-                .map_err(|e| RecycleError::Message(format!("{}", e)))
+                .prepare_cached("SELECT $1")?
+                .query_row([recycle_count], |row| row.get(0))
+                .map_err(RecycleError::from)
         })?;
         if n == recycle_count {
             Ok(())


### PR DESCRIPTION
This index helps by changing the query plan from a `SEARCH` to a `SEARCH ... USING COVERING INDEX` which should be a lot faster.