### PR TITLE
Configurable client addr for outgoing socket bind

### DIFF
--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -315,11 +315,7 @@ async fn build_quinn_client_config(config: &GossipConfig) -> eyre::Result<quinn:
 pub async fn gossip_client_endpoint(config: &GossipConfig) -> eyre::Result<quinn::Endpoint> {
     let client_config = build_quinn_client_config(config).await?;
 
-    let client_bind_addr = match config.bind_addr {
-        SocketAddr::V4(_) => "0.0.0.0:0".parse()?,
-        SocketAddr::V6(_) => "[::]:0".parse()?,
-    };
-    let mut client = quinn::Endpoint::client(client_bind_addr)?;
+    let mut client = quinn::Endpoint::client(SocketAddr::from((config.bind_addr.ip(), 0)))?;
 
     client.set_default_client_config(client_config);
     Ok(client)

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -315,7 +315,7 @@ async fn build_quinn_client_config(config: &GossipConfig) -> eyre::Result<quinn:
 pub async fn gossip_client_endpoint(config: &GossipConfig) -> eyre::Result<quinn::Endpoint> {
     let client_config = build_quinn_client_config(config).await?;
 
-    let mut client = quinn::Endpoint::client(SocketAddr::from((config.bind_addr.ip(), 0)))?;
+    let mut client = quinn::Endpoint::client(config.client_addr)?;
 
     client.set_default_client_config(client_config);
     Ok(client)
@@ -1540,7 +1540,7 @@ mod tests {
     use corro_types::{
         api::{ColumnName, TableName},
         base::CrsqlDbVersion,
-        config::{Config, TlsConfig},
+        config::{Config, TlsConfig, DEFAULT_GOSSIP_CLIENT_ADDR},
         pubsub::pack_columns,
         tls::{generate_ca, generate_client_cert, generate_server_cert},
     };
@@ -1788,6 +1788,7 @@ mod tests {
 
         let gossip_config = GossipConfig {
             bind_addr: "127.0.0.1:0".parse()?,
+            client_addr: DEFAULT_GOSSIP_CLIENT_ADDR,
             external_addr: None,
             bootstrap: vec![],
             tls: Some(TlsConfig {

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -109,6 +109,8 @@ pub struct GossipConfig {
     #[serde(alias = "addr")]
     pub bind_addr: SocketAddr,
     pub external_addr: Option<SocketAddr>,
+    #[serde(default = "default_gossip_client_addr")]
+    pub client_addr: SocketAddr,
     #[serde(default)]
     pub bootstrap: Vec<String>,
     #[serde(default)]
@@ -125,6 +127,13 @@ pub struct GossipConfig {
 
 fn default_gossip_idle_timeout() -> u32 {
     DEFAULT_GOSSIP_IDLE_TIMEOUT
+}
+
+pub const DEFAULT_GOSSIP_CLIENT_ADDR: SocketAddr =
+    SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0u16, 0, 0));
+
+fn default_gossip_client_addr() -> SocketAddr {
+    DEFAULT_GOSSIP_CLIENT_ADDR
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -295,6 +304,7 @@ impl ConfigBuilder {
                     .gossip_addr
                     .ok_or(ConfigBuilderError::GossipAddrRequired)?,
                 external_addr: self.external_addr,
+                client_addr: default_gossip_client_addr(),
                 bootstrap: self.bootstrap.unwrap_or_default(),
                 plaintext: self.tls.is_none(),
                 tls: self.tls,


### PR DESCRIPTION
Using an unspecified IP can sometimes cause issues, especially if your hosts have a lot of network interfaces. With this configuration option, it's possible to set a specific addr or a specific ip with port 0 to keep the pooling features.

Even on hosts with only a few network interface, this can result in faster `sendmmsg` calls.