### PR TITLE
Stop processing changeset on sqlite error

### DIFF
--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -782,27 +782,21 @@ pub async fn process_multiple_changes(
                         }
                     }
 
-                    let (known, versions) = match process_single_version(
-                        &agent,
-                        &tx,
-                        last_db_version,
-                        change,
-                    ) {
-                        Ok((known, changeset)) => {
-                            let versions = changeset.versions();
-                            if let KnownDbVersion::Current(CurrentVersion { db_version, .. }) =
-                                &known
-                            {
-                                last_db_version = Some(*db_version);
-                                changesets.push((actor_id, changeset, *db_version, src));
-                            }
-                            (known, versions)
-                        }
-                        Err(e) => {
-                            error!(%actor_id, ?versions, "could not process single change: {e}");
-                            continue;
-                        }
-                    };
+                    let (known, changeset) =
+                        process_single_version(&agent, &tx, last_db_version, change).map_err(
+                            |source| ChangeError::Rusqlite {
+                                source,
+                                actor_id: Some(actor_id),
+                                version: None,
+                            },
+                        )?;
+
+                    let versions = changeset.versions();
+                    if let KnownDbVersion::Current(CurrentVersion { db_version, .. }) = &known {
+                        last_db_version = Some(*db_version);
+                        changesets.push((actor_id, changeset, *db_version, src));
+                    }
+
                     debug!(%actor_id, self_actor_id = %agent.actor_id(), ?versions, "got known to insert: {known:?}");
                     known
                 };


### PR DESCRIPTION
As mention in the [sqlite3 documentation](https://www.sqlite.org/lang_transaction.html), when certain errors occur within a transaction, it may or may not be automatically rolled back.

This resolves an issue where a transaction fails but some rows are committed to the gaps db, causing a drift between the in-memory and database gaps.