### PR TITLE
RFC: Rewrite LEFT JOINs in Corrosion subscriptions

### DIFF
--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -636,18 +636,16 @@ impl Matcher {
                         Some(FromClause {
                             joins: Some(joins), ..
                         }) if idx > 0 => {
-                            match joins.get_mut(idx - 1) {
-                                Some(JoinedSelectTable {
-                                    operator:
-                                        JoinOperator::TypedJoin {
-                                            join_type: join_type @ Some(JoinType::LeftOuter),
-                                            ..
-                                        },
-                                    ..
-                                }) => {
-                                    *join_type = Some(JoinType::Inner);
-                                }
-                                _ => (),
+                            if let Some(JoinedSelectTable {
+                                operator:
+                                    JoinOperator::TypedJoin {
+                                        join_type: join_type @ Some(JoinType::LeftOuter),
+                                        ..
+                                    },
+                                ..
+                            }) = joins.get_mut(idx - 1)
+                            {
+                                *join_type = Some(JoinType::Inner);
                             };
                         }
                         _ => (),


### PR DESCRIPTION
The PR attempts to optimize Corrosion subscriptions with complex queries with `LEFT JOIN`s. Consider the following query:

```
SELECT
    cs.id, cc.status, m.status as machine_state
FROM
    consul_services AS cs
LEFT OUTER JOIN
    machines m ON m.id = cs.instance_id
LEFT OUTER JOIN
    consul_checks AS cc INDEXED BY consul_checks_node_service_id ON cc.node = cs.node AND cc.service_id = cs.id
```

This is a slightly simplified version of the query that `fly-proxy` needs to subscribe to (in real life, `fly-proxy` selects many more columns).

For the given query Corrosion will generate three modified queries (one for each table) to determine whether a particular set of changes matches the subscription or not. Unfortunatelly, due to `LEFT OUTER JOIN`, the modified queries for `machines` and `consul_checks` tables confuse SQLite and it has to do full `consul_services` table scan for each set of changes, which is extremely slow.

For a change in the `machines` table:
```
sqlite> explain query plan SELECT cs.node AS __corro_pk_cs_node, cs.id AS __corro_pk_cs_id, m.id AS __corro_pk_m_id, cc.node AS __corro_pk_cc_node, cc.id AS __corro_pk_cc_id, cs.id AS col_0, cc.status AS col_1, m.status AS col_2 FROM consul_services AS cs LEFT OUTER JOIN machines m ON m.id = cs.instance_id LEFT OUTER JOIN consul_checks AS cc INDEXED BY consul_checks_node_service_id ON cc.node = cs.node AND cc.service_id = cs.id WHERE (m.id) IN __corro_sub.temp_machines;
QUERY PLAN
|--SCAN cs USING INDEX consul_services_instance_id
|--SEARCH m USING PRIMARY KEY (id=?) LEFT-JOIN
|--LIST SUBQUERY 1
|  `--SCAN __corro_sub.temp_machines
`--SEARCH cc USING INDEX consul_checks_node_service_id (node=? AND service_id=?) LEFT-JOIN
```

For a change in the `consul_checks` table:
```
sqlite> explain query plan SELECT cs.node AS __corro_pk_cs_node, cs.id AS __corro_pk_cs_id, m.id AS __corro_pk_m_id, cc.node AS __corro_pk_cc_node, cc.id AS __corro_pk_cc_id, cs.id AS col_0, cc.status AS col_1, m.status AS col_2 FROM consul_services AS cs LEFT OUTER JOIN machines m ON m.id = cs.instance_id LEFT OUTER JOIN consul_checks AS cc INDEXED BY consul_checks_node_service_id ON cc.node = cs.node AND cc.service_id = cs.id WHERE (cc.node, cc.id) IN __corro_sub.temp_consul_checks;
QUERY PLAN
|--SCAN cs USING INDEX consul_services_instance_id
|--SEARCH m USING PRIMARY KEY (id=?) LEFT-JOIN
|--SEARCH cc USING INDEX consul_checks_node_service_id (node=? AND service_id=?) LEFT-JOIN
`--LIST SUBQUERY 1
   `--SCAN __corro_sub.temp_consul_checks
```


This PR modifies the generated queries to use `INNER JOIN` for the table for which the query is generated. This allows SQLite to use the correct indexes:

For a change in the `machines` table:
```
sqlite> explain query plan SELECT cs.node AS __corro_pk_cs_node, cs.id AS __corro_pk_cs_id, m.id AS __corro_pk_m_id, cc.node AS __corro_pk_cc_node, cc.id AS __corro_pk_cc_id, cs.id AS col_0, cc.status AS col_1, m.status AS col_2 FROM consul_services AS cs INNER JOIN machines m ON m.id = cs.instance_id LEFT OUTER JOIN consul_checks AS cc INDEXED BY consul_checks_node_service_id ON cc.node = cs.node AND cc.service_id = cs.id WHERE (m.id) IN __corro_sub.temp_machines;
QUERY PLAN
|--SEARCH m USING PRIMARY KEY (id=?)
|--LIST SUBQUERY 1
|  `--SCAN __corro_sub.temp_machines
|--SEARCH cs USING INDEX consul_services_instance_id (instance_id=?)
`--SEARCH cc USING INDEX consul_checks_node_service_id (node=? AND service_id=?) LEFT-JOIN
```

For a change in the `consul_checks` table:
```
sqlite> explain query plan SELECT cs.node AS __corro_pk_cs_node, cs.id AS __corro_pk_cs_id, m.id AS __corro_pk_m_id, cc.node AS __corro_pk_cc_node, cc.id AS __corro_pk_cc_id, cs.id AS col_0, cc.status AS col_1, m.status AS col_2 FROM consul_services AS cs LEFT OUTER JOIN machines m ON m.id = cs.instance_id INNER JOIN consul_checks AS cc INDEXED BY consul_checks_node_service_id ON cc.node = cs.node AND cc.service_id = cs.id WHERE (cc.node, cc.id) IN __corro_sub.temp_consul_checks;
QUERY PLAN
|--SEARCH cc USING INDEX consul_checks_node_service_id (node=?)
|--LIST SUBQUERY 1
|  `--SCAN __corro_sub.temp_consul_checks
|--LIST SUBQUERY 1
|  `--SCAN __corro_sub.temp_consul_checks
|--SEARCH cs USING PRIMARY KEY (node=? AND id=?)
`--SEARCH m USING PRIMARY KEY (id=?) LEFT-JOIN
```

Since the modified queries are run over a subset of data from a specific table only, I believe switching `LEFT OUTER JOIN` to `INNER JOIN` does not change the semantics of the query at all. E.g. for a set of changes in the `machines` table we are only intereset in the services that have corresponding machines.
