### PR TITLE
Remove versions at end of function when computing gaps

### DIFF
--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -1668,10 +1668,9 @@ mod tests {
         insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(1)..=Version(1), Version(4)..=Version(4)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(2)..=Version(3)])?;
 
-        // fillgap
+        // fill gap
         insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(3)..=Version(3), Version(2)..=Version(2)])?;
         expect_gaps(&conn, &bv, &all, vec![])?;
-
 
         // try from an empty state again
         let mut bv = BookedVersions::new(actor_id);

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -1174,7 +1174,7 @@ impl VersionsSnapshot {
             remove_ranges: Default::default(),
         };
 
-        for versions in versions {
+        for versions in versions.clone() {
             // only update the max if it's bigger
             changes.max = cmp::max(changes.max, Some(*versions.end()));
 
@@ -1220,10 +1220,13 @@ impl VersionsSnapshot {
                     changes.remove_ranges.insert(range.clone());
                 }
             }
+        }
 
+        for versions in versions {
             // we now know the applied versions
             changes.insert_set.remove(versions.clone());
         }
+
         changes
     }
 }
@@ -1635,6 +1638,7 @@ pub fn find_overwritten_versions(
 
 #[cfg(test)]
 mod tests {
+    use rangemap::range_inclusive_set;
     use super::*;
 
     #[test]
@@ -1650,35 +1654,48 @@ mod tests {
 
         let mut all = RangeInclusiveSet::new();
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(1)..=Version(20))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(1)..=Version(20)])?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(1)..=Version(10))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(1)..=Version(10)])?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
         // try from an empty state again
         let mut bv = BookedVersions::new(actor_id);
         let mut all = RangeInclusiveSet::new();
 
+        // create 2:=3 gap
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(1)..=Version(1), Version(4)..=Version(4)])?;
+        expect_gaps(&conn, &bv, &all, vec![Version(2)..=Version(3)])?;
+
+        // fillgap
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(3)..=Version(3), Version(2)..=Version(2)])?;
+        expect_gaps(&conn, &bv, &all, vec![])?;
+
+
+        // try from an empty state again
+        let mut bv = BookedVersions::new(actor_id);
+        let mut all = RangeInclusiveSet::new();
+
         // insert a non-1 first version
-        insert_everywhere(&conn, &mut bv, &mut all, Version(5)..=Version(20))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(5)..=Version(20)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(1)..=Version(4)])?;
 
         // insert a further change that does not overlap a gap
-        insert_everywhere(&conn, &mut bv, &mut all, Version(6)..=Version(7))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(6)..=Version(7)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(1)..=Version(4)])?;
 
         // insert a further change that does overlap a gap
-        insert_everywhere(&conn, &mut bv, &mut all, Version(3)..=Version(7))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(3)..=Version(7)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(1)..=Version(2)])?;
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(1)..=Version(2))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(1)..=Version(2)])?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(25)..=Version(25))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(25)..=Version(25)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(21)..=Version(24)])?;
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(30)..=Version(35))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(30)..=Version(35)])?;
         expect_gaps(
             &conn,
             &bv,
@@ -1688,7 +1705,7 @@ mod tests {
 
         // NOTE: overlapping partially from the end
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(19)..=Version(22))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(19)..=Version(22)])?;
         expect_gaps(
             &conn,
             &bv,
@@ -1698,7 +1715,7 @@ mod tests {
 
         // NOTE: overlapping partially from the start
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(24)..=Version(25))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(24)..=Version(25)])?;
         expect_gaps(
             &conn,
             &bv,
@@ -1708,27 +1725,27 @@ mod tests {
 
         // NOTE: overlapping 2 ranges
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(23)..=Version(27))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(23)..=Version(27)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(28)..=Version(29)])?;
 
         // NOTE: ineffective insert of already known ranges
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(1)..=Version(20))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(1)..=Version(20)])?;
         expect_gaps(&conn, &bv, &all, vec![Version(28)..=Version(29)])?;
 
         // NOTE: overlapping no ranges, but encompassing a full range
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(27)..=Version(30))?;
+        insert_everywhere(&conn, &mut bv, &mut all,  range_inclusive_set![Version(27)..=Version(30)])?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
         // NOTE: touching multiple ranges, partially
 
         // create gap 36..=39
-        insert_everywhere(&conn, &mut bv, &mut all, Version(40)..=Version(45))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(40)..=Version(45)])?;
         // create gap 46..=49
-        insert_everywhere(&conn, &mut bv, &mut all, Version(50)..=Version(55))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(50)..=Version(55)])?;
 
-        insert_everywhere(&conn, &mut bv, &mut all, Version(38)..=Version(47))?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![Version(38)..=Version(47)])?;
         expect_gaps(
             &conn,
             &bv,
@@ -1750,11 +1767,11 @@ mod tests {
         conn: &Connection,
         bv: &mut BookedVersions,
         all_versions: &mut RangeInclusiveSet<Version>,
-        versions: RangeInclusive<Version>,
+        versions: RangeInclusiveSet<Version>,
     ) -> rusqlite::Result<()> {
-        all_versions.insert(versions.clone());
+        all_versions.extend(versions.clone().into_iter());
         let mut snap = bv.snapshot();
-        snap.insert_db(conn, RangeInclusiveSet::from([versions]))?;
+        snap.insert_db(conn, versions)?;
         bv.commit_snapshot(snap);
         Ok(())
     }


### PR DESCRIPTION
In the compute_gaps_change function, the received version are removed at the end of loop but it could be added back in another iteration of the loop.