### PR TITLE
Add function for clearing empties

### DIFF
--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -306,7 +306,12 @@ async fn handle_conn(
                 }
                 Command::Sync(SyncCommand::ReconcileGaps) => {
                     let actor_ids: Vec<_> = {
-                        bookie.read("admin sync reconcile gaps").await.clone().into_keys().collect()
+                        bookie
+                            .read("admin sync reconcile gaps")
+                            .await
+                            .clone()
+                            .into_keys()
+                            .collect()
                     };
 
                     for actor_id in actor_ids {
@@ -532,10 +537,11 @@ async fn handle_conn(
 
                     let agent = agent.clone();
                     let started = std::time::Instant::now();
-                    let done = tokio::task::spawn(async move {
+                    let done = tokio::task::spawn_local(async move {
                         for actor_id in actor_ids {
                             if let Err(e) =
-                                util::clear_empty_versions(agent.clone(), actor_id, Some(&tx)).await
+                                util::clear_empty_versions(agent.clone(), actor_id, Some(&tx), None)
+                                    .await
                             {
                                 return Some(format!("{e}"));
                             }

--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -539,12 +539,12 @@ async fn handle_conn(
                             if let Err(e) =
                                 util::clear_empty_versions(agent.clone(), actor_id, Some(&tx)).await
                             {
-                                done_tx.send(Some(format!("{e}")));
+                                done_tx.send(Some(format!("{e}"))).unwrap();
                                 return;
                             }
                         }
 
-                        done_tx.send(None);
+                        done_tx.send(None).unwrap();
                     });
 
                     while let Some(msg) = rx.recv().await {

--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-use std::ops::RangeInclusive;
 use std::{
     fmt::Display,
     time::{Duration, Instant},
@@ -8,8 +6,7 @@ use std::{
 use camino::Utf8PathBuf;
 use corro_agent::agent::util;
 use futures::{SinkExt, TryStreamExt};
-use rangemap::RangeInclusiveSet;
-use rusqlite::{named_params, params, Connection, OptionalExtension};
+use rusqlite::{named_params, params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use time::OffsetDateTime;
@@ -22,7 +19,7 @@ use tokio_serde::{formats::Json, Framed};
 use tokio_util::codec::LengthDelimitedCodec;
 use tracing::{debug, error, info, warn};
 
-use corro_types::change::store_empty_changeset;
+
 use corro_types::{
     actor::{ActorId, ClusterId},
     agent::{Agent, BookedVersions, Bookie, LockKind, LockMeta, LockState},

--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -203,6 +203,11 @@ async fn run(agent: Agent, opts: AgentOptions, pconf: PerfConfig) -> eyre::Resul
         rx_apply,
         tripwire.clone(),
     ));
+    tokio::spawn(util::clear_empty_versions_loop(
+        agent.clone(),
+        bookie.clone(),
+        tripwire.clone(),
+    ));
 
     info!("Starting peer API on udp/{gossip_addr} (QUIC)");
 

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -831,7 +831,7 @@ async fn test_clear_empty_versions() -> eyre::Result<()> {
     )
     .await?;
 
-    clear_empty_versions(&ta2.agent.clone(), ta1.agent.actor_id(), None).await.unwrap();
+    clear_empty_versions(ta2.agent.clone(), ta1.agent.actor_id(), None).await?;
 
     check_bookie_versions(
         ta2.clone(),

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -831,7 +831,7 @@ async fn test_clear_empty_versions() -> eyre::Result<()> {
     )
     .await?;
 
-    clear_empty_versions(ta2.agent.clone(), ta1.agent.actor_id()).await?;
+    clear_empty_versions(&ta2.agent.clone(), ta1.agent.actor_id(), None).await.unwrap();
 
     check_bookie_versions(
         ta2.clone(),

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -831,7 +831,18 @@ async fn test_clear_empty_versions() -> eyre::Result<()> {
     )
     .await?;
 
-    clear_empty_versions(ta2.agent.clone(), ta1.agent.actor_id(), None).await?;
+    clear_empty_versions(ta2.agent.clone(), ta1.agent.actor_id(), None, Some(1)).await?;
+    check_bookie_versions(
+        ta2.clone(),
+        ta1.agent.actor_id(),
+        vec![],
+        vec![],
+        vec![],
+        vec![Version(1)..=Version(1)],
+    )
+    .await?;
+
+    clear_empty_versions(ta2.agent.clone(), ta1.agent.actor_id(), None, None).await?;
 
     check_bookie_versions(
         ta2.clone(),

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -5,8 +5,6 @@
 //! a similar API facade, handle the same kinds of data, etc) should
 //! be pulled out of this file in future.
 
-use std::error::Error;
-use std::io::Read;
 use std::{
     cmp,
     collections::{BTreeMap, HashSet},
@@ -35,7 +33,6 @@ use tower::{limit::ConcurrencyLimitLayer, load_shed::LoadShedLayer};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, trace, warn};
 
-use corro_types::agent::PoolError;
 use corro_types::{
     actor::{Actor, ActorId},
     agent::{

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -489,6 +489,10 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             ))
             .await?;
         }
+        Command::Db(DbCommand::CompactEmpties) => {
+            let mut conn = AdminConn::connect(cli.admin_path()).await?;
+            conn.send_command(corro_admin::Command::CompactEmpties).await?;
+        }
         Command::Db(DbCommand::Lock { cmd }) => {
             let config = match cli.config() {
                 Ok(config) => config,
@@ -768,4 +772,7 @@ enum TlsClientCommand {
 enum DbCommand {
     /// Acquires the lock on the DB
     Lock { cmd: String },
+
+    /// Compacts cleared versions in the bookkeeping table
+    CompactEmpties
 }


### PR DESCRIPTION
This pull requests adds an admin command that looks for db_versions in the bookkeeping table that are no longer in `crsql_chnages` table and compacts them