### PR TITLE
Correct storing of empty versions

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export RUST_LOG=info,corro=debug
 
 # Tests (with coverage + generating JUnit XML report)
 export NEXTEST_PROFILE=ci

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -843,6 +843,8 @@ async fn large_tx_sync() -> eyre::Result<()> {
         );
     }
 
+    println!("now waiting for all futures to end");
+
     tripwire_tx.send(()).await.ok();
     tripwire_worker.await;
     wait_for_all_pending_handles().await;
@@ -1275,7 +1277,6 @@ fn test_store_empty_changeset() -> eyre::Result<()> {
             end_version: Some(Version(14))
         }
     );
-
 
     // empties multiple non-empty versions (12 and 13) and touches already emptied version (14)
     {

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -982,6 +982,7 @@ async fn many_small_changes() -> eyre::Result<()> {
 
 #[test]
 fn test_store_empty_changeset() -> eyre::Result<()> {
+    _ = tracing_subscriber::fmt::try_init();
     let mut conn = CrConn::init(rusqlite::Connection::open_in_memory()?)?;
 
     corro_types::sqlite::setup_conn(&mut conn)?;
@@ -1386,6 +1387,282 @@ fn test_store_empty_changeset() -> eyre::Result<()> {
             actor_id,
             start_version: Version(1),
             end_version: Some(Version(23))
+        }
+    );
+
+    // live version after empty range
+
+    conn.execute(
+        "INSERT INTO __corro_bookkeeping (actor_id, start_version) VALUES (?, 24)",
+        [actor_id],
+    )?;
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(15)..=Version(23))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    let rows = conn
+        .prepare("SELECT actor_id, start_version, end_version FROM __corro_bookkeeping")?
+        .query_map([], |row| {
+            Ok(CorroBook {
+                actor_id: row.get(0)?,
+                start_version: row.get(1)?,
+                end_version: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+    println!("rows: {rows:?}");
+
+    assert_eq!(rows.len(), 2);
+
+    assert_eq!(
+        rows[0],
+        CorroBook {
+            actor_id,
+            start_version: Version(1),
+            end_version: Some(Version(23))
+        }
+    );
+
+    assert_eq!(
+        rows[1],
+        CorroBook {
+            actor_id,
+            start_version: Version(24),
+            end_version: None
+        }
+    );
+
+    // live version before empty range
+
+    conn.execute(
+        "UPDATE __corro_bookkeeping SET start_version = 2 WHERE actor_id = ? AND start_version = 1",
+        [actor_id],
+    )?;
+
+    conn.execute(
+        "INSERT INTO __corro_bookkeeping (actor_id, start_version) VALUES (?, 1)",
+        [actor_id],
+    )?;
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(15)..=Version(23))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    let rows = conn
+        .prepare("SELECT actor_id, start_version, end_version FROM __corro_bookkeeping ORDER BY start_version ASC")?
+        .query_map([], |row| {
+            Ok(CorroBook {
+                actor_id: row.get(0)?,
+                start_version: row.get(1)?,
+                end_version: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+    println!("rows: {rows:?}");
+
+    assert_eq!(rows.len(), 3);
+
+    assert_eq!(
+        rows[0],
+        CorroBook {
+            actor_id,
+            start_version: Version(1),
+            end_version: None
+        }
+    );
+
+    assert_eq!(
+        rows[1],
+        CorroBook {
+            actor_id,
+            start_version: Version(2),
+            end_version: Some(Version(23))
+        }
+    );
+
+    assert_eq!(
+        rows[2],
+        CorroBook {
+            actor_id,
+            start_version: Version(24),
+            end_version: None
+        }
+    );
+
+    // live version after empty range, with a gap
+
+    conn.execute(
+        "INSERT INTO __corro_bookkeeping (actor_id, start_version) VALUES (?, 29)",
+        [actor_id],
+    )?;
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(1)..=Version(24))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    let rows = conn
+        .prepare("SELECT actor_id, start_version, end_version FROM __corro_bookkeeping")?
+        .query_map([], |row| {
+            Ok(CorroBook {
+                actor_id: row.get(0)?,
+                start_version: row.get(1)?,
+                end_version: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+    println!("rows: {rows:?}");
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(26)..=Version(27))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    let rows = conn
+        .prepare("SELECT actor_id, start_version, end_version FROM __corro_bookkeeping")?
+        .query_map([], |row| {
+            Ok(CorroBook {
+                actor_id: row.get(0)?,
+                start_version: row.get(1)?,
+                end_version: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+    println!("rows: {rows:?}");
+
+    assert_eq!(rows.len(), 3);
+
+    assert_eq!(
+        rows[0],
+        CorroBook {
+            actor_id,
+            start_version: Version(1),
+            end_version: Some(Version(24))
+        }
+    );
+
+    assert_eq!(
+        rows[1],
+        CorroBook {
+            actor_id,
+            start_version: Version(26),
+            end_version: Some(Version(27))
+        }
+    );
+
+    assert_eq!(
+        rows[2],
+        CorroBook {
+            actor_id,
+            start_version: Version(29),
+            end_version: None
+        }
+    );
+
+    // live version before empty range, with a gap
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(1)..=Version(29))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(40)..=Version(45))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    {
+        let tx = conn.transaction()?;
+        assert_eq!(
+            store_empty_changeset(&tx, actor_id, Version(35)..=Version(37))?,
+            1
+        );
+        tx.commit()?;
+    }
+
+    let rows = conn
+        .prepare("SELECT actor_id, start_version, end_version FROM __corro_bookkeeping")?
+        .query_map([], |row| {
+            Ok(CorroBook {
+                actor_id: row.get(0)?,
+                start_version: row.get(1)?,
+                end_version: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+    println!("rows: {rows:?}");
+
+    let rows = conn
+        .prepare("SELECT actor_id, start_version, end_version FROM __corro_bookkeeping")?
+        .query_map([], |row| {
+            Ok(CorroBook {
+                actor_id: row.get(0)?,
+                start_version: row.get(1)?,
+                end_version: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<rusqlite::Result<Vec<_>>>())?;
+
+    println!("rows: {rows:?}");
+
+    assert_eq!(rows.len(), 3);
+
+    assert_eq!(
+        rows[0],
+        CorroBook {
+            actor_id,
+            start_version: Version(1),
+            end_version: Some(Version(29))
+        }
+    );
+
+    assert_eq!(
+        rows[1],
+        CorroBook {
+            actor_id,
+            start_version: Version(35),
+            end_version: Some(Version(37))
+        }
+    );
+
+    assert_eq!(
+        rows[2],
+        CorroBook {
+            actor_id,
+            start_version: Version(40),
+            end_version: Some(Version(45))
         }
     );
 

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -676,15 +676,21 @@ async fn process_sync(
         }
 
         let branch = tokio::select! {
-            Some(reqs) = chunked_reqs.next() => {
-                Branch::Reqs(reqs)
+            maybe_reqs = chunked_reqs.next() => match maybe_reqs {
+                Some(reqs) => {
+                    Branch::Reqs(reqs)
+                },
+                None => break
             },
             Some(res) = buf.next() => {
                 res?;
                 continue;
             },
-            Some(chunk) = cleared_chunks.next() => {
-                Branch::Cleared(chunk)
+            maybe_chunk = cleared_chunks.next() => match maybe_chunk {
+                Some(chunk) => {
+                    Branch::Cleared(chunk)
+                },
+                None => break
             },
             else => {
                 break;

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -376,7 +376,8 @@ fn handle_known_version(
             ).optional()?;
 
             let (last_seq, ts) = match last_seq_ts {
-                None | Some((None, _)) | Some((_, None)) => {
+                None => return Ok(None),
+                Some((None, _)) | Some((_, None)) => {
                     // empty version!
                     // TODO: optimize by sending the full range found...
                     // sender.blocking_send(SyncMessage::V1(SyncMessageV1::Changeset(ChangeV1 {

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -367,7 +367,7 @@ fn handle_known_version(
             // this is a read transaction!
             let tx = conn.transaction()?;
 
-            let last_seq_ts: Option<(Option<CrsqlSeq>, Option<Timestamp>)> = tx.prepare_cached("SELECT last_seq, ts FROM __corro_bookkeeping WHERE actor_id = :actor_id AND start_version = :version")?.query_row(
+            let last_seq_ts: Option<(Option<CrsqlSeq>, Option<Timestamp>)> = tx.prepare_cached("SELECT last_seq, ts FROM __corro_bookkeeping WHERE actor_id = :actor_id AND (:version BETWEEN start_version AND COALESCE(end_version, start_version))")?.query_row(
                 named_params! {
                     ":actor_id": actor_id,
                     ":version": version


### PR DESCRIPTION
There was a big consistency issue with storing emptied versions. Some ranges were mistakenly collapsed causing versions to be wrongly marked as cleared.

This PR:
- Adds tests and fixes the inconsistency issues
- Bundles cleared versions so they're sent as chunks, easier to process for sync clients.