### PR TITLE
Don't use `block_in_place` for long running blocking tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,7 @@ dependencies = [
  "pgwire",
  "postgres-types",
  "rusqlite",
+ "socket2 0.5.5",
  "spawn",
  "sqlite3-parser",
  "sqlparser",

--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -336,9 +336,12 @@ async fn handle_conn(
                                 .clone();
 
                             let mut conn = agent.pool().write_low().await.unwrap();
+                            debug_log(&mut stream, format!("got write conn for actor id: {actor_id}")).await;
+
                             let mut bv = booked
                                 .write::<&str, _>("admin sync reconcile gaps booked versions", None)
                                 .await;
+                            debug_log(&mut stream, format!("got bookie for actor id: {actor_id}")).await;
 
                             if let Err(e) = collapse_gaps(&mut stream, &mut conn, &mut bv).await {
                                 _ = send_error(&mut stream, e).await;

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -760,10 +760,10 @@ pub async fn handle_changes(
     // complicated loop to process changes efficiently w/ a max concurrency
     // and a minimum chunk size for bigger and faster SQLite transactions
     loop {
-        while buf_cost >= max_changes_chunk && join_set.len() < MAX_CONCURRENT {
-            // we're already bigger than the minimum size of changes batch
-            // so we want to accumulate at least that much and process them
-            // concurrently bvased on MAX_CONCURRENCY
+        while (buf_cost >= max_changes_chunk || !queue.is_empty())
+            && join_set.len() < MAX_CONCURRENT
+        {
+            // Process if we hit the chunk size OR if we have any items and available capacity
             let mut tmp_cost = 0;
             while let Some((change, src, queued_at)) = queue.pop_front() {
                 tmp_cost += change.processing_cost();

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -760,7 +760,7 @@ pub async fn handle_changes(
     // complicated loop to process changes efficiently w/ a max concurrency
     // and a minimum chunk size for bigger and faster SQLite transactions
     loop {
-        while (buf_cost >= max_changes_chunk || !queue.is_empty())
+        while (buf_cost >= max_changes_chunk || !queue.is_empty() && join_set.is_empty())
             && join_set.len() < MAX_CONCURRENT
         {
             // Process if we hit the chunk size OR if we have any items and available capacity

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -760,7 +760,7 @@ pub async fn handle_changes(
     // complicated loop to process changes efficiently w/ a max concurrency
     // and a minimum chunk size for bigger and faster SQLite transactions
     loop {
-        while (buf_cost >= max_changes_chunk || !queue.is_empty() && join_set.is_empty())
+        while (buf_cost >= max_changes_chunk || (!queue.is_empty() && join_set.is_empty()))
             && join_set.len() < MAX_CONCURRENT
         {
             // Process if we hit the chunk size OR if we have any items and available capacity

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -800,7 +800,7 @@ pub async fn process_multiple_changes(
         warn!("process_multiple_changes: removing duplicates took too long - {elapsed:?}");
     }
 
-    let mut conn = timeout(Duration::from_secs(10), agent.pool().write_normal())
+    let mut conn = timeout(Duration::from_secs(5 * 60), agent.pool().write_normal())
         .await
         .map_err(PoolError::from)??;
 

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -447,7 +447,9 @@ async fn execute_schema(agent: &Agent, statements: Vec<String>) -> eyre::Result<
 
     let partial_schema = parse_sql(&new_sql)?;
 
+    info!("getting write connection to update schema");
     let mut conn = agent.pool().write_priority().await?;
+    info!("got write connection to update schema");
 
     // hold onto this lock so nothing else makes changes
     let mut schema_write = agent.schema().write();

--- a/crates/corro-pg/Cargo.toml
+++ b/crates/corro-pg/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { workspace = true }
 tripwire = { path = "../tripwire" }
 sqlparser = { version = "0.39.0" }
 chrono = { version = "0.4.31" }
+socket2 = { version = "0.5" }
 
 [dev-dependencies]
 corro-tests = { path = "../corro-tests" }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -21,11 +21,11 @@ use parking_lot::RwLock;
 use rangemap::RangeInclusiveSet;
 use rusqlite::{named_params, Connection, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{
+use tokio::{sync::{
     AcquireError, OwnedRwLockWriteGuard as OwnedTokioRwLockWriteGuard, OwnedSemaphorePermit,
     RwLock as TokioRwLock, RwLockReadGuard as TokioRwLockReadGuard,
     RwLockWriteGuard as TokioRwLockWriteGuard,
-};
+}, time::error::Elapsed};
 use tokio::{
     runtime::Handle,
     sync::{oneshot, Semaphore},
@@ -532,6 +532,8 @@ pub enum PoolError {
     CallbackClosed,
     #[error("could not acquire write permit")]
     Permit(#[from] AcquireError),
+    #[error("timed out waiting to acquire write connection")]
+    TimedOut(#[from] Elapsed),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -8,7 +8,7 @@ pub const DEFAULT_GOSSIP_PORT: u16 = 4001;
 const DEFAULT_GOSSIP_IDLE_TIMEOUT: u32 = 30;
 
 const fn default_apply_queue() -> usize {
-    100
+    50
 }
 
 const fn default_wal_threshold() -> usize {
@@ -38,7 +38,7 @@ const fn default_small_channel() -> usize {
 }
 
 const fn default_apply_timeout() -> usize {
-    50
+    10
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -545,7 +545,7 @@ fn main() {
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .worker_threads(4)
+        .worker_threads(8)
         .build()
         .expect("could not build tokio runtime");
 


### PR DESCRIPTION
- Uses more threads
- Uses `spawn_blocking` instead of `block_in_place` in `corro-pg`
- Processes items faster and in smaller batches