### PR TITLE
restore: `site_id` can't be null on clock tables anymore

### DIFF
--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -270,7 +270,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
 
                     for table in tables {
                         let n = conn.execute(
-                            &format!("UPDATE \"{table}\" SET site_id = NULL WHERE site_id = ?"),
+                            &format!("UPDATE \"{table}\" SET site_id = 0 WHERE site_id = ?"),
                             [ordinal],
                         )?;
                         info!("Updated {n} rows in {table}");


### PR DESCRIPTION
Restoring a DB with the current site_id was broken because of a missing change in the SQL to update clock tables after restore.