### PR TITLE
manually drop snapshot without running its destructor

### DIFF
--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -976,6 +976,8 @@ pub async fn process_multiple_changes(
                     actor_id: None,
                     version: None,
                 })?;
+
+            std::mem::forget(snap);
         }
 
         tx.commit().map_err(|source| ChangeError::Rusqlite {


### PR DESCRIPTION
this fixes the panic in debug build:

  thread 'tokio-runtime-worker' panicked at crates/corro-types/src/agent.rs:1306:9:
  max value was not applied

steps to reproduce:

  - schema

    CREATE TABLE todos ( id INTEGER NOT NULL PRIMARY KEY, title TEXT NOT NULL DEFAULT '' );

  - node A

    ./corrosion -c corro.toml exec 'INSERT INTO todos (id, title) VALUES (1, "test todo")'

  - node B

    ./corrosion -c corro.toml query 'SELECT * FROM todos' ./corrosion -c corro.toml exec 'DELETE FROM todos WHERE id == 1'

  now node A crashes with assert message `max value was not applied`