### PR TITLE
Troubleshooting tools and buffered changes fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -36,7 +36,7 @@ checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.2.9",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -290,7 +290,7 @@ dependencies = [
 name = "backoff"
 version = "0.1.0"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -664,7 +664,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom",
  "once_cell",
  "proc-macro-hack",
  "tiny-keccak",
@@ -751,7 +751,7 @@ dependencies = [
  "http-body",
  "hyper",
  "indexmap 2.1.0",
- "itertools 0.10.5",
+ "itertools",
  "metrics",
  "opentelemetry",
  "parking_lot",
@@ -759,7 +759,7 @@ dependencies = [
  "quinn-plaintext",
  "quinn-proto",
  "quoted-string",
- "rand 0.8.5",
+ "rand",
  "rangemap",
  "rusqlite",
  "rustls",
@@ -853,8 +853,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "nom",
- "rand 0.8.5",
- "random_graphs",
+ "rand",
  "serde",
  "serde_json",
  "thiserror",
@@ -872,7 +871,7 @@ dependencies = [
  "fallible-iterator 0.3.0",
  "futures",
  "hex",
- "itertools 0.10.5",
+ "itertools",
  "metrics",
  "pgwire",
  "postgres-types",
@@ -966,12 +965,12 @@ dependencies = [
  "futures",
  "hex",
  "indexmap 2.1.0",
- "itertools 0.10.5",
+ "itertools",
  "metrics",
  "once_cell",
  "opentelemetry",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "rangemap",
  "rcgen",
  "rusqlite",
@@ -1509,12 +1508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1522,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -1653,24 +1646,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2089,15 +2071,6 @@ checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
@@ -2424,7 +2397,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -2640,7 +2613,7 @@ dependencies = [
  "opentelemetry_api",
  "ordered-float",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde_json",
  "thiserror",
@@ -2715,16 +2688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset",
- "indexmap 1.9.3",
-]
-
-[[package]]
 name = "pgwire"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,7 +2704,7 @@ dependencies = [
  "log",
  "md5",
  "postgres-types",
- "rand 0.8.5",
+ "rand",
  "ring",
  "stringprep",
  "thiserror",
@@ -2778,7 +2741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2848,7 +2811,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -2880,7 +2843,7 @@ checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.10.5",
+ "itertools",
  "predicates-core",
 ]
 
@@ -2966,7 +2929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2982,7 +2945,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "web-sys",
  "winapi",
 ]
@@ -3028,7 +2991,7 @@ version = "0.10.5"
 source = "git+https://github.com/jeromegn/quinn?rev=108f25a6#108f25a6d45ce0c41acf2d87f8d0b2d35fedfbaa"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3069,36 +3032,13 @@ checksum = "5a206a30ce37189d1340e7da2ee0b4d65e342590af676541c23a4f3959ba272e"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3108,16 +3048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3126,29 +3057,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "random_graphs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ace5d2f73bca32195a82a8bf345f274ce4712046de915163c0d8702d9e13fe"
-dependencies = [
- "itertools 0.9.0",
- "num-integer",
- "petgraph",
- "rand 0.7.3",
- "thiserror",
+ "getrandom",
 ]
 
 [[package]]
@@ -3156,6 +3065,9 @@ name = "rangemap"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -4132,7 +4044,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.8.5",
+ "rand",
  "socket2 0.5.5",
  "tokio",
  "tokio-util",
@@ -4250,7 +4162,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -4430,7 +4342,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "thiserror",
  "tinyvec",
@@ -4477,7 +4389,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "thiserror",
  "url",
@@ -4500,7 +4412,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand",
  "serde",
  "spin 0.9.8",
 ]
@@ -4598,7 +4510,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom",
  "serde",
 ]
 
@@ -4648,12 +4560,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ quinn-proto = "0.10.5"
 quinn-plaintext = { version = "0.2.0" }
 quoted-string = "0.6.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
-rangemap = { version = "1.4.0" }
+rangemap = { version = "1.4.0", features = ["serde1"] }
 rcgen = { version = "0.11.1", features = ["x509-parser"] }
 rhai = { version = "1.15.1", features = ["sync"] }
 rusqlite = { version = "0.30.0", features = ["serde_json", "time", "bundled", "uuid", "array", "load_extension", "column_decltype", "vtab", "functions", "chrono"] }

--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -300,8 +300,10 @@ async fn handle_conn(
                                 KnownVersion::Cleared => {
                                     Ok(serde_json::Value::String("cleared".into()))
                                 }
-                                KnownVersion::Current(known) => serde_json::to_value(known),
-                                KnownVersion::Partial(known) => serde_json::to_value(known),
+                                KnownVersion::Current(known) => serde_json::to_value(known)
+                                    .map(|v| serde_json::json!({"current": v})),
+                                KnownVersion::Partial(known) => serde_json::to_value(known)
+                                    .map(|v| serde_json::json!({"partial": v})),
                             },
                             None => Ok(serde_json::Value::Null),
                         }

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -690,8 +690,14 @@ mod tests {
         let tmpdir = tempfile::tempdir()?;
 
         let conn = rusqlite::Connection::open(tmpdir.path().join("db.sqlite"))?;
+        let pragma_value = 12345u64;
+        conn.pragma_update(None, "busy_timeout", pragma_value)?;
 
         db_cleanup(&conn)?;
+        assert_eq!(
+            conn.pragma_query_value(None, "busy_timeout", |row| row.get::<_, u64>(0))?,
+            pragma_value
+        );
 
         Ok(())
     }

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -379,7 +379,7 @@ pub async fn handle_changes(
     mut rx_changes: CorroReceiver<(ChangeV1, ChangeSource)>,
     mut tripwire: Tripwire,
 ) {
-    const MIN_CHANGES_CHUNK: usize = 2000;
+    const MIN_CHANGES_CHUNK: usize = 500;
     let mut queue: VecDeque<(ChangeV1, ChangeSource, Instant)> = VecDeque::new();
     let mut buf = vec![];
     let mut count = 0;

--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -203,10 +203,10 @@ async fn run(agent: Agent, opts: AgentOptions) -> eyre::Result<Bookie> {
         tripwire.clone(),
     ));
 
-    tokio::spawn(util::clear_overwritten_versions(
-        agent.clone(),
-        bookie.clone(),
-    ));
+    // tokio::spawn(util::clear_overwritten_versions(
+    //     agent.clone(),
+    //     bookie.clone(),
+    // ));
 
     Ok(bookie)
 }

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -610,7 +610,7 @@ pub async fn clear_buffered_meta_loop(
     }
 }
 
-const MAX_EMPTIES_BATCH_SIZE: u64 = 10;
+const MAX_EMPTIES_BATCH_SIZE: u64 = 40;
 
 /// Clear empty versions from the database in chunks to avoid locking
 /// the database for too long.

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -1312,10 +1312,7 @@ pub fn process_incomplete_version(
             "
             DELETE FROM __corro_seq_bookkeeping
                 WHERE site_id = :actor_id AND version = :version AND
-                (
-                    -- start_seq is between start and end of range AND no end_seq
-                    ( start_seq BETWEEN :start AND :end AND end_seq IS NULL ) OR
-                    
+                (   
                     -- start_seq and end_seq are within the range
                     ( start_seq >= :start AND end_seq <= :end ) OR
 
@@ -1323,7 +1320,7 @@ pub fn process_incomplete_version(
                     ( start_seq <= :end AND end_seq >= :end ) OR
 
                     -- start_seq = end + 1 (to collapse ranges)
-                    ( start_seq = :end + 1 AND end_seq IS NOT NULL ) OR
+                    ( start_seq = :end + 1) OR
 
                     -- end_seq = start - 1 (to collapse ranges)
                     ( end_seq = :start - 1 )
@@ -1340,7 +1337,7 @@ pub fn process_incomplete_version(
             ],
             |row| {
                 let start = row.get(0)?;
-                Ok(start..=row.get::<_, Option<CrsqlSeq>>(1)?.unwrap_or(start))
+                Ok(start..=row.get(1)?)
             },
         )
         .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -1328,6 +1328,7 @@ pub fn process_incomplete_version(
                     -- end_seq = start - 1 (to collapse ranges)
                     ( end_seq = :start - 1 )
                 )
+                RETURNING start_seq, end_seq
         ",
         )?
         .query_map(

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -572,10 +572,12 @@ pub async fn clear_buffered_meta_loop(
 
                         // TODO: delete buffered changes from deleted sequences only (maybe, it's kind of hard and may not be necessary)
 
+                        // sub query required due to DELETE and LIMIT interaction
                         let seq_count = tx
                             .prepare_cached("DELETE FROM __corro_seq_bookkeeping WHERE (site_id, version, start_seq) IN (SELECT site_id, version, start_seq FROM __corro_seq_bookkeeping WHERE site_id = ? AND version >= ? AND version <= ? LIMIT ?)")?
                             .execute(params![actor_id, versions.start(), versions.end(), TO_CLEAR_COUNT])?;
 
+                        // sub query required due to DELETE and LIMIT interaction
                         let buf_count = tx
                             .prepare_cached("DELETE FROM __corro_buffered_changes WHERE (site_id, db_version, version, seq) IN (SELECT site_id, db_version, version, seq FROM __corro_buffered_changes WHERE site_id = ? AND version >= ? AND version <= ? LIMIT ?)")?
                             .execute(params![actor_id, versions.start(), versions.end(), TO_CLEAR_COUNT])?;
@@ -608,6 +610,8 @@ pub async fn clear_buffered_meta_loop(
     }
 }
 
+const MAX_EMPTIES_BATCH_SIZE: u64 = 100;
+
 /// Clear empty versions from the database in chunks to avoid locking
 /// the database for too long.
 ///
@@ -625,12 +629,17 @@ pub async fn write_empties_loop(
     let next_empties_check = tokio::time::sleep(CHECK_EMPTIES_TO_INSERT_AFTER);
     tokio::pin!(next_empties_check);
 
+    let mut count = 0;
+
     loop {
         tokio::select! {
             maybe_empty = rx_empty.recv() => match maybe_empty {
                 Some((actor_id, versions)) => {
                     empties.entry(actor_id).or_default().insert(versions);
-                    continue;
+                    count += 1;
+                    if count < MAX_EMPTIES_BATCH_SIZE {
+                        continue;
+                    }
                 },
                 None => {
                     debug!("empties queue is done");
@@ -653,6 +662,8 @@ pub async fn write_empties_loop(
             process_completed_empties(agent.clone(), empties_to_process)
                 .inspect_err(|e| error!("could not process empties: {e}")),
         );
+
+        count = 0;
     }
     info!("Draining empty versions to process...");
     // drain empties channel

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -610,7 +610,7 @@ pub async fn clear_buffered_meta_loop(
     }
 }
 
-const MAX_EMPTIES_BATCH_SIZE: u64 = 100;
+const MAX_EMPTIES_BATCH_SIZE: u64 = 10;
 
 /// Clear empty versions from the database in chunks to avoid locking
 /// the database for too long.

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -523,13 +523,13 @@ pub fn runtime_loop(
                 let (member_count, max_transmissions) = {
                     let config = config.read();
                     let members = agent.members().read();
+                    let count = members.states.len();
                     let ring0_count = members.ring0(agent.cluster_id()).count();
                     let max_transmissions = config.max_transmissions.get();
                     (
                         std::cmp::max(
                             config.num_indirect_probes.get(),
-                            (cluster_size.load(Ordering::Acquire) as usize - ring0_count)
-                                / (max_transmissions as usize * 10),
+                            (count - ring0_count) / (max_transmissions as usize * 10),
                         ),
                         max_transmissions,
                     )

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -264,7 +264,7 @@ fn index_bookkeeping_ranges(tx: &Transaction) -> rusqlite::Result<()> {
         -- we often query these columns
         -- creating them will make SQLite use covering indexes
         CREATE UNIQUE INDEX __corro_bookkeeping_actor_id_start_version_end_version ON __corro_bookkeeping (actor_id, start_version, end_version);
-        CREATE UNIQUE INDEX __corro_seq_bookkeeping_site_id_version_start_seq_end_seq ON __corro_bookkeeping (site_id, version, start_seq, end_seq);
+        CREATE UNIQUE INDEX __corro_seq_bookkeeping_site_id_version_start_seq_end_seq ON __corro_seq_bookkeeping (site_id, version, start_seq, end_seq);
     "#,
     )
 }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -961,7 +961,7 @@ impl Drop for LockTracker {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CurrentVersion {
     // cr-sqlite db version
     pub db_version: CrsqlDbVersion,
@@ -971,7 +971,7 @@ pub struct CurrentVersion {
     pub ts: Timestamp,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PartialVersion {
     // range of sequences recorded
     pub seqs: RangeInclusiveSet<CrsqlSeq>,

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -252,21 +252,9 @@ pub fn migrate(conn: &mut Connection) -> rusqlite::Result<()> {
         Box::new(create_corro_subs as fn(&Transaction) -> rusqlite::Result<()>),
         Box::new(refactor_corro_members as fn(&Transaction) -> rusqlite::Result<()>),
         Box::new(crsqlite_v0_16_migration as fn(&Transaction) -> rusqlite::Result<()>),
-        Box::new(index_bookkeeping_ranges as fn(&Transaction) -> rusqlite::Result<()>),
     ];
 
     crate::sqlite::migrate(conn, migrations)
-}
-
-fn index_bookkeeping_ranges(tx: &Transaction) -> rusqlite::Result<()> {
-    tx.execute_batch(
-        r#"
-        -- we often query these columns
-        -- creating them will make SQLite use covering indexes
-        CREATE UNIQUE INDEX __corro_bookkeeping_actor_id_start_version_end_version ON __corro_bookkeeping (actor_id, start_version, end_version);
-        CREATE UNIQUE INDEX __corro_seq_bookkeeping_site_id_version_start_seq_end_seq ON __corro_seq_bookkeeping (site_id, version, start_seq, end_seq);
-    "#,
-    )
 }
 
 // since crsqlite 0.16, site_id is NOT NULL in clock tables

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -252,9 +252,21 @@ pub fn migrate(conn: &mut Connection) -> rusqlite::Result<()> {
         Box::new(create_corro_subs as fn(&Transaction) -> rusqlite::Result<()>),
         Box::new(refactor_corro_members as fn(&Transaction) -> rusqlite::Result<()>),
         Box::new(crsqlite_v0_16_migration as fn(&Transaction) -> rusqlite::Result<()>),
+        Box::new(index_bookkeeping_ranges as fn(&Transaction) -> rusqlite::Result<()>),
     ];
 
     crate::sqlite::migrate(conn, migrations)
+}
+
+fn index_bookkeeping_ranges(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(
+        r#"
+        -- we often query these columns
+        -- creating them will make SQLite use covering indexes
+        CREATE UNIQUE INDEX __corro_bookkeeping_actor_id_start_version_end_version ON __corro_bookkeeping (actor_id, start_version, end_version);
+        CREATE UNIQUE INDEX __corro_seq_bookkeeping_site_id_version_start_seq_end_seq ON __corro_bookkeeping (site_id, version, start_seq, end_seq);
+    "#,
+    )
 }
 
 // since crsqlite 0.16, site_id is NOT NULL in clock tables


### PR DESCRIPTION
Whew...

- Adds a command `actor version <actor id> <version>` to inspect the state of a version in-memory.
- Fixes a mistaken SQL query meant to squash `__corro_seq_bookkeeping` rows (forgot a `RETURNING` on the `DELETE`).
- Disables detection of cleared versions for now
- Changes the `busy_timeout` before truncating the WAL periodically and then restores it.
- Tweaks a few values for processing changes more efficiently (should be made configurable)