### PR TITLE
Increase WAL checkpoint timeout

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -396,7 +396,7 @@ fn wal_checkpoint(conn: &rusqlite::Connection) -> eyre::Result<()> {
     let start = Instant::now();
 
     let orig: u64 = conn.pragma_query_value(None, "busy_timeout", |row| row.get(0))?;
-    conn.pragma_update(None, "busy_timeout", 60000)?;
+    conn.pragma_update(None, "busy_timeout", 600000)?;
 
     let busy: bool = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE);", [], |row| row.get(0))?;
     if busy {

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -396,7 +396,7 @@ fn wal_checkpoint(conn: &rusqlite::Connection) -> eyre::Result<()> {
     let start = Instant::now();
 
     let orig: u64 = conn.pragma_query_value(None, "busy_timeout", |row| row.get(0))?;
-    conn.pragma_update(None, "busy_timeout", 600000)?;
+    conn.pragma_update(None, "busy_timeout", 240000)?;
 
     let busy: bool = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE);", [], |row| row.get(0))?;
     if busy {


### PR DESCRIPTION
busy_handler of checkpoints will wait until all readers are on the same latest snapshot, NOT when all readers complete. With huge subs we often have readers that take very long to complete, and in that case we might keep missing checkpoints until the WAL blows up in size, slowing down readers even further.

Because we don't actually need to wait for all readers to fully complete, and it doesn't block new readers (they'll be on the new snapshot), try increasing the timeout by quite a lot. This will still cause writes (changes) to temporarily queue up, but at least this will _not_ be blowing everything up if a lot of slow readers (subs) constantly block checkpointing.