### PR TITLE
Handle failed changes properly

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -750,8 +750,8 @@ pub async fn handle_changes(
         agent.config().perf.apply_queue_timeout as u64,
     ));
 
-    const MAX_SEEN_CACHE_LEN: usize = 10000;
-    const KEEP_SEEN_CACHE_SIZE: usize = 1000;
+    let max_seen_cache_len: usize = max_queue_len;
+    let keep_seen_cache_size: usize = cmp::max(10, max_seen_cache_len / 10);
     let mut seen: IndexMap<_, RangeInclusiveSet<CrsqlSeq>> = IndexMap::new();
 
     let mut drop_log_count: u64 = 0;
@@ -819,9 +819,9 @@ pub async fn handle_changes(
                     buf_cost = 0;
                 }
 
-                if seen.len() > MAX_SEEN_CACHE_LEN {
+                if seen.len() > max_seen_cache_len {
                     // we don't want to keep too many entries in here.
-                    seen = seen.split_off(seen.len() - KEEP_SEEN_CACHE_SIZE);
+                    seen = seen.split_off(seen.len() - keep_seen_cache_size);
                 }
                 continue
             },

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -849,7 +849,6 @@ mod tests {
 
         assert!(drop_oldest_broadcast(&mut queue, max).is_none());
 
-
         queue.push_front(build_broadcast(1, 0));
         queue.push_front(build_broadcast(2, 3));
         queue.push_front(build_broadcast(3, 1));

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -14,8 +14,9 @@ const fn default_apply_queue() -> usize {
 const fn default_wal_threshold() -> usize {
     10
 }
+
 const fn default_processing_queue() -> usize {
-    50000
+    20000
 }
 
 /// Used for the apply channel

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -15,7 +15,7 @@ const fn default_wal_threshold() -> usize {
     10
 }
 const fn default_processing_queue() -> usize {
-    5000000
+    50000
 }
 
 /// Used for the apply channel


### PR DESCRIPTION
This pull request adds the following changes:
- The use of savepoints for commit single versions are handled within `process_multiple_changes` so if one version fails we can continue with the others. 
- It reverts the behaviour of removing failed versions from the seen map as this can cause duplicate changes from broadcasts to be re-sent. Now the changes will eventually be retried when the cache is cleared.
- We now maintain the same size for the both the cache and the queue, so that we never have duplicate items in the queue