### PR TITLE
Add cli command to change log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,8 @@ dependencies = [
  "tokio-serde",
  "tokio-util",
  "tracing",
+ "tracing-filter",
+ "tracing-subscriber",
  "tripwire",
  "uuid",
 ]

--- a/crates/corro-admin/Cargo.toml
+++ b/crates/corro-admin/Cargo.toml
@@ -18,6 +18,8 @@ tokio = { workspace = true }
 tokio-serde = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-filter = { workspace = true }
 tripwire = { path = "../tripwire" }
 rangemap = { workspace = true }
 uuid = { workspace = true }

--- a/crates/corrosion/src/command/agent.rs
+++ b/crates/corrosion/src/command/agent.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, time::Duration};
 
 use build_info::VersionControl;
 use camino::Utf8PathBuf;
-use corro_admin::AdminConfig;
+use corro_admin::{AdminConfig, TracingHandle};
 use corro_types::config::{Config, PrometheusConfig};
 use metrics::gauge;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
@@ -13,7 +13,11 @@ use tracing::{error, info};
 
 use crate::VERSION;
 
-pub async fn run(config: Config, config_path: &Utf8PathBuf) -> eyre::Result<()> {
+pub async fn run(
+    config: Config,
+    config_path: &Utf8PathBuf,
+    tracing_handle: Option<TracingHandle>,
+) -> eyre::Result<()> {
     info!("Starting Corrosion Agent v{VERSION}");
 
     if let Some(PrometheusConfig { bind_addr }) = config.telemetry.prometheus {
@@ -64,6 +68,7 @@ pub async fn run(config: Config, config_path: &Utf8PathBuf) -> eyre::Result<()> 
             listen_path: config.admin.uds_path.clone(),
             config_path: config_path.clone(),
         },
+        tracing_handle,
         tripwire,
     )?;
 


### PR DESCRIPTION
This pull request adds two commands `corrosion log set <FILTER>` and `corrosion log reset` to dynamically set the log filtering when corrosion is running, which can be helpful during debugging