### PR TITLE
Add nix flake build environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1701671019,
+        "narHash": "sha256-ctG01Syj/7TrfV4arc3qyN4a3mAvgXbivYrdXKqdL8U=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "5e6667eda7fb055c0a8388172372fb89e5b33e05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701436327,
+        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701447636,
+        "narHash": "sha256-WaCcxLNAqo/FAK0QtYqweKCUVTGcbKpFIHClc+k2YlI=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "e402c494b7c7d94a37c6d789a216187aaf9ccd3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "corrosion2-dev";
+
+  ## Specify the flake environment inputs
+  inputs = {
+    ## The fenix flake gives us access to nightly rust toolchains
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  ## Specify flake environment outputs
+  ##
+  ## The flake-utils harness is used to make supporting different
+  ## architectures (x86_64-linux, aarch64-darwin, etc) easier.
+  outputs = { flake-utils, nixpkgs, fenix, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        rust-latest = fenix.packages."${system}".latest;
+      in
+        {
+          ## Here we declare the only flake output to be a nix build
+          ## of the corrosion crate tree
+          packages.default =
+            pkgs.rustPlatform.buildRustPackage {
+              name = "corrosion2";
+              src = ./.;
+
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+
+                # Needed for vendored dependencies
+                allowBuiltinFetchGit = true;
+              };
+
+              ## Build environment dependencies
+              nativeBuildInputs = [
+                pkgs.pkg-config
+                pkgs.mold
+                rust-latest.toolchain
+              ];
+
+              ## Dependencies for the linked binary
+              buildInputs = with pkgs; [
+                openssl
+                sqlite
+                libgit2
+              ];
+            };
+        });
+}


### PR DESCRIPTION

- pull in a pinned version of the rust nightly toolchain (2023-12-03)
- run `nix flake update` to update dependencies
- run `nix build` to build the corrosion package output
- run `nix develop` to enter a bash shell with all required dependencies in scope