### PR TITLE
replace clap attributes with command and arg

### DIFF
--- a/crates/corro-devcluster/src/main.rs
+++ b/crates/corro-devcluster/src/main.rs
@@ -16,21 +16,21 @@ use std::{
 use crate::topology::Simple;
 
 #[derive(Parser)]
-#[clap(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
     /// Set the state directory path.  If not set the environment
     /// variable CORRO_DEVCLUSTER_STATE_DIR will be used
-    #[clap(long = "statedir", short = 'd', global = true)]
+    #[arg(long = "statedir", short = 'd', global = true)]
     state_directory: Option<PathBuf>,
 
     /// Set the state directory path.  If not set the environment
     /// variable CORRO_DEVCLUSTER_SCHEMA_DIR will be used
-    #[clap(long = "schemadir", short = 's', global = true)]
+    #[arg(long = "schemadir", short = 's', global = true)]
     schema_directory: Option<PathBuf>,
 
     /// Provide the binary path for corrosion.  If none is provided,
     /// corrosion will be built with nix (which may take a minute)
-    #[clap(long = "binpath", short = 'b', global = true)]
+    #[arg(long = "binpath", short = 'b', global = true)]
     binary_path: Option<String>,
 
     #[command(subcommand)]

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -543,10 +543,10 @@ fn main() {
 }
 
 #[derive(Parser)]
-#[clap(version = VERSION)]
+#[command(version = VERSION)]
 struct Cli {
     /// Set the config file path
-    #[clap(
+    #[arg(
         long = "config",
         short,
         global = true,
@@ -554,13 +554,13 @@ struct Cli {
     )]
     config_path: Utf8PathBuf,
 
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     api_addr: Option<SocketAddr>,
 
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     db_path: Option<Utf8PathBuf>,
 
-    #[clap(long, global = true)]
+    #[arg(long, global = true)]
     admin_path: Option<Utf8PathBuf>,
 
     #[command(subcommand)]


### PR DESCRIPTION
even though `#[clap()]` still works, `#[command()]` and `#[arg()]` are now recommended since clap v4, ref https://github.com/clap-rs/clap/pull/4180