### PR TITLE
corro-client: fix subscription io::Error backoff

### DIFF
--- a/crates/corro-client/src/sub.rs
+++ b/crates/corro-client/src/sub.rs
@@ -229,18 +229,20 @@ where
         if let Some(backoff) = self.backoff.as_mut() {
             ready!(backoff.as_mut().poll(cx));
             self.backoff = None;
-            self.backoff_count = 0;
         }
 
         let io_err = match ready!(self.as_mut().poll_stream(cx)) {
             Some(Err(SubscriptionError::Io(io_err))) => io_err,
-            other => return Poll::Ready(other),
+            other => {
+                self.backoff_count = 0;
+                return Poll::Ready(other);
+            }
         };
 
         // reset the stream
         self.stream = None;
 
-        if self.backoff_count >= 30 {
+        if self.backoff_count >= 10 {
             return Poll::Ready(Some(Err(SubscriptionError::MaxRetryAttempts)));
         }
 


### PR DESCRIPTION
Make sure the count is only cleared once the client get a successful
request or encounters a non-IO error. Otherwise it never finishes.

Also, since the upper layer usually retries on its own, limit the numer
of retries to just 10.

This should be enough in case of a simple server restart, but will
provide faster reaction times if the host is down completely.
