### PR TITLE
Apply schema before starting http api handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ name = "corro-client"
 version = "0.1.0-alpha.1"
 dependencies = [
  "bytes",
+ "corro-agent",
  "corro-api-types",
  "futures",
  "hickory-resolver",

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -58,6 +58,7 @@ use std::{
     convert::Infallible,
     net::SocketAddr,
     ops::{Deref, RangeInclusive},
+    path::Path,
     sync::{atomic::AtomicI64, Arc},
     time::{Duration, Instant},
 };
@@ -1443,6 +1444,87 @@ pub fn check_buffered_meta_to_clear(
     }
 
     conn.prepare_cached("SELECT EXISTS(SELECT 1 FROM __corro_seq_bookkeeping WHERE site_id = ? AND version >= ? AND version <= ?)")?.query_row(params![actor_id, versions.start(), versions.end()], |row| row.get(0))
+}
+
+pub async fn read_files_from_paths<P: AsRef<Path>>(
+    schema_paths: &[P],
+) -> eyre::Result<Vec<String>> {
+    let mut contents = vec![];
+
+    for schema_path in schema_paths.iter() {
+        match tokio::fs::metadata(schema_path).await {
+            Ok(meta) => {
+                if meta.is_dir() {
+                    match tokio::fs::read_dir(schema_path).await {
+                        Ok(mut dir) => {
+                            let mut entries = vec![];
+
+                            while let Ok(Some(entry)) = dir.next_entry().await {
+                                entries.push(entry);
+                            }
+
+                            let mut entries: Vec<_> = entries
+                                .into_iter()
+                                .filter_map(|entry| {
+                                    entry.path().extension().and_then(|ext| {
+                                        if ext == "sql" {
+                                            Some(entry)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                })
+                                .collect();
+
+                            entries.sort_by_key(|entry| entry.path());
+
+                            for entry in entries.iter() {
+                                match tokio::fs::read_to_string(entry.path()).await {
+                                    Ok(s) => {
+                                        contents.push(s);
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "could not read schema file '{}', error: {e}",
+                                            entry.path().display()
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "could not read dir '{}', error: {e}",
+                                schema_path.as_ref().display()
+                            );
+                        }
+                    }
+                } else if meta.is_file() {
+                    match tokio::fs::read_to_string(schema_path).await {
+                        Ok(s) => {
+                            contents.push(s);
+                            // pushed.push(schema_path.clone());
+                        }
+                        Err(e) => {
+                            warn!(
+                                "could not read schema file '{}', error: {e}",
+                                schema_path.as_ref().display()
+                            );
+                        }
+                    }
+                }
+            }
+
+            Err(e) => {
+                warn!(
+                    "could not read schema file meta '{}', error: {e}",
+                    schema_path.as_ref().display()
+                );
+            }
+        }
+    }
+
+    Ok(contents)
 }
 
 pub fn log_at_pow_10(msg: &str, count: &mut u64) {

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -508,7 +508,7 @@ pub async fn api_v1_queries(
     }
 }
 
-async fn execute_schema(agent: &Agent, statements: Vec<String>) -> eyre::Result<()> {
+pub(crate) async fn execute_schema(agent: &Agent, statements: Vec<String>) -> eyre::Result<()> {
     let new_sql: String = statements.join(";");
 
     let partial_schema = parse_sql(&new_sql)?;

--- a/crates/corro-client/Cargo.toml
+++ b/crates/corro-client/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [dependencies]
 bytes = { workspace = true }
 corro-api-types = { version = "0.1.0-alpha.1", path = "../corro-api-types" }
+corro-agent = { path = "../corro-agent" }
 futures = { workspace = true }
 hickory-resolver = { workspace = true }
 http = { workspace = true }

--- a/crates/corro-tests/src/lib.rs
+++ b/crates/corro-tests/src/lib.rs
@@ -77,14 +77,7 @@ pub async fn launch_test_agent<F: FnOnce(ConfigBuilder) -> Result<Config, Config
     tokio::fs::create_dir(&schema_path).await?;
     tokio::fs::write(schema_path.join("tests.sql"), TEST_SCHEMA.as_bytes()).await?;
 
-    let schema_paths = conf.db.schema_paths.clone();
-
     let (agent, bookie) = start_with_config(conf.clone(), tripwire).await?;
-
-    {
-        let client = corro_client::CorrosionApiClient::new(agent.api_addr());
-        client.schema_from_paths(&schema_paths).await?;
-    }
 
     Ok(TestAgent {
         agent,


### PR DESCRIPTION
This pull request moves the code that applies the schema on startup. Sometimes we can fail to process requests and changes from other nodes because the schema isn't loaded yet.