### PR TITLE
Restore improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "spawn",
  "sqlite3-restore",
  "tempfile",
+ "thiserror",
  "tikv-jemallocator",
  "time",
  "tokio",

--- a/crates/corrosion/Cargo.toml
+++ b/crates/corrosion/Cargo.toml
@@ -37,6 +37,7 @@ shellwords = { version = "1" }
 spawn = { path = "../spawn" }
 sqlite3-restore = { path = "../sqlite3-restore" }
 tempfile = { workspace = true }
+thiserror = { workspace = true }
 tikv-jemallocator = "0.5"
 time = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
- Delete all subscriptions on restore (before starting node)
- `corrosion consul sync` should exit with a failure if it gets a sqlite-caused error
- When starting back up, queue the buffered changes to apply, asynchronously so as to not block startup