### PR TITLE
Use `rust-toolchain.toml` with `fenix` for reproducible builds while allowing for flake updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,17 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1701671019,
-        "narHash": "sha256-ctG01Syj/7TrfV4arc3qyN4a3mAvgXbivYrdXKqdL8U=",
+        "lastModified": 1748414334,
+        "narHash": "sha256-pWLq78fWssxiRAvLQZnxKupUogR25u+28XS4lfxMMoE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "5e6667eda7fb055c0a8388172372fb89e5b33e05",
+        "rev": "1c050d9008ff9e934f8bb5298c902259ea2cb3f7",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
+        "rev": "1c050d9008ff9e934f8bb5298c902259ea2cb3f7",
         "type": "github"
       }
     },
@@ -26,31 +27,32 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701436327,
-        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
+        "lastModified": 1748302896,
+        "narHash": "sha256-ixMT0a8mM091vSswlTORZj93WQAJsRNmEvqLL+qwTFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
+        "rev": "7848cd8c982f7740edf76ddb3b43d234cb80fc4d",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "type": "indirect"
       }
     },
@@ -64,11 +66,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1701447636,
-        "narHash": "sha256-WaCcxLNAqo/FAK0QtYqweKCUVTGcbKpFIHClc+k2YlI=",
+        "lastModified": 1748389118,
+        "narHash": "sha256-5QJCzMtA2lBFNGou2dbFrGgWXxfL2O92oJoUnqeoNjI=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "e402c494b7c7d94a37c6d789a216187aaf9ccd3e",
+        "rev": "4f7af13637a77ce1dc21e58fcd3f635efbfb43a7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,19 @@
             mdbook serve
           '';
         };
+
+        # Run using `nix develop`. This devShell sets up the same dependencies and toolchain used in package.default
+        devShells.default = pkgs.mkShell {
+          name = "test-shell";
+          nativeBuildInputs = with pkgs; [
+            clang
+            mold
+            toolchain
+            pkg-config
+          ];
+
+          RUST_BACKTRACE = 1;
+        };
         ## Here we declare the only flake output to be a nix build
         ## of the corrosion crate tree
         packages.default = rust.buildRustPackage {

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,11 @@
             pkg-config
           ];
 
+          # Keep shell hook from packages.default
+          shellHook = ''
+            ulimit -n 65536
+          '';
+
           RUST_BACKTRACE = 1;
         };
         ## Here we declare the only flake output to be a nix build

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,11 @@
   inputs = {
     ## The fenix flake gives us access to nightly rust toolchains
     fenix = {
-      url = "github:nix-community/fenix";
+      url = "github:nix-community/fenix?rev=1c050d9008ff9e934f8bb5298c902259ea2cb3f7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs.url = "nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils?rev=11707dc2f618dd54ca8739b309ec4fc024de578b";
   };
 
   ## Specify flake environment outputs


### PR DESCRIPTION
This PR refines flake.nix to improve Rust toolchain handling and development workflow:
- Configures `fenix` to derive the Rust toolchain from `rust-toolchain.toml`.
- Ensures the project builds using the derived toolchain.
- Adds a devShell (`nix develop`) that bootstraps the same toolchain for development and testing.
![image](https://github.com/user-attachments/assets/8d93feb5-a576-43a5-9523-de1dd79b2877)

These changes enhance reproducibility by strictly pinning the Rust toolchain used in both builds and development, while still allowing flake inputs to be updated independently. 
