### PR TITLE
flake: add mdbook dependencies target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,14 @@
         rust-latest = fenix.packages."${system}".latest;
       in
         {
+          packages.mdbook-shell = pkgs.mkShell {
+            buildInputs = with pkgs; [ mdbook mdbook-linkcheck mdbook-admonish ];
+
+            shellHook = ''
+              mdbook serve
+            '';
+          };
+          
           ## Here we declare the only flake output to be a nix build
           ## of the corrosion crate tree
           packages.default =


### PR DESCRIPTION
You can serve the docs book locally with: nix develop .#mdbook-shell