### PR TITLE
Return error of provided change ID is too old

### DIFF
--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -139,6 +139,7 @@ impl CorrosionApiClient {
             self.api_client.clone(),
             self.api_addr,
             res.into_body(),
+            from,
         ))
     }
 
@@ -189,6 +190,7 @@ impl CorrosionApiClient {
             self.api_client.clone(),
             self.api_addr,
             res.into_body(),
+            from,
         ))
     }
 

--- a/crates/corro-client/src/sub.rs
+++ b/crates/corro-client/src/sub.rs
@@ -94,13 +94,14 @@ where
         client: hyper::Client<HttpConnector, Body>,
         api_addr: SocketAddr,
         body: hyper::Body,
+        change_id: Option<ChangeId>,
     ) -> Self {
         Self {
             id,
             client,
             api_addr,
-            observed_eoq: false,
-            last_change_id: None,
+            observed_eoq: change_id.is_some(),
+            last_change_id: change_id,
             stream: Some(FramedRead::new(
                 StreamReader::new(IoBodyStream { body }),
                 LinesBytesCodec::default(),


### PR DESCRIPTION
The PR fixes client's behavior to return an error if the change ID provided to subscription handler
is too old and already recycled on the server side.

The PR also introduces DNS resolve timeout to make sure something is printed to the logs if DNS resolve
takes too much time.
