### PR TITLE
Update settings around wal checkpoint in sql

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -541,8 +541,9 @@ fn calc_busy_timeout(wal_size: u64, threshold: u64) -> u64 {
     }
 
     // Double the timeout every 10gb and cap at 64 minutes
-    let diff = cmp::min(7, wal_size_gb / 10);
+    let diff = cmp::min(6, wal_size_gb / 10);
     let timeout = base_timeout * 2_u64.pow(diff as u32);
+    // we are using a 16min timeout, something is wrong if we get here
     if diff >= 5 {
         warn!("WAL size is too large, setting busy timeout {timeout}ms");
     }
@@ -1279,8 +1280,9 @@ mod tests {
         assert_eq!(calc_busy_timeout(to_bytes(40), to_bytes(5)), 480000); // 8m
         assert_eq!(calc_busy_timeout(to_bytes(57), to_bytes(5)), 960000); // 16m
         assert_eq!(calc_busy_timeout(to_bytes(60), to_bytes(5)), 1920000); // 32m
-        assert_eq!(calc_busy_timeout(to_bytes(100), to_bytes(5)), 3840000); // 64m maybe too aggressive?
-        assert_eq!(calc_busy_timeout(to_bytes(1000), to_bytes(5)), 3840000); // 64m
+        assert_eq!(calc_busy_timeout(to_bytes(70), to_bytes(5)), 1920000); // 32m
+        assert_eq!(calc_busy_timeout(to_bytes(100), to_bytes(5)), 1920000); // 32m
+        assert_eq!(calc_busy_timeout(to_bytes(1000), to_bytes(5)), 1920000); // 32m
     }
 
     fn to_bytes(gb: u64) -> u64 {

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1,10 +1,11 @@
 use std::{
     collections::BTreeSet,
+    net::SocketAddr,
     ops::Deref,
     time::{Duration, Instant},
 };
 
-use axum::{response::IntoResponse, Extension};
+use axum::{extract::ConnectInfo, response::IntoResponse, Extension};
 use bytes::{BufMut, BytesMut};
 use compact_str::ToCompactString;
 use corro_types::{
@@ -32,7 +33,7 @@ use tokio::{
     },
     task::block_in_place,
 };
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use corro_types::broadcast::broadcast_changes;
 
@@ -241,6 +242,7 @@ pub enum QueryError {
 
 async fn build_query_rows_response(
     agent: &Agent,
+    client_addr: SocketAddr,
     data_tx: mpsc::Sender<QueryEvent>,
     stmt: Statement,
 ) -> Result<(), (StatusCode, ExecResult)> {
@@ -261,6 +263,8 @@ async fn build_query_rows_response(
                 return;
             }
         };
+
+        trace!(%client_addr, "Preparing statement {}", stmt.query());
 
         let prepped_res = block_in_place(|| conn.prepare(stmt.query()));
 
@@ -304,7 +308,9 @@ async fn build_query_rows_response(
 
             let start = Instant::now();
 
-            let query = match stmt {
+            trace!(%client_addr, "Executing statement {}", stmt.query());
+
+            let query = match &stmt {
                 Statement::Simple(_)
                 | Statement::Verbose {
                     params: None,
@@ -342,6 +348,12 @@ async fn build_query_rows_response(
                 }
             };
             let elapsed = start.elapsed();
+
+            trace!(%client_addr, elapsed = %elapsed.as_secs(), "Statement finished executing {}", stmt.query());
+
+            if elapsed > Duration::from_secs(10) {
+                warn!(%client_addr, elapsed = %elapsed.as_secs(), "Slow read statement {}!", stmt.query());
+            }
 
             if let Err(_e) = res_tx.send(Ok(())) {
                 error!("could not send back response through oneshot channel, aborting");
@@ -406,6 +418,7 @@ async fn build_query_rows_response(
 
 pub async fn api_v1_queries(
     Extension(agent): Extension<Agent>,
+    ConnectInfo(client_addr): ConnectInfo<SocketAddr>,
     axum::extract::Json(stmt): axum::extract::Json<Statement>,
 ) -> impl IntoResponse {
     let (mut tx, body) = hyper::Body::channel();
@@ -447,7 +460,7 @@ pub async fn api_v1_queries(
 
     trace!("building query rows response...");
 
-    match build_query_rows_response(&agent, data_tx, stmt).await {
+    match build_query_rows_response(&agent, client_addr, data_tx, stmt).await {
         Ok(_) => {
             histogram!("corro.api.queries.processing.time.seconds", "result" => "success")
                 .record(start.elapsed());
@@ -798,6 +811,7 @@ mod tests {
 
         let res = api_v1_queries(
             Extension(agent.clone()),
+            ConnectInfo("127.0.0.1:1234".parse().unwrap()),
             axum::Json(Statement::Simple("select * from tests".into())),
         )
         .await


### PR DESCRIPTION
This pull request updates some settings around wal checkpoint
qw set the busy timeout based on what the current size of the wal size, doubling the timeout with every extra gigabyte so we give any current readers not on the latest snapshot to complete so the wal_checkpoint can proceed.

@PeterCxy comment from a related PR:
busy_handler of checkpoints will wait until all readers are on the same latest snapshot, NOT when all readers complete. With huge subs we often have readers that take very long to complete, and in that case we might keep missing checkpoints until the WAL blows up in size, slowing down readers even further.

Because we don't actually need to wait for all readers to fully complete, and it doesn't block new readers (they'll be on the new snapshot), try increasing the timeout by quite a lot. This will still cause writes (changes) to temporarily queue up, but at least this will not be blowing everything up if a lot of slow readers (subs) constantly block checkpointing.