### PR TITLE
Adds an info and list command for getting more details on subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tripwire",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/corro-admin/Cargo.toml
+++ b/crates/corro-admin/Cargo.toml
@@ -20,3 +20,4 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 tripwire = { path = "../tripwire" }
 rangemap = { workspace = true }
+uuid = { workspace = true }

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -279,7 +279,6 @@ impl From<SyncStateV1> for SyncMessage {
     }
 }
 
-
 // generates a `SyncMessage` to tell another node what versions we're missing
 #[tracing::instrument(skip_all, level = "debug")]
 pub async fn generate_sync(bookie: &Bookie, self_actor_id: ActorId) -> SyncStateV1 {

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -522,6 +522,19 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             info!("Exited with code: {:?}", exit.code());
             std::process::exit(exit.code().unwrap_or(1));
         }
+        Command::Subs(SubsCommand::Info { hash, id }) => {
+            let mut conn = AdminConn::connect(cli.admin_path()).await?;
+            conn.send_command(corro_admin::Command::Subs(corro_admin::SubsCommand::Info {
+                hash: hash.clone(),
+                id: *id,
+            }))
+            .await?;
+        }
+        Command::Subs(SubsCommand::List) => {
+            let mut conn = AdminConn::connect(cli.admin_path()).await?;
+            conn.send_command(corro_admin::Command::Subs(corro_admin::SubsCommand::List))
+                .await?;
+        }
     }
 
     Ok(())
@@ -686,6 +699,10 @@ enum Command {
     /// DB-related commands
     #[command(subcommand)]
     Db(DbCommand),
+
+    /// Subscription related commands
+    #[command(subcommand)]
+    Subs(SubsCommand),
 }
 
 #[derive(Subcommand)]
@@ -768,4 +785,17 @@ enum TlsClientCommand {
 enum DbCommand {
     /// Acquires the lock on the DB
     Lock { cmd: String },
+}
+
+#[derive(Subcommand)]
+enum SubsCommand {
+    /// List all subscriptions on a node
+    List,
+    /// Get information on a subscription
+    Info {
+        #[arg(long)]
+        hash: Option<String>,
+        #[arg(long)]
+        id: Option<Uuid>,
+    },
 }


### PR DESCRIPTION
```
somma@odysseus:~/workspace/superfly/corrosion$ target/debug/corrosion -c _personal/config.toml subs info --hash 6525eb339b115733
{
  "hash": "6525eb339b115733",
  "id": "fe4523c2-c1ef-4d49-99e7-cd35ac8632de",
  "last_change_id": 0,
  "original_query": "SELECT id,title,completed_at FROM todos",
  "path": "./test-corrosion/subscriptions/fe4523c2c1ef4d4999e7cd35ac8632de",
  "statements": [
    {
      "todos": "SELECT todos.id AS __corro_pk_todos_id, id AS col_0, title AS col_1, completed_at AS col_2 FROM todos WHERE (todos.id) IN __corro_sub.temp_todos"
    }
  ]
}
```