### PR TITLE
pubsub: make sure to catch up sub in a transaction

### DIFF
--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -370,8 +370,11 @@ async fn catch_up_sub_anew(
     });
 
     let last_change_id = {
-        let conn = matcher.pool().get().await?;
-        block_in_place(|| matcher.all_rows(&conn, q_tx))?
+        let mut conn = matcher.pool().get().await?;
+        block_in_place(|| {
+            let conn_tx = conn.transaction()?;
+            matcher.all_rows(&conn_tx, q_tx)
+        })?
     };
 
     task.await??;


### PR DESCRIPTION
So the last sent row and the last change ID values are consistent.
Otherwise it might skip all the changes happened between reading the rows
and querying the last change ID.
