### PR TITLE
Store and use last seen empty timestamp when requesting for empties

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -741,6 +741,7 @@ pub async fn handle_changes(
         agent.config().perf.apply_queue_timeout as u64,
     ));
 
+    const MAX_QUEUE_LEN: usize = 10000;
     const MAX_SEEN_CACHE_LEN: usize = 10000;
     const KEEP_SEEN_CACHE_SIZE: usize = 1000;
     let mut seen: IndexMap<_, RangeInclusiveSet<CrsqlSeq>> = IndexMap::new();
@@ -857,6 +858,15 @@ pub async fn handle_changes(
         counter!("corro.agent.changes.recv").increment(std::cmp::max(change_len, 1) as u64); // count empties...
 
         if change.actor_id == agent.actor_id() {
+            continue;
+        }
+
+        // drop items when the queue is full.
+        if queue.len() > MAX_QUEUE_LEN {
+            warn!(
+                "dropping changes from {} because changes queue is full",
+                change.actor_id
+            );
             continue;
         }
 

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -741,7 +741,6 @@ pub async fn handle_changes(
         agent.config().perf.apply_queue_timeout as u64,
     ));
 
-    const MAX_QUEUE_LEN: usize = 10000;
     const MAX_SEEN_CACHE_LEN: usize = 10000;
     const KEEP_SEEN_CACHE_SIZE: usize = 1000;
     let mut seen: IndexMap<_, RangeInclusiveSet<CrsqlSeq>> = IndexMap::new();
@@ -858,15 +857,6 @@ pub async fn handle_changes(
         counter!("corro.agent.changes.recv").increment(std::cmp::max(change_len, 1) as u64); // count empties...
 
         if change.actor_id == agent.actor_id() {
-            continue;
-        }
-
-        // drop items when the queue is full.
-        if queue.len() > MAX_QUEUE_LEN {
-            warn!(
-                "dropping changes from {} because changes queue is full",
-                change.actor_id
-            );
             continue;
         }
 

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -34,7 +34,6 @@ use corro_tests::*;
 use corro_types::agent::Agent;
 use corro_types::broadcast::Timestamp;
 use corro_types::change::Change;
-use corro_types::sync::get_last_cleared_ts;
 use corro_types::{
     actor::ActorId,
     agent::migrate,
@@ -838,10 +837,7 @@ async fn test_clear_empty_versions() -> eyre::Result<()> {
     .await?;
 
     let mut last_cleared: HashMap<ActorId, Option<Timestamp>> = HashMap::new();
-    last_cleared.insert(
-        ta1.agent.actor_id(),
-        get_last_cleared_ts(&ta2.bookie, &ta1.agent.actor_id()).await,
-    );
+    last_cleared.insert(ta1.agent.actor_id(), None);
 
     println!("got last cleared - {last_cleared:?}");
 

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -1136,7 +1136,7 @@ pub async fn parallel_sync(
                     if let Some(ts) = cleared_ts {
                         if let Some(last_seen) = our_empty_ts.get(&actor_id) {
                             if last_seen.is_none() || last_seen.unwrap() < ts {
-                                debug!(%actor_id, "got last cleared ts {cleared_ts:?} - out last_seen {last_seen:?}");
+                                info!(%actor_id, "got last cleared ts {cleared_ts:?} - out last_seen {last_seen:?}");
                                 needs.entry(actor_id).or_default().push( SyncNeedV1::Empty { ts: *last_seen });
                             }
                         }

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -1136,7 +1136,7 @@ pub async fn parallel_sync(
                     if let Some(ts) = cleared_ts {
                         if let Some(last_seen) = our_empty_ts.get(&actor_id) {
                             if last_seen.is_none() || last_seen.unwrap() < ts {
-                                info!(%actor_id, "got last cleared ts {cleared_ts:?} - out last_seen {last_seen:?}");
+                                debug!(%actor_id, "got last cleared ts {cleared_ts:?} - out last_seen {last_seen:?}");
                                 needs.entry(actor_id).or_default().push( SyncNeedV1::Empty { ts: *last_seen });
                             }
                         }

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -717,8 +717,8 @@ fn handle_need(
             if last_cleared_ts.is_none() {
                 return Ok(());
             }
+            debug!("processing empty versions to {actor_id} with ts: {:?}", ts);
             let ts = ts.unwrap_or(Default::default());
-            debug!("processing empty versions to {actor_id}");
             let mut stmt = tx.prepare_cached(
                 "
                 SELECT start_version, end_version, ts FROM __corro_bookkeeping
@@ -1133,14 +1133,10 @@ pub async fn parallel_sync(
 
                     let cleared_ts = their_sync_state.last_cleared_ts;
 
-                    info!(%actor_id, "got last cleared ts {cleared_ts:?}");
-                    if let Some(ts) = cleared_ts {
-                        if let Some(last_seen) = our_empty_ts.get(&actor_id) {
-                            if last_seen.is_none() || last_seen.unwrap() < ts {
-                                needs.entry(actor_id).or_default().push( SyncNeedV1::Empty { ts: *last_seen });
-                            }
-                        }
-                    }
+                    let last_seen = our_empty_ts.get(&actor_id).unwrap_or(&None);
+                    info!(%actor_id, "got last cleared ts {cleared_ts:?} - {last_seen:?} {:?}", last_seen.unwrap_or(Default::default()).0.to_string());
+                    needs.entry(actor_id).or_default().push( SyncNeedV1::Empty { ts: *last_seen });
+
                     Ok::<_, SyncError>((needs, tx, read))
                 }.await
             )
@@ -1371,14 +1367,13 @@ pub async fn parallel_sync(
     }.instrument(info_span!("send_sync_requests")));
 
     // now handle receiving changesets!
-
     let counts = FuturesUnordered::from_iter(readers.into_iter().map(|(actor_id, mut read)| {
         let tx_changes = agent.tx_changes().clone();
         let tx_emptyset = agent.tx_emptyset().clone();
 
         async move {
             let mut count = 0;
-
+            let mut last_empty_ts = None;
             loop {
                 match read_sync_msg(&mut read).await {
                     Ok(None) => {
@@ -1403,10 +1398,15 @@ pub async fn parallel_sync(
                             );
                             // only accept emptyset that's from the same node that's syncing
                             if change.is_empty_set() {
+                                let change_ts = change.ts();
                                 tx_emptyset
                                     .send(change)
                                     .await
                                     .map_err(|_| SyncRecvError::ChangesChannelClosed)?;
+
+                                if change_ts > last_empty_ts {
+                                    last_empty_ts = change_ts;
+                                }
                                 continue;
                             }
 
@@ -1436,19 +1436,22 @@ pub async fn parallel_sync(
 
             debug!(%actor_id, %count, "done reading sync messages");
 
-            Ok((actor_id, count))
+            Ok((actor_id, count, last_empty_ts))
         }
         .instrument(info_span!("read_sync_requests_responses", %actor_id))
     }))
-    .collect::<Vec<Result<(ActorId, usize), SyncError>>>()
+    .collect::<Vec<Result<(ActorId, usize, Option<Timestamp>), SyncError>>>()
     .await;
 
-    let ts = Timestamp::from(agent.clock().new_timestamp());
     let mut members = agent.members().write();
+    let ts = Timestamp::from(agent.clock().new_timestamp());
     for res in counts.iter() {
         match res {
             Err(e) => error!("could not properly recv from peer: {e}"),
-            Ok((actor_id, _)) => members.update_sync_ts(actor_id, ts),
+            Ok((actor_id, _, last_empty_ts)) => {
+                members.update_sync_ts(actor_id, ts);
+                members.update_last_empty(actor_id, *last_empty_ts);
+            }
         };
     }
 

--- a/crates/corro-types/src/members.rs
+++ b/crates/corro-types/src/members.rs
@@ -21,19 +21,14 @@ pub struct MemberState {
 }
 
 impl MemberState {
-    pub fn new(
-        addr: SocketAddr,
-        ts: Timestamp,
-        cluster_id: ClusterId,
-        last_empty_ts: Option<Timestamp>,
-    ) -> Self {
+    pub fn new(addr: SocketAddr, ts: Timestamp, cluster_id: ClusterId) -> Self {
         Self {
             addr,
             ts,
             cluster_id,
             ring: None,
             last_sync_ts: None,
-            last_empty_ts: last_empty_ts,
+            last_empty_ts: None,
         }
     }
 
@@ -84,17 +79,13 @@ impl Members {
 
     // A result of `true` means that the effective list of
     // cluster member addresses has changed
-    pub fn add_member(
-        &mut self,
-        actor: &Actor,
-        last_empty_ts: Option<Timestamp>,
-    ) -> MemberAddedResult {
+    pub fn add_member(&mut self, actor: &Actor) -> MemberAddedResult {
         let actor_id = actor.id();
         let mut ret = MemberAddedResult::Ignored;
 
         let member = self.states.entry(actor_id).or_insert_with(|| {
             ret = MemberAddedResult::NewMember;
-            MemberState::new(actor.addr(), actor.ts(), actor.cluster_id(), last_empty_ts)
+            MemberState::new(actor.addr(), actor.ts(), actor.cluster_id())
         });
 
         trace!("member: {member:?}");

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -279,18 +279,6 @@ impl From<SyncStateV1> for SyncMessage {
     }
 }
 
-pub async fn get_last_cleared_ts(bookie: &Bookie, actor_id: &ActorId) -> Option<Timestamp> {
-    let booked = bookie
-        .read("get_last_cleared_ts")
-        .await
-        .get(actor_id)
-        .cloned();
-    if let Some(booked) = booked {
-        let booked_reader = booked.read("get_last_cleared_ts").await;
-        return booked_reader.last_cleared_ts();
-    }
-    None
-}
 
 // generates a `SyncMessage` to tell another node what versions we're missing
 #[tracing::instrument(skip_all, level = "debug")]


### PR DESCRIPTION
When a node processes empties slowly, we can end up requesting already received empties that are still in the buffer. This pull request adds a field to the Members struct to store the last received empties timestamp and use that instead when requesting so we would not request an empty that we already have.