### PR TITLE
corro-api-types: remove dependency on unstable Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,6 @@ dependencies = [
  "async-trait",
  "camino",
  "compact_str 0.7.0",
- "corro-base-types",
  "corro-speedy",
  "deadpool",
  "hex",

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -1067,8 +1067,10 @@ mod tests {
     use super::*;
     use axum::{http::StatusCode, Extension, Json};
     use corro_tests::TEST_SCHEMA;
-    use corro_types::api::{Change, ColumnName, TableName};
-    use corro_types::{base::CrsqlDbVersion, base::Version, config::Config, pubsub::pack_columns};
+    use corro_types::api::{ColumnName, TableName};
+    use corro_types::{
+        base::CrsqlDbVersion, base::Version, change::Change, config::Config, pubsub::pack_columns,
+    };
     use rusqlite::Connection;
     use std::sync::Arc;
     use tokio::sync::Semaphore;

--- a/crates/corro-agent/src/api/peer.rs
+++ b/crates/corro-agent/src/api/peer.rs
@@ -1766,7 +1766,7 @@ mod tests {
             assert_eq!(status_code, StatusCode::OK);
 
             let version = body.0.version.unwrap();
-            assert_eq!(version, Version(i));
+            assert_eq!(version, i);
         }
 
         let dir = tempfile::tempdir()?;

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -201,7 +201,7 @@ pub async fn api_v1_transactions(
         axum::Json(ExecResponse {
             results,
             time: elapsed.as_secs_f64(),
-            version,
+            version: version.map(Into::into),
         }),
     )
 }

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -883,9 +883,10 @@ async fn forward_bytes_to_body_sender(
 mod tests {
     use corro_types::actor::ActorId;
     use corro_types::api::NotifyEvent;
-    use corro_types::api::{Change, ColumnName, TableName};
+    use corro_types::api::{ColumnName, TableName};
     use corro_types::base::{CrsqlDbVersion, CrsqlSeq, Version};
     use corro_types::broadcast::{ChangeSource, ChangeV1, Changeset};
+    use corro_types::change::Change;
     use corro_types::pubsub::pack_columns;
     use corro_types::{
         api::{ChangeId, RowId},

--- a/crates/corro-api-types/Cargo.toml
+++ b/crates/corro-api-types/Cargo.toml
@@ -19,4 +19,3 @@ speedy = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true } 
 tokio = { workspace = true }
-corro-base-types = { path = "../corro-base-types" }

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -7,10 +7,9 @@ use std::{
 };
 
 use compact_str::CompactString;
-use corro_base_types::{CrsqlDbVersion, CrsqlSeq, Version};
 use rusqlite::{
     types::{FromSql, FromSqlError, ToSqlOutput, Value, ValueRef},
-    Row, ToSql,
+    ToSql,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -220,7 +219,7 @@ impl From<&str> for Statement {
 pub struct ExecResponse {
     pub results: Vec<ExecResult>,
     pub time: f64,
-    pub version: Option<Version>,
+    pub version: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -239,51 +238,6 @@ pub struct TableStatRequest {
 pub struct TableStatResponse {
     pub total_row_count: i64,
     pub invalid_tables: Vec<String>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Readable, Writable, PartialEq)]
-pub struct Change {
-    pub table: TableName,
-    pub pk: Vec<u8>,
-    pub cid: ColumnName,
-    pub val: SqliteValue,
-    pub col_version: i64,
-    pub db_version: CrsqlDbVersion,
-    pub seq: CrsqlSeq,
-    pub site_id: [u8; 16],
-    pub cl: i64,
-}
-
-impl Change {
-    // this is an ESTIMATE, it should give a rough idea of how many bytes will
-    // be required on the wire
-    pub fn estimated_byte_size(&self) -> usize {
-        self.table.len() + self.pk.len() + self.cid.len() + self.val.estimated_byte_size() +
-        // col_version
-        8 +
-        // db_version
-        8 +
-        // seq
-        8 +
-        // site_id
-        16 +
-        // cl
-        8
-    }
-}
-
-pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
-    Ok(Change {
-        table: row.get(0)?,
-        pk: row.get(1)?,
-        cid: row.get(2)?,
-        val: row.get(3)?,
-        col_version: row.get(4)?,
-        db_version: row.get(5)?,
-        seq: row.get(6)?,
-        site_id: row.get(7)?,
-        cl: row.get(8)?,
-    })
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/crates/corro-base-types/src/lib.rs
+++ b/crates/corro-base-types/src/lib.rs
@@ -17,6 +17,12 @@ use speedy::{Context, Readable, Writable};
 #[serde(transparent)]
 pub struct Version(pub u64);
 
+impl From<Version> for u64 {
+    fn from(v: Version) -> Self {
+        v.0
+    }
+}
+
 impl Step for Version {
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
         u64::steps_between(&start.0, &end.0)

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use bytes::{Bytes, BytesMut};
-use corro_api_types::{row_to_change, Change};
 use foca::{Identity, Member, Notification, Runtime, Timer};
 use itertools::Itertools;
 use metrics::counter;
@@ -28,7 +27,7 @@ use crate::{
     actor::{Actor, ActorId, ClusterId},
     agent::Agent,
     base::{CrsqlDbVersion, CrsqlSeq, Version},
-    change::{ChunkedChanges, MAX_CHANGES_BYTE_SIZE},
+    change::{row_to_change, Change, ChunkedChanges, MAX_CHANGES_BYTE_SIZE},
     channel::CorroSender,
     sqlite::SqlitePoolError,
     sync::SyncTraceContextV1,

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -1,9 +1,11 @@
 use std::{iter::Peekable, ops::RangeInclusive, time::Instant};
 
-pub use corro_api_types::{row_to_change, Change, SqliteValue};
+pub use corro_api_types::SqliteValue;
+use corro_api_types::{ColumnName, TableName};
 use corro_base_types::{CrsqlDbVersion, Version};
 use rangemap::RangeInclusiveSet;
-use rusqlite::{named_params, params, Connection};
+use rusqlite::{named_params, params, Connection, Row};
+use speedy::{Readable, Writable};
 use tracing::{debug, trace, warn};
 
 use crate::{
@@ -12,6 +14,51 @@ use crate::{
     base::CrsqlSeq,
     broadcast::Timestamp,
 };
+
+#[derive(Debug, Default, Clone, Readable, Writable, PartialEq)]
+pub struct Change {
+    pub table: TableName,
+    pub pk: Vec<u8>,
+    pub cid: ColumnName,
+    pub val: SqliteValue,
+    pub col_version: i64,
+    pub db_version: CrsqlDbVersion,
+    pub seq: CrsqlSeq,
+    pub site_id: [u8; 16],
+    pub cl: i64,
+}
+
+impl Change {
+    // this is an ESTIMATE, it should give a rough idea of how many bytes will
+    // be required on the wire
+    pub fn estimated_byte_size(&self) -> usize {
+        self.table.len() + self.pk.len() + self.cid.len() + self.val.estimated_byte_size() +
+        // col_version
+        8 +
+        // db_version
+        8 +
+        // seq
+        8 +
+        // site_id
+        16 +
+        // cl
+        8
+    }
+}
+
+pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
+    Ok(Change {
+        table: row.get(0)?,
+        pk: row.get(1)?,
+        cid: row.get(2)?,
+        val: row.get(3)?,
+        col_version: row.get(4)?,
+        db_version: row.get(5)?,
+        seq: row.get(6)?,
+        site_id: row.get(7)?,
+        cl: row.get(8)?,
+    })
+}
 
 pub struct ChunkedChanges<I: Iterator> {
     iter: Peekable<I>,

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -10,7 +10,7 @@ use bytes::{Buf, BufMut};
 use camino::{Utf8Path, Utf8PathBuf};
 use compact_str::{format_compact, ToCompactString};
 use corro_api_types::{
-    Change, ChangeId, ColumnName, ColumnType, RowId, SqliteValue, SqliteValueRef, TableName,
+    ChangeId, ColumnName, ColumnType, RowId, SqliteValue, SqliteValueRef, TableName,
 };
 use enquote::unquote;
 use fallible_iterator::FallibleIterator;
@@ -44,6 +44,7 @@ use crate::{
     agent::SplitPool,
     api::QueryEvent,
     base::CrsqlDbVersion,
+    change::Change,
     schema::{Schema, Table},
     sqlite::CrConn,
     updates::HandleMetrics,
@@ -528,7 +529,9 @@ pub struct MatcherStmt {
 }
 
 impl MatcherStmt {
-    pub fn new_query(&self) -> &String { &self.new_query }
+    pub fn new_query(&self) -> &String {
+        &self.new_query
+    }
 }
 
 const CHANGE_ID_COL: &str = "id";
@@ -2450,7 +2453,6 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use camino::Utf8PathBuf;
-    use corro_api_types::row_to_change;
     use rusqlite::params;
     use spawn::wait_for_all_pending_handles;
     use tokio::sync::Semaphore;
@@ -2458,6 +2460,7 @@ mod tests {
     use crate::{
         actor::ActorId,
         agent::migrate,
+        change::row_to_change,
         schema::{apply_schema, parse_sql},
         sqlite::{setup_conn, CrConn},
     };

--- a/crates/corro-types/src/updates.rs
+++ b/crates/corro-types/src/updates.rs
@@ -1,9 +1,10 @@
 use crate::agent::SplitPool;
+use crate::change::Change;
 use crate::pubsub::{unpack_columns, MatchCandidates, MatchableChange, MatcherError};
 use crate::schema::Schema;
 use async_trait::async_trait;
 use corro_api_types::sqlite::ChangeType;
-use corro_api_types::{Change, ColumnName, NotifyEvent, SqliteValueRef, TableName};
+use corro_api_types::{ColumnName, NotifyEvent, SqliteValueRef, TableName};
 use corro_base_types::CrsqlDbVersion;
 use metrics::{counter, histogram, Counter};
 use parking_lot::RwLock;

--- a/crates/sqlite-pool/src/config.rs
+++ b/crates/sqlite-pool/src/config.rs
@@ -10,8 +10,6 @@ use crate::{
 
 /// Configuration object.
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde_1::Deserialize, serde_1::Serialize))]
-#[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct Config {
     /// Path to SQLite database file.
     pub path: PathBuf,


### PR DESCRIPTION
This PR moves some code around to remove dependency on unstable Rust
toolchain in the corro-api-types crate.

The Step trait has been changed recently and it makes it impossible to
update Rust toolchain in corro-api-types/corro-client consumers without
first updating it in Corrosion to a compatible version.
