### PR TITLE
Separate Bookie instantiation to listen on public API faster

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use corro_types::{
     actor::{Actor, ActorId},
-    agent::{Agent, SplitPool},
+    agent::{Agent, Bookie, SplitPool},
     broadcast::{BroadcastV1, ChangeSource, ChangeV1, FocaInput, UniPayload},
     sync::generate_sync,
 };
@@ -37,12 +37,14 @@ use tripwire::{Outcome, PreemptibleFutureExt, TimeoutFutureExt, Tripwire};
 /// connections, streams, and their respective payloads.
 pub fn spawn_gossipserver_handler(
     agent: &Agent,
+    bookie: &Bookie,
     tripwire: &Tripwire,
     gossip_server_endpoint: quinn::Endpoint,
     process_uni_tx: Sender<UniPayload>,
 ) {
     spawn_counted({
         let agent = agent.clone();
+        let bookie = bookie.clone();
         let mut tripwire = tripwire.clone();
         async move {
             loop {
@@ -59,6 +61,7 @@ pub fn spawn_gossipserver_handler(
                 // Spawn incoming connection handlers
                 spawn_incoming_connection_handlers(
                     &agent,
+                    &bookie,
                     &tripwire,
                     process_uni_tx.clone(),
                     connecting,
@@ -80,12 +83,14 @@ pub fn spawn_gossipserver_handler(
 /// incoming connection.  This function spawns many futures!
 pub fn spawn_incoming_connection_handlers(
     agent: &Agent,
+    bookie: &Bookie,
     tripwire: &Tripwire,
     process_uni_tx: Sender<UniPayload>,
     connecting: quinn::Connecting,
 ) {
     let process_uni_tx = process_uni_tx.clone();
     let agent = agent.clone();
+    let bookie = bookie.clone();
     let tripwire = tripwire.clone();
     tokio::spawn(async move {
         let remote_addr = connecting.remote_address();
@@ -107,7 +112,7 @@ pub fn spawn_incoming_connection_handlers(
         // Spawn handler tasks for this connection
         spawn_foca_handler(&agent, &tripwire, &conn);
         uni::spawn_unipayload_handler(&tripwire, &conn, process_uni_tx);
-        bi::spawn_bipayload_handler(&agent, &tripwire, &conn);
+        bi::spawn_bipayload_handler(&agent, &bookie, &tripwire, &conn);
     });
 }
 
@@ -167,7 +172,7 @@ pub fn spawn_foca_handler(agent: &Agent, tripwire: &Tripwire, conn: &quinn::Conn
 }
 
 // DOCME: provide function context
-pub fn spawn_backoff_handler(agent: &Agent, gossip_addr: SocketAddr) {
+pub fn spawn_swim_announcer(agent: &Agent, gossip_addr: SocketAddr) {
     tokio::spawn({
         let agent = agent.clone();
         async move {
@@ -331,8 +336,7 @@ pub async fn handle_notifications(
     }
 }
 
-// DOCME: provide function context
-pub async fn handle_db_cleanup(pool: SplitPool) -> eyre::Result<()> {
+async fn db_cleanup(pool: &SplitPool) -> eyre::Result<()> {
     debug!("handling db_cleanup (WAL truncation)");
     let conn = pool.write_low().await?;
     block_in_place(move || {
@@ -356,9 +360,25 @@ pub async fn handle_db_cleanup(pool: SplitPool) -> eyre::Result<()> {
     Ok(())
 }
 
+// Every now and then, we need to truncate the WAL.
+// It can get enormous when under write pressure.
+pub async fn spawn_handle_db_cleanup(pool: SplitPool) {
+    tokio::spawn(async move {
+        let mut db_cleanup_interval = tokio::time::interval(Duration::from_secs(60 * 15));
+        loop {
+            db_cleanup_interval.tick().await;
+
+            if let Err(e) = db_cleanup(&pool).await {
+                error!("could not truncate db: {e}");
+            }
+        }
+    });
+}
+
 // DOCME: provide function context
 pub async fn handle_changes(
     agent: Agent,
+    bookie: Bookie,
     mut rx_changes: Receiver<(ChangeV1, ChangeSource)>,
     mut tripwire: Tripwire,
 ) {
@@ -393,7 +413,9 @@ pub async fn handle_changes(
 
         // drain and process current changes!
         #[allow(clippy::drain_collect)]
-        if let Err(e) = util::process_multiple_changes(&agent, buf.drain(..).collect()).await {
+        if let Err(e) =
+            util::process_multiple_changes(&agent, &bookie, buf.drain(..).collect()).await
+        {
             error!("could not process multiple changes: {e}");
         }
 
@@ -412,7 +434,9 @@ pub async fn handle_changes(
         if count >= MIN_CHANGES_CHUNK {
             // drain and process current changes!
             #[allow(clippy::drain_collect)]
-            if let Err(e) = util::process_multiple_changes(&agent, buf.drain(..).collect()).await {
+            if let Err(e) =
+                util::process_multiple_changes(&agent, &bookie, buf.drain(..).collect()).await
+            {
                 error!("could not process last multiple changes: {e}");
             }
 
@@ -422,15 +446,19 @@ pub async fn handle_changes(
     }
 
     // process the last changes we got!
-    if let Err(e) = util::process_multiple_changes(&agent, buf).await {
+    if let Err(e) = util::process_multiple_changes(&agent, &bookie, buf).await {
         error!("could not process multiple changes: {e}");
     }
 }
 
 // DOCME: add context
 #[tracing::instrument(skip_all, err, level = "debug")]
-pub async fn handle_sync(agent: &Agent, transport: &Transport) -> Result<(), SyncClientError> {
-    let sync_state = generate_sync(agent.bookie(), agent.actor_id()).await;
+pub async fn handle_sync(
+    agent: &Agent,
+    bookie: &Bookie,
+    transport: &Transport,
+) -> Result<(), SyncClientError> {
+    let sync_state = generate_sync(bookie, agent.actor_id()).await;
 
     for (actor_id, needed) in sync_state.need.iter() {
         gauge!("corro.sync.client.needed", needed.len() as f64, "actor_id" => actor_id.to_string());

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -362,7 +362,7 @@ async fn db_cleanup(pool: &SplitPool) -> eyre::Result<()> {
 
 // Every now and then, we need to truncate the WAL.
 // It can get enormous when under write pressure.
-pub async fn spawn_handle_db_cleanup(pool: SplitPool) {
+pub fn spawn_handle_db_cleanup(pool: SplitPool) {
     tokio::spawn(async move {
         let mut db_cleanup_interval = tokio::time::interval(Duration::from_secs(60 * 15));
         loop {

--- a/crates/corro-agent/src/agent/metrics.rs
+++ b/crates/corro-agent/src/agent/metrics.rs
@@ -46,6 +46,7 @@ pub fn collect_metrics(agent: &Agent, transport: &Transport) {
         }
     }
 
+    // TODO: collect from bookie?
     match conn
         .prepare_cached("SELECT actor_id, (select count(site_id) FROM __corro_buffered_changes WHERE site_id = actor_id) FROM __corro_members")
         .and_then(|mut prepped| {

--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -4,7 +4,7 @@
 //! 2. bar
 //! 3. spawn `super::other_module`
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::{
     agent::{
@@ -52,7 +52,7 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<Bookie> {
         gossip_server_endpoint,
         transport,
         api_listener,
-        mut tripwire,
+        tripwire,
         lock_registry,
         rx_bcast,
         rx_apply,
@@ -142,7 +142,7 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<Bookie> {
 
     spawn_handle_db_cleanup(agent.pool().clone());
 
-    let mut bookie = Bookie::new_with_registry(Default::default(), lock_registry);
+    let bookie = Bookie::new_with_registry(Default::default(), lock_registry);
     {
         let mut w = bookie.write("init").await;
         w.insert(agent.actor_id(), agent.booked().clone());

--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -7,53 +7,53 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::{
-    agent::{handlers, metrics, setup, uni, util, AgentOptions},
+    agent::{
+        handlers::{self, spawn_handle_db_cleanup},
+        metrics, setup, uni, util, AgentOptions,
+    },
     api::public::pubsub::{
         process_sub_channel, MatcherBroadcastCache, SharedMatcherBroadcastCache,
     },
     broadcast::runtime_loop,
 };
 use corro_types::{
-    actor::Actor,
-    agent::Agent,
+    actor::{Actor, ActorId},
+    agent::{Agent, BookedVersions, Bookie},
+    base::CrsqlSeq,
     broadcast::BroadcastV1,
     config::Config,
     pubsub::{Matcher, SubsManager},
 };
 
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt, TryStreamExt};
 use spawn::spawn_counted;
-use tokio::sync::{mpsc::channel, RwLock as TokioRwLock};
-use tracing::{debug, error, info};
-use tripwire::{PreemptibleFutureExt, Tripwire};
+use tokio::{
+    sync::{mpsc::channel, RwLock as TokioRwLock},
+    task::block_in_place,
+};
+use tracing::{error, info};
+use tripwire::Tripwire;
 
 /// Start a new agent with an existing configuration
 ///
 /// First initialise `AgentOptions` state via `setup()`, then spawn a
 /// new task that runs the main agent state machine
-pub async fn start_with_config(conf: Config, tripwire: Tripwire) -> eyre::Result<Agent> {
+pub async fn start_with_config(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Bookie)> {
     let (agent, opts) = setup(conf, tripwire.clone()).await?;
 
-    tokio::spawn({
-        let agent = agent.clone();
-        async move {
-            match run(agent, opts).await {
-                Ok(_) => info!("corrosion agent run is done"),
-                Err(e) => error!("running corrosion agent failed: {e}"),
-            }
-        }
-    });
+    let bookie = run(agent.clone(), opts).await?;
 
-    Ok(agent)
+    Ok((agent, bookie))
 }
 
-async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
+async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<Bookie> {
     let AgentOptions {
         actor_id,
         gossip_server_endpoint,
         transport,
         api_listener,
         mut tripwire,
+        lock_registry,
         rx_bcast,
         rx_apply,
         rx_empty,
@@ -106,18 +106,7 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     //// Update member connection RTTs
     handlers::spawn_rtt_handler(&agent, rtt_rx);
 
-    //// Start async uni-broadcast message decoder
-    uni::spawn_unipayload_message_decoder(&agent, process_uni_rx, bcast_msg_tx);
-
-    //// Start an incoming (corrosion) connection handler.  This
-    //// future tree spawns additional message type sub-handlers
-    handlers::spawn_gossipserver_handler(&agent, &tripwire, gossip_server_endpoint, process_uni_tx);
-
-    info!("Starting peer API on udp/{gossip_addr} (QUIC)");
-
-    handlers::spawn_backoff_handler(&agent, gossip_addr);
-
-    tokio::spawn(util::clear_overwritten_versions(agent.clone()));
+    handlers::spawn_swim_announcer(&agent, gossip_addr);
 
     // Load existing cluster members into the SWIM runtime
     util::initialise_foca(&agent).await;
@@ -132,12 +121,6 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     )
     .await?;
 
-    spawn_counted(handlers::handle_changes(
-        agent.clone(),
-        rx_changes,
-        tripwire.clone(),
-    ));
-
     spawn_counted(util::write_empties_loop(
         agent.clone(),
         rx_empty,
@@ -145,11 +128,6 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     ));
 
     tokio::spawn(util::clear_buffered_meta_loop(agent.clone(), rx_clear_buf));
-
-    spawn_counted(
-        util::sync_loop(agent.clone(), transport.clone(), rx_apply, tripwire.clone())
-            .inspect(|_| info!("corrosion agent sync loop is done")),
-    );
 
     tokio::spawn(metrics::metrics_loop(agent.clone(), transport.clone()));
     tokio::spawn(handlers::handle_gossip_to_send(
@@ -162,22 +140,99 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<()> {
     ));
     tokio::spawn(handlers::handle_broadcasts(agent.clone(), bcast_rx));
 
-    let mut db_cleanup_interval = tokio::time::interval(Duration::from_secs(60 * 15));
+    spawn_handle_db_cleanup(agent.pool().clone());
 
-    loop {
-        tokio::select! {
-            biased;
-            _ = db_cleanup_interval.tick() => {
-                tokio::spawn(handlers::handle_db_cleanup(agent.pool().clone()).preemptible(tripwire.clone()));
-            },
-            _ = &mut tripwire => {
-                debug!("tripped corrosion");
-                break;
+    let mut bookie = Bookie::new_with_registry(Default::default(), lock_registry);
+    {
+        let mut w = bookie.write("init").await;
+        w.insert(agent.actor_id(), agent.booked().clone());
+    }
+    {
+        let conn = agent.pool().read().await?;
+        let actor_ids: Vec<ActorId> = conn
+            .prepare("SELECT DISTINCT actor_id FROM __corro_bookkeeping")?
+            .query_map([], |row| row.get(0))
+            .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+        let pool = agent.pool();
+
+        let mut buf = futures::stream::iter(
+            actor_ids
+                .into_iter()
+                // don't re-process the current actor!
+                .filter(|other_actor_id| *other_actor_id != agent.actor_id())
+                .map(|actor_id| {
+                    let pool = pool.clone();
+                    async move {
+                        tokio::spawn(async move {
+                            let conn = pool.read().await?;
+
+                            block_in_place(|| BookedVersions::from_conn(&conn, actor_id))
+                                .map(|bv| (actor_id, bv))
+                                .map_err(eyre::Report::from)
+                        })
+                        .await?
+                    }
+                }),
+        )
+        .buffer_unordered(8);
+
+        while let Some((actor_id, bv)) = TryStreamExt::try_next(&mut buf).await? {
+            for (version, partial) in bv.partials.iter() {
+                let gaps_count = partial.seqs.gaps(&(CrsqlSeq(0)..=partial.last_seq)).count();
+
+                if gaps_count == 0 {
+                    info!(%actor_id, %version, "found fully buffered, unapplied, changes! scheduling apply");
+                    let _ = agent.tx_apply().send((actor_id, *version)).await;
+                }
             }
+
+            bookie
+                .write("replace_actor")
+                .await
+                .replace_actor(actor_id, bv);
         }
     }
 
-    Ok(())
+    spawn_counted(
+        util::sync_loop(
+            agent.clone(),
+            bookie.clone(),
+            transport.clone(),
+            rx_apply,
+            tripwire.clone(),
+        )
+        .inspect(|_| info!("corrosion agent sync loop is done")),
+    );
+
+    info!("Starting peer API on udp/{gossip_addr} (QUIC)");
+
+    //// Start an incoming (corrosion) connection handler.  This
+    //// future tree spawns additional message type sub-handlers
+    handlers::spawn_gossipserver_handler(
+        &agent,
+        &bookie,
+        &tripwire,
+        gossip_server_endpoint,
+        process_uni_tx,
+    );
+
+    //// Start async uni-broadcast message decoder
+    uni::spawn_unipayload_message_decoder(&agent, &bookie, process_uni_rx, bcast_msg_tx);
+
+    spawn_counted(handlers::handle_changes(
+        agent.clone(),
+        bookie.clone(),
+        rx_changes,
+        tripwire.clone(),
+    ));
+
+    tokio::spawn(util::clear_overwritten_versions(
+        agent.clone(),
+        bookie.clone(),
+    ));
+
+    Ok(bookie)
 }
 
 /// Initialise subscription state and tasks

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -2,17 +2,9 @@
 
 // External crates
 use arc_swap::ArcSwap;
-use futures::lock;
 use parking_lot::RwLock;
-use rangemap::RangeInclusiveSet;
-use rusqlite::{params, Connection};
-use std::{
-    collections::{BTreeMap, HashMap},
-    net::SocketAddr,
-    ops::RangeInclusive,
-    sync::Arc,
-    time::Duration,
-};
+use rusqlite::Connection;
+use std::{net::SocketAddr, ops::RangeInclusive, sync::Arc, time::Duration};
 use tokio::{
     net::TcpListener,
     sync::{
@@ -20,19 +12,16 @@ use tokio::{
         Semaphore,
     },
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use tripwire::Tripwire;
 
 // Internals
 use crate::{api::peer::gossip_server_endpoint, transport::Transport};
 use corro_types::{
     actor::ActorId,
-    agent::{
-        migrate, Agent, AgentConfig, Booked, BookedVersions, Bookie, CurrentVersion,
-        KnownDbVersion, LockRegistry, PartialVersion, SplitPool,
-    },
-    base::{CrsqlSeq, Version},
-    broadcast::{BroadcastInput, ChangeSource, ChangeV1, FocaInput, Timestamp},
+    agent::{migrate, Agent, AgentConfig, Booked, BookedVersions, LockRegistry, SplitPool},
+    base::Version,
+    broadcast::{BroadcastInput, ChangeSource, ChangeV1, FocaInput},
     config::Config,
     members::Members,
     pubsub::SubsManager,

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -2,6 +2,7 @@
 
 // External crates
 use arc_swap::ArcSwap;
+use futures::lock;
 use parking_lot::RwLock;
 use rangemap::RangeInclusiveSet;
 use rusqlite::{params, Connection};
@@ -27,8 +28,8 @@ use crate::{api::peer::gossip_server_endpoint, transport::Transport};
 use corro_types::{
     actor::ActorId,
     agent::{
-        migrate, Agent, AgentConfig, BookedVersions, Bookie, CurrentVersion, KnownDbVersion,
-        PartialVersion, SplitPool,
+        migrate, Agent, AgentConfig, Booked, BookedVersions, Bookie, CurrentVersion,
+        KnownDbVersion, LockRegistry, PartialVersion, SplitPool,
     },
     base::{CrsqlSeq, Version},
     broadcast::{BroadcastInput, ChangeSource, ChangeV1, FocaInput, Timestamp},
@@ -42,6 +43,7 @@ use corro_types::{
 /// Runtime state for the Corrosion agent
 pub struct AgentOptions {
     pub actor_id: ActorId,
+    pub lock_registry: LockRegistry,
     pub gossip_server_endpoint: quinn::Endpoint,
     pub transport: Transport,
     pub api_listener: TcpListener,
@@ -92,132 +94,141 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
     let (tx_apply, rx_apply) = channel(20480);
     let (tx_clear_buf, rx_clear_buf) = channel(10240);
 
-    let mut bk: HashMap<ActorId, BookedVersions> = HashMap::new();
+    let lock_registry = LockRegistry::default();
+    let booked = {
+        let conn = pool.read().await?;
+        Booked::new(
+            BookedVersions::from_conn(&conn, actor_id)?,
+            lock_registry.clone(),
+        )
+    };
 
-    {
-        debug!("getting read-only conn for pull bookkeeping rows");
-        let mut conn = pool.write_priority().await?;
+    // let mut bk: HashMap<ActorId, BookedVersions> = HashMap::new();
 
-        debug!("getting bookkept rows");
+    // {
+    //     debug!("getting read-only conn for pull bookkeeping rows");
+    //     let mut conn = pool.write_priority().await?;
 
-        let mut cleared_rows: BTreeMap<ActorId, usize> = BTreeMap::new();
+    //     debug!("getting bookkept rows");
 
-        {
-            let mut prepped = conn.prepare_cached(
-                "SELECT actor_id, start_version, end_version, db_version, last_seq, ts
-                FROM __corro_bookkeeping",
-            )?;
-            let mut rows = prepped.query([])?;
+    //     let mut cleared_rows: BTreeMap<ActorId, usize> = BTreeMap::new();
 
-            loop {
-                let row = rows.next()?;
-                match row {
-                    None => break,
-                    Some(row) => {
-                        let actor_id = row.get(0)?;
-                        let ranges = bk.entry(actor_id).or_default();
-                        let start_v = row.get(1)?;
-                        let end_v: Option<Version> = row.get(2)?;
-                        ranges.insert_many(
-                            start_v..=end_v.unwrap_or(start_v),
-                            match row.get(3)? {
-                                Some(db_version) => KnownDbVersion::Current(CurrentVersion {
-                                    db_version,
-                                    last_seq: row.get(4)?,
-                                    ts: row.get(5)?,
-                                }),
-                                None => {
-                                    *cleared_rows.entry(actor_id).or_default() += 1;
-                                    KnownDbVersion::Cleared
-                                }
-                            },
-                        );
-                    }
-                }
-            }
+    //     {
+    //         let mut prepped = conn.prepare_cached(
+    //             "SELECT actor_id, start_version, end_version, db_version, last_seq, ts
+    //             FROM __corro_bookkeeping",
+    //         )?;
+    //         let mut rows = prepped.query([])?;
 
-            let mut partials: HashMap<
-                (ActorId, Version),
-                (RangeInclusiveSet<CrsqlSeq>, CrsqlSeq, Timestamp),
-            > = HashMap::new();
+    //         loop {
+    //             let row = rows.next()?;
+    //             match row {
+    //                 None => break,
+    //                 Some(row) => {
+    //                     let actor_id = row.get(0)?;
+    //                     let ranges = bk.entry(actor_id).or_default();
+    //                     let start_v = row.get(1)?;
+    //                     let end_v: Option<Version> = row.get(2)?;
+    //                     ranges.insert_many(
+    //                         start_v..=end_v.unwrap_or(start_v),
+    //                         match row.get(3)? {
+    //                             Some(db_version) => KnownDbVersion::Current(CurrentVersion {
+    //                                 db_version,
+    //                                 last_seq: row.get(4)?,
+    //                                 ts: row.get(5)?,
+    //                             }),
+    //                             None => {
+    //                                 *cleared_rows.entry(actor_id).or_default() += 1;
+    //                                 KnownDbVersion::Cleared
+    //                             }
+    //                         },
+    //                     );
+    //                 }
+    //             }
+    //         }
 
-            debug!("getting seq bookkept rows");
+    //         let mut partials: HashMap<
+    //             (ActorId, Version),
+    //             (RangeInclusiveSet<CrsqlSeq>, CrsqlSeq, Timestamp),
+    //         > = HashMap::new();
 
-            let mut prepped = conn.prepare_cached(
-                "SELECT site_id, version, start_seq, end_seq, last_seq, ts
-                FROM __corro_seq_bookkeeping",
-            )?;
-            let mut rows = prepped.query([])?;
+    //         debug!("getting seq bookkept rows");
 
-            loop {
-                let row = rows.next()?;
-                match row {
-                    None => break,
-                    Some(row) => {
-                        let (range, last_seq, ts) =
-                            partials.entry((row.get(0)?, row.get(1)?)).or_default();
+    //         let mut prepped = conn.prepare_cached(
+    //             "SELECT site_id, version, start_seq, end_seq, last_seq, ts
+    //             FROM __corro_seq_bookkeeping",
+    //         )?;
+    //         let mut rows = prepped.query([])?;
 
-                        range.insert(row.get(2)?..=row.get(3)?);
-                        *last_seq = row.get(4)?;
-                        *ts = row.get(5)?;
-                    }
-                }
-            }
+    //         loop {
+    //             let row = rows.next()?;
+    //             match row {
+    //                 None => break,
+    //                 Some(row) => {
+    //                     let (range, last_seq, ts) =
+    //                         partials.entry((row.get(0)?, row.get(1)?)).or_default();
 
-            debug!("filling up partial known versions");
+    //                     range.insert(row.get(2)?..=row.get(3)?);
+    //                     *last_seq = row.get(4)?;
+    //                     *ts = row.get(5)?;
+    //                 }
+    //             }
+    //         }
 
-            for ((actor_id, version), (seqs, last_seq, ts)) in partials {
-                debug!(%actor_id, %version, "looking at partials (seq: {seqs:?}, last_seq: {last_seq})");
-                let ranges = bk.entry(actor_id).or_default();
+    //         debug!("filling up partial known versions");
 
-                if let Some(known) = ranges.get(&version) {
-                    warn!(%actor_id, %version, "found partial data that has been applied, clearing buffered meta, known: {known:?}");
+    //         for ((actor_id, version), (seqs, last_seq, ts)) in partials {
+    //             debug!(%actor_id, %version, "looking at partials (seq: {seqs:?}, last_seq: {last_seq})");
+    //             let ranges = bk.entry(actor_id).or_default();
 
-                    _ = tx_clear_buf.try_send((actor_id, version..=version));
-                    continue;
-                }
+    //             if let Some(known) = ranges.get(&version) {
+    //                 warn!(%actor_id, %version, "found partial data that has been applied, clearing buffered meta, known: {known:?}");
 
-                let gaps_count = seqs.gaps(&(CrsqlSeq(0)..=last_seq)).count();
+    //                 _ = tx_clear_buf.try_send((actor_id, version..=version));
+    //                 continue;
+    //             }
 
-                ranges.insert(
-                    version,
-                    KnownDbVersion::Partial(PartialVersion { seqs, last_seq, ts }),
-                );
+    //             let gaps_count = seqs.gaps(&(CrsqlSeq(0)..=last_seq)).count();
 
-                if gaps_count == 0 {
-                    info!(%actor_id, %version, "found fully buffered, unapplied, changes! scheduling apply");
-                    // spawn this because it can block if the channel gets full, nothing is draining it yet!
-                    tokio::spawn({
-                        let tx_apply = tx_apply.clone();
-                        async move {
-                            let _ = tx_apply.send((actor_id, version)).await;
-                        }
-                    });
-                }
-            }
-        }
+    //             ranges.insert(
+    //                 version,
+    //                 KnownDbVersion::Partial(PartialVersion { seqs, last_seq, ts }),
+    //             );
 
-        for (actor_id, booked) in bk.iter() {
-            if let Some(clear_count) = cleared_rows.get(actor_id).copied() {
-                if clear_count > booked.cleared.len() {
-                    warn!(%actor_id, "cleared bookkept rows count ({clear_count}) in DB was bigger than in-memory entries count ({}), compacting...", booked.cleared.len());
-                    let tx = conn.immediate_transaction()?;
-                    let deleted = tx.execute("DELETE FROM __corro_bookkeeping WHERE actor_id = ? AND end_version IS NOT NULL", [actor_id])?;
-                    info!("deleted {deleted} rows that had an end_version");
-                    let mut inserted = 0;
-                    for range in booked.cleared.iter() {
-                        inserted += tx.execute("INSERT INTO __corro_bookkeeping (actor_id, start_version, end_version) VALUES (?, ?, ?)", params![actor_id, range.start(), range.end()])?;
-                    }
-                    info!("inserted {inserted} cleared version rows");
-                    tx.commit()?;
-                }
-            }
-        }
-    }
+    //             if gaps_count == 0 {
+    //                 info!(%actor_id, %version, "found fully buffered, unapplied, changes! scheduling apply");
+    //                 // spawn this because it can block if the channel gets full, nothing is draining it yet!
+    //                 tokio::spawn({
+    //                     let tx_apply = tx_apply.clone();
+    //                     async move {
+    //                         let _ = tx_apply.send((actor_id, version)).await;
+    //                     }
+    //                 });
+    //             }
+    //         }
+    //     }
 
-    debug!("done building bookkeeping");
+    //     for (actor_id, booked) in bk.iter() {
+    //         if let Some(clear_count) = cleared_rows.get(actor_id).copied() {
+    //             if clear_count > booked.cleared.len() {
+    //                 warn!(%actor_id, "cleared bookkept rows count ({clear_count}) in DB was bigger than in-memory entries count ({}), compacting...", booked.cleared.len());
+    //                 let tx = conn.immediate_transaction()?;
+    //                 let deleted = tx.execute("DELETE FROM __corro_bookkeeping WHERE actor_id = ? AND end_version IS NOT NULL", [actor_id])?;
+    //                 info!("deleted {deleted} rows that had an end_version");
+    //                 let mut inserted = 0;
+    //                 for range in booked.cleared.iter() {
+    //                     inserted += tx.execute("INSERT INTO __corro_bookkeeping (actor_id, start_version, end_version) VALUES (?, ?, ?)", params![actor_id, range.start(), range.end()])?;
+    //                 }
+    //                 info!("inserted {inserted} cleared version rows");
+    //                 tx.commit()?;
+    //             }
+    //         }
+    //     }
+    // }
 
-    let bookie = Bookie::new(bk);
+    // debug!("done building bookkeeping");
+
+    // let bookie = Bookie::new(bk);
 
     let gossip_server_endpoint = gossip_server_endpoint(&conf.gossip).await?;
     let gossip_addr = gossip_server_endpoint.local_addr()?;
@@ -250,6 +261,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
         gossip_server_endpoint,
         transport,
         api_listener,
+        lock_registry,
         rx_bcast,
         rx_apply,
         rx_empty,
@@ -270,7 +282,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
         members: RwLock::new(members),
         config: ArcSwap::from_pointee(conf),
         clock,
-        bookie,
+        booked,
         tx_bcast,
         tx_apply,
         tx_empty,

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -4,7 +4,7 @@ use axum::{response::IntoResponse, Extension};
 use bytes::{BufMut, BytesMut};
 use compact_str::ToCompactString;
 use corro_types::{
-    agent::{Agent, Booked, ChangeError, CurrentVersion, KnownDbVersion},
+    agent::{Agent, ChangeError, CurrentVersion, KnownDbVersion},
     api::{row_to_change, ColumnName, ExecResponse, ExecResult, QueryEvent, Statement},
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast::{ChangeV1, Changeset, Timestamp},

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -4,7 +4,7 @@ use axum::{response::IntoResponse, Extension};
 use bytes::{BufMut, BytesMut};
 use compact_str::ToCompactString;
 use corro_types::{
-    agent::{Agent, ChangeError, CurrentVersion, KnownDbVersion},
+    agent::{Agent, Booked, ChangeError, CurrentVersion, KnownDbVersion},
     api::{row_to_change, ColumnName, ExecResponse, ExecResult, QueryEvent, Statement},
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast::{ChangeV1, Changeset, Timestamp},
@@ -42,16 +42,10 @@ where
     trace!("got conn");
 
     let actor_id = agent.actor_id();
-    let booked = {
-        agent
-            .bookie()
-            .write("make_broadcastable_changes(for_actor)")
-            .await
-            .for_actor(actor_id)
-    };
     // maybe we should do this earlier, but there can only ever be 1 write conn at a time,
     // so it probably doesn't matter too much, except for reads of internal state
-    let mut book_writer = booked
+    let mut book_writer = agent
+        .booked()
         .write("make_broadcastable_changes(booked writer)")
         .await;
 
@@ -748,17 +742,7 @@ mod tests {
             }))
         ));
 
-        assert_eq!(
-            agent
-                .bookie()
-                .write("test")
-                .await
-                .for_actor(agent.actor_id())
-                .read("test")
-                .await
-                .last(),
-            Some(Version(1))
-        );
+        assert_eq!(agent.booked().read("test").await.last(), Some(Version(1)));
 
         println!("second req...");
 

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -14,7 +14,7 @@ use bytes::Buf;
 use chrono::NaiveDateTime;
 use compact_str::CompactString;
 use corro_types::{
-    agent::{Agent, Booked, CurrentVersion, KnownDbVersion},
+    agent::{Agent, CurrentVersion, KnownDbVersion},
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast::{BroadcastInput, BroadcastV1, ChangeV1, Changeset, Timestamp},
     change::{row_to_change, ChunkedChanges, MAX_CHANGES_BYTE_SIZE},
@@ -3129,7 +3129,6 @@ mod tests {
 
     use chrono::{DateTime, Utc};
     use corro_tests::launch_test_agent;
-    use corro_types::agent::Bookie;
     use spawn::wait_for_all_pending_handles;
     use tokio_postgres::NoTls;
     use tripwire::Tripwire;

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -14,7 +14,7 @@ use bytes::Buf;
 use chrono::NaiveDateTime;
 use compact_str::CompactString;
 use corro_types::{
-    agent::{Agent, CurrentVersion, KnownDbVersion},
+    agent::{Agent, Booked, CurrentVersion, KnownDbVersion},
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast::{BroadcastInput, BroadcastV1, ChangeV1, Changeset, Timestamp},
     change::{row_to_change, ChunkedChanges, MAX_CHANGES_BYTE_SIZE},
@@ -338,7 +338,7 @@ fn parse_query(sql: &str) -> Result<VecDeque<ParsedCmd>, ParseError> {
 }
 
 #[derive(Debug, Default)]
-enum OpenTx {
+enum TxState {
     Started {
         kind: OpenTxKind,
         write_permit: Option<OwnedSemaphorePermit>,
@@ -347,7 +347,7 @@ enum OpenTx {
     Ended,
 }
 
-impl OpenTx {
+impl TxState {
     fn implicit() -> Self {
         Self::Started {
             kind: OpenTxKind::Implicit,
@@ -364,7 +364,7 @@ impl OpenTx {
     fn is_writing(&self) -> bool {
         matches!(
             self,
-            OpenTx::Started {
+            TxState::Started {
                 write_permit: Some(_),
                 ..
             }
@@ -373,8 +373,8 @@ impl OpenTx {
 
     fn set_write_permit(&mut self, permit: OwnedSemaphorePermit) {
         match self {
-            OpenTx::Started { write_permit, .. } => *write_permit = Some(permit),
-            OpenTx::Ended => {
+            TxState::Started { write_permit, .. } => *write_permit = Some(permit),
+            TxState::Ended => {
                 // do nothing, maybe bomb?
             }
         }
@@ -383,7 +383,7 @@ impl OpenTx {
     fn is_implicit(&self) -> bool {
         matches!(
             self,
-            OpenTx::Started {
+            TxState::Started {
                 kind: OpenTxKind::Implicit,
                 ..
             }
@@ -392,14 +392,14 @@ impl OpenTx {
     fn is_explicit(&self) -> bool {
         matches!(
             self,
-            OpenTx::Started {
+            TxState::Started {
                 kind: OpenTxKind::Explicit,
                 ..
             }
         )
     }
     fn is_ended(&self) -> bool {
-        matches!(self, OpenTx::Ended)
+        matches!(self, TxState::Ended)
     }
 
     fn start_implicit(&mut self) {
@@ -412,10 +412,10 @@ impl OpenTx {
 
     fn end(&mut self) -> Option<OwnedSemaphorePermit> {
         let permit = match self {
-            OpenTx::Started { write_permit, .. } => write_permit.take(),
-            OpenTx::Ended => None,
+            TxState::Started { write_permit, .. } => write_permit.take(),
+            TxState::Ended => None,
         };
-        *self = OpenTx::Ended;
+        *self = TxState::Ended;
         permit
     }
 }
@@ -703,7 +703,10 @@ pub async fn start(
 
                     let mut discard_until_sync = false;
 
-                    let mut open_tx = OpenTx::default();
+                    let mut session = Session {
+                        agent,
+                        tx_state: TxState::default(),
+                    };
 
                     'outer: while let Some(msg) = front_rx.blocking_recv() {
                         debug!("msg: {msg:?}");
@@ -1401,13 +1404,7 @@ pub async fn start(
                                 )?;
                             }
                             PgWireFrontendMessage::Sync(_) => {
-                                send_ready(
-                                    &agent,
-                                    &conn,
-                                    &mut open_tx,
-                                    discard_until_sync,
-                                    &back_tx,
-                                )?;
+                                send_ready(&mut session, &conn, discard_until_sync, &back_tx)?;
 
                                 // reset this
                                 discard_until_sync = false;
@@ -1463,13 +1460,11 @@ pub async fn start(
                                     max_rows as usize
                                 };
 
-                                if let Err(e) = handle_execute(
-                                    &agent,
+                                if let Err(e) = session.handle_execute(
                                     &conn,
                                     prepped,
                                     result_formats,
                                     cmd,
-                                    &mut open_tx,
                                     max_rows,
                                     &back_tx,
                                 ) {
@@ -1480,13 +1475,7 @@ pub async fn start(
 
                                     discard_until_sync = true;
 
-                                    send_ready(
-                                        &agent,
-                                        &conn,
-                                        &mut open_tx,
-                                        discard_until_sync,
-                                        &back_tx,
-                                    )?;
+                                    send_ready(&mut session, &conn, discard_until_sync, &back_tx)?;
                                     continue;
                                 }
                             }
@@ -1509,9 +1498,8 @@ pub async fn start(
                                                 .into(),
                                         )?;
                                         send_ready(
-                                            &agent,
+                                            &mut session,
                                             &conn,
-                                            &mut open_tx,
                                             discard_until_sync,
                                             &back_tx,
                                         )?;
@@ -1530,33 +1518,21 @@ pub async fn start(
                                             .into(),
                                     )?;
 
-                                    send_ready(
-                                        &agent,
-                                        &conn,
-                                        &mut open_tx,
-                                        discard_until_sync,
-                                        &back_tx,
-                                    )?;
+                                    send_ready(&mut session, &conn, discard_until_sync, &back_tx)?;
                                     continue;
                                 }
 
                                 for cmd in parsed_query.into_iter() {
-                                    if let Err(e) = handle_query(
-                                        &agent,
-                                        &conn,
-                                        &cmd,
-                                        &mut open_tx,
-                                        &back_tx,
-                                        true,
-                                    ) {
+                                    if let Err(e) =
+                                        session.handle_query(&conn, &cmd, &back_tx, true)
+                                    {
                                         back_tx.blocking_send(BackendResponse::Message {
                                             message: e.try_into()?,
                                             flush: true,
                                         })?;
                                         send_ready(
-                                            &agent,
+                                            &mut session,
                                             &conn,
-                                            &mut open_tx,
                                             discard_until_sync,
                                             &back_tx,
                                         )?;
@@ -1565,11 +1541,11 @@ pub async fn start(
                                 }
 
                                 // automatically commit an implicit tx
-                                if open_tx.is_implicit() {
+                                if session.tx_state.is_implicit() {
                                     trace!("committing IMPLICIT tx");
-                                    let _permit = open_tx.end();
+                                    let _permit = session.tx_state.end();
 
-                                    if let Err(e) = handle_commit(&agent, &conn) {
+                                    if let Err(e) = session.handle_commit(&conn) {
                                         back_tx.blocking_send(
                                             (
                                                 PgWireBackendMessage::ErrorResponse(
@@ -1585,9 +1561,8 @@ pub async fn start(
                                                 .into(),
                                         )?;
                                         send_ready(
-                                            &agent,
+                                            &mut session,
                                             &conn,
-                                            &mut open_tx,
                                             discard_until_sync,
                                             &back_tx,
                                         )?;
@@ -1596,13 +1571,7 @@ pub async fn start(
                                     trace!("committed IMPLICIT tx");
                                 }
 
-                                send_ready(
-                                    &agent,
-                                    &conn,
-                                    &mut open_tx,
-                                    discard_until_sync,
-                                    &back_tx,
-                                )?;
+                                send_ready(&mut session, &conn, discard_until_sync, &back_tx)?;
                             }
                             PgWireFrontendMessage::Terminate(_) => {
                                 break;
@@ -1769,15 +1738,520 @@ pub async fn start(
     Ok(PgServer { local_addr })
 }
 
+struct Session {
+    agent: Agent,
+    tx_state: TxState,
+}
+
+impl Session {
+    fn handle_query(
+        &mut self,
+        conn: &Connection,
+        cmd: &ParsedCmd,
+        back_tx: &Sender<BackendResponse>,
+        send_row_desc: bool,
+    ) -> Result<(), QueryError> {
+        if cmd.is_show() {
+            back_tx
+                .blocking_send(
+                    (
+                        PgWireBackendMessage::CommandComplete(CommandComplete::new("SHOW".into())),
+                        true,
+                    )
+                        .into(),
+                )
+                .map_err(|_| QueryError::BackendResponseSendFailed)?;
+            return Ok(());
+        }
+
+        if cmd.is_set() {
+            back_tx
+                .blocking_send(
+                    (
+                        PgWireBackendMessage::CommandComplete(CommandComplete::new("SET".into())),
+                        true,
+                    )
+                        .into(),
+                )
+                .map_err(|_| QueryError::BackendResponseSendFailed)?;
+            return Ok(());
+        }
+
+        // need to start an implicit transaction
+        if self.tx_state.is_ended() && !cmd.is_begin() {
+            conn.execute_batch("BEGIN")?;
+            trace!("started IMPLICIT tx");
+            self.tx_state.start_implicit();
+        } else if self.tx_state.is_implicit() && cmd.is_begin() {
+            trace!("committing IMPLICIT tx");
+            let _permit = self.tx_state.end();
+
+            self.handle_commit(conn)?;
+            trace!("committed IMPLICIT tx");
+        }
+
+        let count = if cmd.is_begin() {
+            conn.execute_batch("BEGIN")?;
+            self.tx_state.start_explicit();
+            0
+        } else if cmd.is_commit() {
+            let _permit = self.tx_state.end();
+            self.handle_commit(conn)?;
+            0
+        } else if cmd.is_rollback() {
+            let _permit = self.tx_state.end();
+            conn.execute_batch("ROLLBACK")?;
+            0
+        } else {
+            let mut prepped = if cmd.is_pg() {
+                return Err(QueryError::NotSqlite);
+            } else {
+                conn.prepare(&cmd.to_string())?
+            };
+
+            let mut fields = vec![];
+            for col in prepped.columns() {
+                let col_type = name_to_type(col.decl_type().unwrap_or("text"))?;
+                fields.push(FieldInfo::new(
+                    col.name().to_string(),
+                    None,
+                    None,
+                    col_type,
+                    FieldFormat::Text,
+                ));
+            }
+
+            if send_row_desc {
+                back_tx
+                    .blocking_send(
+                        (
+                            PgWireBackendMessage::RowDescription(RowDescription::new(
+                                fields.iter().map(Into::into).collect(),
+                            )),
+                            true,
+                        )
+                            .into(),
+                    )
+                    .map_err(|_| QueryError::BackendResponseSendFailed)?;
+            }
+
+            let schema = Arc::new(fields);
+
+            if !self.tx_state.is_writing() && !prepped.readonly() {
+                trace!("query statement writes, acquiring permit...");
+                self.tx_state
+                    .set_write_permit(self.agent.write_permit_blocking()?);
+            }
+
+            let mut rows = prepped.raw_query();
+            let ncols = schema.len();
+
+            let mut count = 0;
+            while let Some(row) = rows.next()? {
+                count += 1;
+                let mut encoder = DataRowEncoder::new(schema.clone());
+                for idx in 0..ncols {
+                    let data = row.get_ref_unwrap::<usize>(idx);
+                    match data {
+                        ValueRef::Null => encoder.encode_field(&None::<i8>).unwrap(),
+                        ValueRef::Integer(i) => {
+                            encoder.encode_field(&i).unwrap();
+                        }
+                        ValueRef::Real(f) => {
+                            encoder.encode_field(&f).unwrap();
+                        }
+                        ValueRef::Text(t) => {
+                            encoder
+                                .encode_field(&String::from_utf8_lossy(t).as_ref())
+                                .unwrap();
+                        }
+                        ValueRef::Blob(b) => {
+                            encoder.encode_field(&b).unwrap();
+                        }
+                    }
+                }
+                let data_row = encoder.finish()?;
+                back_tx
+                    .blocking_send((PgWireBackendMessage::DataRow(data_row), false).into())
+                    .map_err(|_| QueryError::BackendResponseSendFailed)?;
+            }
+            count
+        };
+
+        back_tx
+            .blocking_send(
+                (
+                    PgWireBackendMessage::CommandComplete(
+                        cmd.tag().into_command_complete(count, conn),
+                    ),
+                    true,
+                )
+                    .into(),
+            )
+            .map_err(|_| QueryError::BackendResponseSendFailed)?;
+
+        if cmd.is_begin() {
+            trace!("setting EXPLICIT tx");
+            // explicit tx
+            self.tx_state.start_explicit();
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn handle_execute<'conn>(
+        &mut self,
+        conn: &'conn Connection,
+        prepped: &mut Statement<'conn>,
+        result_formats: &[FieldFormat],
+        cmd: &ParsedCmd,
+        max_rows: usize,
+        back_tx: &Sender<BackendResponse>,
+    ) -> Result<(), QueryError> {
+        // TODO: maybe we don't need to recompute this...
+        let mut fields = vec![];
+        for (i, col) in prepped.columns().into_iter().enumerate() {
+            trace!("col decl_type: {:?}", col.decl_type());
+            let col_type = name_to_type(col.decl_type().unwrap_or("any"))?;
+
+            fields.push(FieldInfo::new(
+                col.name().to_string(),
+                None,
+                None,
+                col_type,
+                result_formats.get(i).copied().unwrap_or(FieldFormat::Text),
+            ));
+        }
+
+        trace!("fields: {fields:?}");
+
+        let schema = Arc::new(fields);
+
+        // we need to know because we'll commit it right away
+        let mut opened_implicit_tx = false;
+
+        if self.tx_state.is_ended() {
+            if !cmd.is_begin() && !prepped.readonly() {
+                // NOT in a tx and statement mutates DB...
+                conn.execute_batch("BEGIN")?;
+
+                self.tx_state.start_implicit();
+                opened_implicit_tx = true;
+            } else if cmd.is_begin() {
+                conn.execute_batch("BEGIN")?;
+                self.tx_state.start_explicit();
+            }
+        }
+
+        let mut count = 0;
+
+        if cmd.is_commit() {
+            let _permit = self.tx_state.end();
+            self.handle_commit(conn)?;
+        } else {
+            if !self.tx_state.is_writing() && !prepped.readonly() {
+                trace!("statement writes, acquiring permit...");
+                self.tx_state
+                    .set_write_permit(self.agent.write_permit_blocking()?);
+            }
+            let mut rows = prepped.raw_query();
+            loop {
+                if count >= max_rows {
+                    trace!("attained max rows");
+                    // forget the Rows iterator here so as to not reset the statement!
+                    std::mem::forget(rows);
+                    back_tx
+                        .blocking_send(
+                            (
+                                PgWireBackendMessage::PortalSuspended(PortalSuspended::new()),
+                                true,
+                            )
+                                .into(),
+                        )
+                        .map_err(|_| QueryError::BackendResponseSendFailed)?;
+                    return Ok(());
+                }
+
+                let row = match rows.next()? {
+                    Some(row) => {
+                        trace!("got a row: {row:?}");
+                        row
+                    }
+                    None => {
+                        trace!("done w/ rows");
+                        break;
+                    }
+                };
+
+                count += 1;
+
+                let mut encoder = DataRowEncoder::new(schema.clone());
+                for (idx, field) in schema.iter().enumerate() {
+                    trace!("processing field: {field:?}");
+                    let format = *field.format();
+                    match field.datatype() {
+                        &Type::ANY => {
+                            let data = row.get_ref_unwrap(idx);
+                            match data {
+                                ValueRef::Null => encoder
+                                    .encode_field_with_type_and_format(
+                                        &None::<i8>,
+                                        &Type::ANY,
+                                        format,
+                                    )
+                                    .unwrap(),
+                                ValueRef::Integer(i) => {
+                                    encoder
+                                        .encode_field_with_type_and_format(&i, &Type::INT8, format)
+                                        .unwrap();
+                                }
+                                ValueRef::Real(f) => {
+                                    encoder
+                                        .encode_field_with_type_and_format(
+                                            &f,
+                                            &Type::FLOAT8,
+                                            format,
+                                        )
+                                        .unwrap();
+                                }
+                                ValueRef::Text(t) => {
+                                    encoder
+                                        .encode_field_with_type_and_format(
+                                            &String::from_utf8_lossy(t).as_ref(),
+                                            &Type::TEXT,
+                                            format,
+                                        )
+                                        .unwrap();
+                                }
+                                ValueRef::Blob(b) => {
+                                    encoder
+                                        .encode_field_with_type_and_format(&b, &Type::BYTEA, format)
+                                        .unwrap();
+                                }
+                            }
+                        }
+                        t @ &Type::INT8 => {
+                            encoder
+                                .encode_field_with_type_and_format(
+                                    &row.get::<_, Option<i64>>(idx)?,
+                                    t,
+                                    format,
+                                )
+                                .unwrap();
+                        }
+                        t @ &Type::TIMESTAMP => {
+                            encoder
+                                .encode_field_with_type_and_format(
+                                    &row.get::<_, Option<NaiveDateTime>>(idx)?,
+                                    t,
+                                    format,
+                                )
+                                .unwrap();
+                        }
+                        t @ &Type::VARCHAR | t @ &Type::TEXT | t @ &Type::JSON => {
+                            encoder
+                                .encode_field_with_type_and_format(
+                                    &row.get::<_, Option<String>>(idx)?,
+                                    t,
+                                    format,
+                                )
+                                .unwrap();
+                        }
+                        t @ &Type::BYTEA | t @ &Type::JSONB => {
+                            encoder
+                                .encode_field_with_type_and_format(
+                                    &row.get::<_, Option<Vec<u8>>>(idx)?,
+                                    t,
+                                    format,
+                                )
+                                .unwrap();
+                        }
+                        t @ &Type::FLOAT8 => {
+                            encoder
+                                .encode_field_with_type_and_format(
+                                    &row.get::<_, Option<f64>>(idx)?,
+                                    t,
+                                    format,
+                                )
+                                .unwrap();
+                        }
+                        _ => {
+                            return Err(UnsupportedSqliteToPostgresType(field.name().clone()).into())
+                        }
+                    }
+                }
+
+                let data_row = encoder.finish()?;
+                back_tx
+                    .blocking_send((PgWireBackendMessage::DataRow(data_row), false).into())
+                    .map_err(|_| QueryError::BackendResponseSendFailed)?;
+            }
+
+            if opened_implicit_tx {
+                let _permit = self.tx_state.end();
+                self.handle_commit(conn)?;
+            }
+        }
+
+        let tag = cmd.tag();
+        trace!("done w/ rows, computing tag: {tag:?}");
+
+        // done!
+        back_tx
+            .blocking_send(
+                (
+                    PgWireBackendMessage::CommandComplete(tag.into_command_complete(count, conn)),
+                    true,
+                )
+                    .into(),
+            )
+            .map_err(|_| QueryError::BackendResponseSendFailed)?;
+
+        Ok(())
+    }
+
+    fn handle_commit(&self, conn: &Connection) -> rusqlite::Result<()> {
+        trace!("HANDLE COMMIT");
+        let actor_id = self.agent.actor_id();
+
+        let ts = Timestamp::from(self.agent.clock().new_timestamp());
+
+        let db_version: CrsqlDbVersion = conn
+            .prepare_cached("SELECT crsql_next_db_version()")?
+            .query_row((), |row| row.get(0))?;
+
+        let has_changes: bool = conn
+            .prepare_cached("SELECT EXISTS(SELECT 1 FROM crsql_changes WHERE db_version = ?);")?
+            .query_row([db_version], |row| row.get(0))?;
+
+        if !has_changes {
+            conn.execute_batch("COMMIT")?;
+            return Ok(());
+        }
+
+        let last_seq: CrsqlSeq = conn
+            .prepare_cached("SELECT MAX(seq) FROM crsql_changes WHERE db_version = ?")?
+            .query_row([db_version], |row| row.get(0))?;
+
+        let mut book_writer = self
+            .agent
+            .booked()
+            .blocking_write("handle_write_tx(book_writer)");
+
+        let last_version = book_writer.last().unwrap_or_default();
+        trace!("last_version: {last_version}");
+        let version = last_version + 1;
+        trace!("version: {version}");
+
+        conn.prepare_cached(
+            r#"
+                INSERT INTO __corro_bookkeeping (actor_id, start_version, db_version, last_seq, ts)
+                    VALUES (:actor_id, :start_version, :db_version, :last_seq, :ts);
+            "#,
+        )?
+        .execute(named_params! {
+            ":actor_id": actor_id,
+            ":start_version": version,
+            ":db_version": db_version,
+            ":last_seq": last_seq,
+            ":ts": ts
+        })?;
+
+        debug!(%actor_id, %version, %db_version, "inserted local bookkeeping row!");
+
+        conn.execute_batch("COMMIT")?;
+
+        trace!("committed tx, db_version: {db_version}, last_seq: {last_seq:?}");
+
+        book_writer.insert(
+            version,
+            KnownDbVersion::Current(CurrentVersion {
+                db_version,
+                last_seq,
+                ts,
+            }),
+        );
+
+        drop(book_writer);
+
+        spawn_counted({
+            let agent = self.agent.clone();
+            async move {
+                let conn = agent.pool().read().await?;
+
+                block_in_place(|| {
+                    // TODO: make this more generic so both sync and local changes can use it.
+                    let mut prepped = conn.prepare_cached(
+                        r#"
+                    SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl
+                        FROM crsql_changes
+                        WHERE db_version = ?
+                        ORDER BY seq ASC
+                "#,
+                    )?;
+                    let rows = prepped.query_map([db_version], row_to_change)?;
+                    let chunked =
+                        ChunkedChanges::new(rows, CrsqlSeq(0), last_seq, MAX_CHANGES_BYTE_SIZE);
+                    for changes_seqs in chunked {
+                        match changes_seqs {
+                            Ok((changes, seqs)) => {
+                                for (table_name, count) in
+                                    changes.iter().counts_by(|change| &change.table)
+                                {
+                                    counter!("corro.changes.committed", count as u64, "table" => table_name.to_string(), "source" => "local");
+                                }
+
+                                trace!("broadcasting changes: {changes:?} for seq: {seqs:?}");
+
+                                agent.subs_manager().match_changes(&changes, db_version);
+
+                                let tx_bcast = agent.tx_bcast().clone();
+                                tokio::spawn(async move {
+                                    if let Err(e) = tx_bcast
+                                        .send(BroadcastInput::AddBroadcast(BroadcastV1::Change(
+                                            ChangeV1 {
+                                                actor_id,
+                                                changeset: Changeset::Full {
+                                                    version,
+                                                    changes,
+                                                    seqs,
+                                                    last_seq,
+                                                    ts,
+                                                },
+                                            },
+                                        )))
+                                        .await
+                                    {
+                                        error!("could not send change message for broadcast: {e}");
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                error!("could not process crsql change (db_version: {db_version}) for broadcast: {e}");
+                                break;
+                            }
+                        }
+                    }
+                    Ok::<_, rusqlite::Error>(())
+                })?;
+
+                Ok::<_, BoxError>(())
+            }
+        });
+
+        Ok(())
+    }
+}
+
 fn send_ready(
-    agent: &Agent,
+    session: &mut Session,
     conn: &Connection,
-    open_tx: &mut OpenTx,
     discard_until_sync: bool,
     back_tx: &Sender<BackendResponse>,
 ) -> Result<(), BoxError> {
-    let ready_status = if open_tx.is_implicit() {
-        let _permit = open_tx.end(); // do this first, in case of failure
+    let ready_status = if session.tx_state.is_implicit() {
+        let _permit = session.tx_state.end(); // do this first, in case of failure
         if discard_until_sync {
             // an error occured, rollback implicit tx!
             warn!("receive Sync message w/ an error to send, rolling back implicit tx");
@@ -1785,11 +2259,11 @@ fn send_ready(
         } else {
             // no error, commit implicit tx
             warn!("receive Sync message, committing implicit tx");
-            handle_commit(agent, conn)?;
+            session.handle_commit(conn)?;
         }
 
         READY_STATUS_IDLE
-    } else if open_tx.is_explicit() {
+    } else if session.tx_state.is_explicit() {
         if discard_until_sync {
             READY_STATUS_FAILED_TRANSACTION_BLOCK
         } else {
@@ -1851,361 +2325,6 @@ impl TryFrom<QueryError> for PgWireBackendMessage {
             QueryError::BackendResponseSendFailed => return Err(ChannelClosed),
         }))
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn handle_execute<'conn>(
-    agent: &Agent,
-    conn: &'conn Connection,
-    prepped: &mut Statement<'conn>,
-    result_formats: &[FieldFormat],
-    cmd: &ParsedCmd,
-    open_tx: &mut OpenTx,
-    max_rows: usize,
-    back_tx: &Sender<BackendResponse>,
-) -> Result<(), QueryError> {
-    // TODO: maybe we don't need to recompute this...
-    let mut fields = vec![];
-    for (i, col) in prepped.columns().into_iter().enumerate() {
-        trace!("col decl_type: {:?}", col.decl_type());
-        let col_type = name_to_type(col.decl_type().unwrap_or("any"))?;
-
-        fields.push(FieldInfo::new(
-            col.name().to_string(),
-            None,
-            None,
-            col_type,
-            result_formats.get(i).copied().unwrap_or(FieldFormat::Text),
-        ));
-    }
-
-    trace!("fields: {fields:?}");
-
-    let schema = Arc::new(fields);
-
-    // we need to know because we'll commit it right away
-    let mut opened_implicit_tx = false;
-
-    if open_tx.is_ended() {
-        if !cmd.is_begin() && !prepped.readonly() {
-            // NOT in a tx and statement mutates DB...
-            conn.execute_batch("BEGIN")?;
-
-            open_tx.start_implicit();
-            opened_implicit_tx = true;
-        } else if cmd.is_begin() {
-            conn.execute_batch("BEGIN")?;
-            open_tx.start_explicit();
-        }
-    }
-
-    let mut count = 0;
-
-    if cmd.is_commit() {
-        let _permit = open_tx.end();
-        handle_commit(agent, conn)?;
-    } else {
-        if !open_tx.is_writing() && !prepped.readonly() {
-            trace!("statement writes, acquiring permit...");
-            open_tx.set_write_permit(agent.write_permit_blocking()?);
-        }
-        let mut rows = prepped.raw_query();
-        loop {
-            if count >= max_rows {
-                trace!("attained max rows");
-                // forget the Rows iterator here so as to not reset the statement!
-                std::mem::forget(rows);
-                back_tx
-                    .blocking_send(
-                        (
-                            PgWireBackendMessage::PortalSuspended(PortalSuspended::new()),
-                            true,
-                        )
-                            .into(),
-                    )
-                    .map_err(|_| QueryError::BackendResponseSendFailed)?;
-                return Ok(());
-            }
-
-            let row = match rows.next()? {
-                Some(row) => {
-                    trace!("got a row: {row:?}");
-                    row
-                }
-                None => {
-                    trace!("done w/ rows");
-                    break;
-                }
-            };
-
-            count += 1;
-
-            let mut encoder = DataRowEncoder::new(schema.clone());
-            for (idx, field) in schema.iter().enumerate() {
-                trace!("processing field: {field:?}");
-                let format = *field.format();
-                match field.datatype() {
-                    &Type::ANY => {
-                        let data = row.get_ref_unwrap(idx);
-                        match data {
-                            ValueRef::Null => encoder
-                                .encode_field_with_type_and_format(&None::<i8>, &Type::ANY, format)
-                                .unwrap(),
-                            ValueRef::Integer(i) => {
-                                encoder
-                                    .encode_field_with_type_and_format(&i, &Type::INT8, format)
-                                    .unwrap();
-                            }
-                            ValueRef::Real(f) => {
-                                encoder
-                                    .encode_field_with_type_and_format(&f, &Type::FLOAT8, format)
-                                    .unwrap();
-                            }
-                            ValueRef::Text(t) => {
-                                encoder
-                                    .encode_field_with_type_and_format(
-                                        &String::from_utf8_lossy(t).as_ref(),
-                                        &Type::TEXT,
-                                        format,
-                                    )
-                                    .unwrap();
-                            }
-                            ValueRef::Blob(b) => {
-                                encoder
-                                    .encode_field_with_type_and_format(&b, &Type::BYTEA, format)
-                                    .unwrap();
-                            }
-                        }
-                    }
-                    t @ &Type::INT8 => {
-                        encoder
-                            .encode_field_with_type_and_format(
-                                &row.get::<_, Option<i64>>(idx)?,
-                                t,
-                                format,
-                            )
-                            .unwrap();
-                    }
-                    t @ &Type::TIMESTAMP => {
-                        encoder
-                            .encode_field_with_type_and_format(
-                                &row.get::<_, Option<NaiveDateTime>>(idx)?,
-                                t,
-                                format,
-                            )
-                            .unwrap();
-                    }
-                    t @ &Type::VARCHAR | t @ &Type::TEXT | t @ &Type::JSON => {
-                        encoder
-                            .encode_field_with_type_and_format(
-                                &row.get::<_, Option<String>>(idx)?,
-                                t,
-                                format,
-                            )
-                            .unwrap();
-                    }
-                    t @ &Type::BYTEA | t @ &Type::JSONB => {
-                        encoder
-                            .encode_field_with_type_and_format(
-                                &row.get::<_, Option<Vec<u8>>>(idx)?,
-                                t,
-                                format,
-                            )
-                            .unwrap();
-                    }
-                    t @ &Type::FLOAT8 => {
-                        encoder
-                            .encode_field_with_type_and_format(
-                                &row.get::<_, Option<f64>>(idx)?,
-                                t,
-                                format,
-                            )
-                            .unwrap();
-                    }
-                    _ => return Err(UnsupportedSqliteToPostgresType(field.name().clone()).into()),
-                }
-            }
-
-            let data_row = encoder.finish()?;
-            back_tx
-                .blocking_send((PgWireBackendMessage::DataRow(data_row), false).into())
-                .map_err(|_| QueryError::BackendResponseSendFailed)?;
-        }
-
-        if opened_implicit_tx {
-            let _permit = open_tx.end();
-            handle_commit(agent, conn)?;
-        }
-    }
-
-    let tag = cmd.tag();
-    trace!("done w/ rows, computing tag: {tag:?}");
-
-    // done!
-    back_tx
-        .blocking_send(
-            (
-                PgWireBackendMessage::CommandComplete(tag.into_command_complete(count, conn)),
-                true,
-            )
-                .into(),
-        )
-        .map_err(|_| QueryError::BackendResponseSendFailed)?;
-
-    Ok(())
-}
-
-fn handle_query(
-    agent: &Agent,
-    conn: &Connection,
-    cmd: &ParsedCmd,
-    open_tx: &mut OpenTx,
-    back_tx: &Sender<BackendResponse>,
-    send_row_desc: bool,
-) -> Result<(), QueryError> {
-    if cmd.is_show() {
-        back_tx
-            .blocking_send(
-                (
-                    PgWireBackendMessage::CommandComplete(CommandComplete::new("SHOW".into())),
-                    true,
-                )
-                    .into(),
-            )
-            .map_err(|_| QueryError::BackendResponseSendFailed)?;
-        return Ok(());
-    }
-
-    if cmd.is_set() {
-        back_tx
-            .blocking_send(
-                (
-                    PgWireBackendMessage::CommandComplete(CommandComplete::new("SET".into())),
-                    true,
-                )
-                    .into(),
-            )
-            .map_err(|_| QueryError::BackendResponseSendFailed)?;
-        return Ok(());
-    }
-
-    // need to start an implicit transaction
-    if open_tx.is_ended() && !cmd.is_begin() {
-        conn.execute_batch("BEGIN")?;
-        trace!("started IMPLICIT tx");
-        open_tx.start_implicit();
-    } else if open_tx.is_implicit() && cmd.is_begin() {
-        trace!("committing IMPLICIT tx");
-        let _permit = open_tx.end();
-
-        handle_commit(agent, conn)?;
-        trace!("committed IMPLICIT tx");
-    }
-
-    let count = if cmd.is_begin() {
-        conn.execute_batch("BEGIN")?;
-        open_tx.start_explicit();
-        0
-    } else if cmd.is_commit() {
-        let _permit = open_tx.end();
-        handle_commit(agent, conn)?;
-        0
-    } else if cmd.is_rollback() {
-        let _permit = open_tx.end();
-        conn.execute_batch("ROLLBACK")?;
-        0
-    } else {
-        let mut prepped = if cmd.is_pg() {
-            return Err(QueryError::NotSqlite);
-        } else {
-            conn.prepare(&cmd.to_string())?
-        };
-
-        let mut fields = vec![];
-        for col in prepped.columns() {
-            let col_type = name_to_type(col.decl_type().unwrap_or("text"))?;
-            fields.push(FieldInfo::new(
-                col.name().to_string(),
-                None,
-                None,
-                col_type,
-                FieldFormat::Text,
-            ));
-        }
-
-        if send_row_desc {
-            back_tx
-                .blocking_send(
-                    (
-                        PgWireBackendMessage::RowDescription(RowDescription::new(
-                            fields.iter().map(Into::into).collect(),
-                        )),
-                        true,
-                    )
-                        .into(),
-                )
-                .map_err(|_| QueryError::BackendResponseSendFailed)?;
-        }
-
-        let schema = Arc::new(fields);
-
-        if !open_tx.is_writing() && !prepped.readonly() {
-            trace!("query statement writes, acquiring permit...");
-            open_tx.set_write_permit(agent.write_permit_blocking()?);
-        }
-
-        let mut rows = prepped.raw_query();
-        let ncols = schema.len();
-
-        let mut count = 0;
-        while let Some(row) = rows.next()? {
-            count += 1;
-            let mut encoder = DataRowEncoder::new(schema.clone());
-            for idx in 0..ncols {
-                let data = row.get_ref_unwrap::<usize>(idx);
-                match data {
-                    ValueRef::Null => encoder.encode_field(&None::<i8>).unwrap(),
-                    ValueRef::Integer(i) => {
-                        encoder.encode_field(&i).unwrap();
-                    }
-                    ValueRef::Real(f) => {
-                        encoder.encode_field(&f).unwrap();
-                    }
-                    ValueRef::Text(t) => {
-                        encoder
-                            .encode_field(&String::from_utf8_lossy(t).as_ref())
-                            .unwrap();
-                    }
-                    ValueRef::Blob(b) => {
-                        encoder.encode_field(&b).unwrap();
-                    }
-                }
-            }
-            let data_row = encoder.finish()?;
-            back_tx
-                .blocking_send((PgWireBackendMessage::DataRow(data_row), false).into())
-                .map_err(|_| QueryError::BackendResponseSendFailed)?;
-        }
-        count
-    };
-
-    back_tx
-        .blocking_send(
-            (
-                PgWireBackendMessage::CommandComplete(cmd.tag().into_command_complete(count, conn)),
-                true,
-            )
-                .into(),
-        )
-        .map_err(|_| QueryError::BackendResponseSendFailed)?;
-
-    if cmd.is_begin() {
-        trace!("setting EXPLICIT tx");
-        // explicit tx
-        open_tx.start_explicit();
-    }
-
-    Ok(())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2275,142 +2394,6 @@ fn name_to_type(name: &str) -> Result<Type, UnsupportedSqliteToPostgresType> {
         "FLOAT" => Type::FLOAT8,
         _ => return Err(UnsupportedSqliteToPostgresType(name.to_string())),
     })
-}
-
-fn handle_commit(agent: &Agent, conn: &Connection) -> rusqlite::Result<()> {
-    trace!("HANDLE COMMIT");
-    let actor_id = agent.actor_id();
-
-    let ts = Timestamp::from(agent.clock().new_timestamp());
-
-    let db_version: CrsqlDbVersion = conn
-        .prepare_cached("SELECT crsql_next_db_version()")?
-        .query_row((), |row| row.get(0))?;
-
-    let has_changes: bool = conn
-        .prepare_cached("SELECT EXISTS(SELECT 1 FROM crsql_changes WHERE db_version = ?);")?
-        .query_row([db_version], |row| row.get(0))?;
-
-    if !has_changes {
-        conn.execute_batch("COMMIT")?;
-        return Ok(());
-    }
-
-    let booked = {
-        agent
-            .bookie()
-            .blocking_write("handle_write_tx(for_actor)")
-            .for_actor(actor_id)
-    };
-
-    let last_seq: CrsqlSeq = conn
-        .prepare_cached("SELECT MAX(seq) FROM crsql_changes WHERE db_version = ?")?
-        .query_row([db_version], |row| row.get(0))?;
-
-    let mut book_writer = booked.blocking_write("handle_write_tx(book_writer)");
-
-    let last_version = book_writer.last().unwrap_or_default();
-    trace!("last_version: {last_version}");
-    let version = last_version + 1;
-    trace!("version: {version}");
-
-    conn.prepare_cached(
-        r#"
-            INSERT INTO __corro_bookkeeping (actor_id, start_version, db_version, last_seq, ts)
-                VALUES (:actor_id, :start_version, :db_version, :last_seq, :ts);
-        "#,
-    )?
-    .execute(named_params! {
-        ":actor_id": actor_id,
-        ":start_version": version,
-        ":db_version": db_version,
-        ":last_seq": last_seq,
-        ":ts": ts
-    })?;
-
-    debug!(%actor_id, %version, %db_version, "inserted local bookkeeping row!");
-
-    conn.execute_batch("COMMIT")?;
-
-    trace!("committed tx, db_version: {db_version}, last_seq: {last_seq:?}");
-
-    book_writer.insert(
-        version,
-        KnownDbVersion::Current(CurrentVersion {
-            db_version,
-            last_seq,
-            ts,
-        }),
-    );
-
-    drop(book_writer);
-
-    spawn_counted({
-        let agent = agent.clone();
-        async move {
-            let conn = agent.pool().read().await?;
-
-            block_in_place(|| {
-                // TODO: make this more generic so both sync and local changes can use it.
-                let mut prepped = conn.prepare_cached(
-                    r#"
-                SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl
-                    FROM crsql_changes
-                    WHERE db_version = ?
-                    ORDER BY seq ASC
-            "#,
-                )?;
-                let rows = prepped.query_map([db_version], row_to_change)?;
-                let chunked =
-                    ChunkedChanges::new(rows, CrsqlSeq(0), last_seq, MAX_CHANGES_BYTE_SIZE);
-                for changes_seqs in chunked {
-                    match changes_seqs {
-                        Ok((changes, seqs)) => {
-                            for (table_name, count) in
-                                changes.iter().counts_by(|change| &change.table)
-                            {
-                                counter!("corro.changes.committed", count as u64, "table" => table_name.to_string(), "source" => "local");
-                            }
-
-                            trace!("broadcasting changes: {changes:?} for seq: {seqs:?}");
-
-                            agent.subs_manager().match_changes(&changes, db_version);
-
-                            let tx_bcast = agent.tx_bcast().clone();
-                            tokio::spawn(async move {
-                                if let Err(e) = tx_bcast
-                                    .send(BroadcastInput::AddBroadcast(BroadcastV1::Change(
-                                        ChangeV1 {
-                                            actor_id,
-                                            changeset: Changeset::Full {
-                                                version,
-                                                changes,
-                                                seqs,
-                                                last_seq,
-                                                ts,
-                                            },
-                                        },
-                                    )))
-                                    .await
-                                {
-                                    error!("could not send change message for broadcast: {e}");
-                                }
-                            });
-                        }
-                        Err(e) => {
-                            error!("could not process crsql change (db_version: {db_version}) for broadcast: {e}");
-                            break;
-                        }
-                    }
-                }
-                Ok::<_, rusqlite::Error>(())
-            })?;
-
-            Ok::<_, BoxError>(())
-        }
-    });
-
-    Ok(())
 }
 
 fn compute_schema(conn: &Connection) -> Result<Schema, SchemaError> {
@@ -3146,6 +3129,7 @@ mod tests {
 
     use chrono::{DateTime, Utc};
     use corro_tests::launch_test_agent;
+    use corro_types::agent::Bookie;
     use spawn::wait_for_all_pending_handles;
     use tokio_postgres::NoTls;
     use tripwire::Tripwire;

--- a/crates/corro-tests/src/lib.rs
+++ b/crates/corro-tests/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use corro_agent::agent::start_with_config;
 use corro_types::{
-    agent::Agent,
+    agent::{Agent, Bookie},
     config::{Config, ConfigBuilder, ConfigBuilderError},
 };
 use tempfile::TempDir;
@@ -33,6 +33,7 @@ pub const TEST_SCHEMA: &str = r#"
 #[derive(Clone)]
 pub struct TestAgent {
     pub agent: Agent,
+    pub bookie: Bookie,
     pub tmpdir: Arc<TempDir>,
 }
 
@@ -56,7 +57,7 @@ pub async fn launch_test_agent<F: FnOnce(ConfigBuilder) -> Result<Config, Config
 
     let schema_paths = conf.db.schema_paths.clone();
 
-    let agent = start_with_config(conf, tripwire).await?;
+    let (agent, bookie) = start_with_config(conf, tripwire).await?;
 
     {
         let client = corro_client::CorrosionApiClient::new(agent.api_addr());
@@ -65,6 +66,7 @@ pub async fn launch_test_agent<F: FnOnce(ConfigBuilder) -> Result<Config, Config
 
     Ok(TestAgent {
         agent,
+        bookie,
         tmpdir: Arc::new(tmpdir),
     })
 }

--- a/crates/corrosion/src/command/agent.rs
+++ b/crates/corrosion/src/command/agent.rs
@@ -24,12 +24,13 @@ pub async fn run(config: Config, config_path: &Utf8PathBuf) -> eyre::Result<()> 
 
     let (tripwire, tripwire_worker) = tripwire::Tripwire::new_signals();
 
-    let agent = corro_agent::agent::start_with_config(config.clone(), tripwire.clone())
+    let (agent, bookie) = corro_agent::agent::start_with_config(config.clone(), tripwire.clone())
         .await
         .expect("could not start agent");
 
     corro_admin::start_server(
         agent,
+        bookie,
         AdminConfig {
             listen_path: config.admin.uds_path.clone(),
             config_path: config_path.clone(),


### PR DESCRIPTION
Loading the full bookkeeping of versions in memory can be time and resources consuming. This slows down accepting and processing public API endpoints such as transaction, queries, subscriptions, etc. and can create odd-looking behaviour.

This PR tries to spawn as many tasks as possible (all the ones that don't need access to the full bookkeeping), seed `Bookie` and then launch the tasks that need complete in-memory bookkeeping.

This should significantly improve startup times. It should be instantaneous for nodes that don't have any local versions.