### PR TITLE
Apply the same optimizations to LEFT JOINs in subs

### DIFF
--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -639,7 +639,8 @@ impl Matcher {
                             if let Some(JoinedSelectTable {
                                 operator:
                                     JoinOperator::TypedJoin {
-                                        join_type: join_type @ Some(JoinType::LeftOuter),
+                                        join_type:
+                                            join_type @ Some(JoinType::LeftOuter | JoinType::Left),
                                         ..
                                     },
                                 ..


### PR DESCRIPTION
They are semantically the same as LEFT OUTER JOINs, but the parser
creates separate tokens for them.
