### PR TITLE
corro-client: don't depend on corro-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "corro-speedy",
  "corro-tests",
  "corro-types",
+ "corro-utils",
  "eyre",
  "foca",
  "futures",
@@ -870,8 +871,8 @@ name = "corro-client"
 version = "0.1.0-alpha.1"
 dependencies = [
  "bytes",
- "corro-agent",
  "corro-api-types",
+ "corro-utils",
  "futures",
  "hickory-resolver",
  "http",
@@ -1042,6 +1043,15 @@ dependencies = [
  "tripwire",
  "uhlc",
  "uuid",
+]
+
+[[package]]
+name = "corro-utils"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/corro-agent/Cargo.toml
+++ b/crates/corro-agent/Cargo.toml
@@ -14,6 +14,7 @@ camino = { workspace = true }
 compact_str = { workspace = true }
 config = { workspace = true }
 corro-types = { path = "../corro-types" }
+corro-utils = { path = "../corro-utils" }
 eyre = { workspace = true }
 foca = { workspace = true }
 futures = { workspace = true }

--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -94,7 +94,7 @@ async fn run(agent: Agent, opts: AgentOptions, pconf: PerfConfig) -> eyre::Resul
     util::initialise_foca(&agent).await;
 
     // Load schema from paths
-    let stmts = util::read_files_from_paths(&agent.config().db.schema_paths).await?;
+    let stmts = corro_utils::read_files_from_paths(&agent.config().db.schema_paths).await?;
     if !stmts.is_empty() {
         if let Err(e) = execute_schema(&agent, stmts).await {
             error!("could not execute schema: {e}");

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -58,7 +58,6 @@ use std::{
     convert::Infallible,
     net::SocketAddr,
     ops::{Deref, RangeInclusive},
-    path::Path,
     sync::{atomic::AtomicI64, Arc},
     time::{Duration, Instant},
 };
@@ -1444,87 +1443,6 @@ pub fn check_buffered_meta_to_clear(
     }
 
     conn.prepare_cached("SELECT EXISTS(SELECT 1 FROM __corro_seq_bookkeeping WHERE site_id = ? AND version >= ? AND version <= ?)")?.query_row(params![actor_id, versions.start(), versions.end()], |row| row.get(0))
-}
-
-pub async fn read_files_from_paths<P: AsRef<Path>>(
-    schema_paths: &[P],
-) -> eyre::Result<Vec<String>> {
-    let mut contents = vec![];
-
-    for schema_path in schema_paths.iter() {
-        match tokio::fs::metadata(schema_path).await {
-            Ok(meta) => {
-                if meta.is_dir() {
-                    match tokio::fs::read_dir(schema_path).await {
-                        Ok(mut dir) => {
-                            let mut entries = vec![];
-
-                            while let Ok(Some(entry)) = dir.next_entry().await {
-                                entries.push(entry);
-                            }
-
-                            let mut entries: Vec<_> = entries
-                                .into_iter()
-                                .filter_map(|entry| {
-                                    entry.path().extension().and_then(|ext| {
-                                        if ext == "sql" {
-                                            Some(entry)
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                })
-                                .collect();
-
-                            entries.sort_by_key(|entry| entry.path());
-
-                            for entry in entries.iter() {
-                                match tokio::fs::read_to_string(entry.path()).await {
-                                    Ok(s) => {
-                                        contents.push(s);
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            "could not read schema file '{}', error: {e}",
-                                            entry.path().display()
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            warn!(
-                                "could not read dir '{}', error: {e}",
-                                schema_path.as_ref().display()
-                            );
-                        }
-                    }
-                } else if meta.is_file() {
-                    match tokio::fs::read_to_string(schema_path).await {
-                        Ok(s) => {
-                            contents.push(s);
-                            // pushed.push(schema_path.clone());
-                        }
-                        Err(e) => {
-                            warn!(
-                                "could not read schema file '{}', error: {e}",
-                                schema_path.as_ref().display()
-                            );
-                        }
-                    }
-                }
-            }
-
-            Err(e) => {
-                warn!(
-                    "could not read schema file meta '{}', error: {e}",
-                    schema_path.as_ref().display()
-                );
-            }
-        }
-    }
-
-    Ok(contents)
 }
 
 pub fn log_at_pow_10(msg: &str, count: &mut u64) {

--- a/crates/corro-client/Cargo.toml
+++ b/crates/corro-client/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 [dependencies]
 bytes = { workspace = true }
 corro-api-types = { version = "0.1.0-alpha.1", path = "../corro-api-types" }
-corro-agent = { path = "../corro-agent" }
+corro-utils = { path = "../corro-utils" }
 futures = { workspace = true }
 hickory-resolver = { workspace = true }
 http = { workspace = true }

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod sub;
 
-use corro_agent::agent::util::read_files_from_paths;
 use corro_api_types::{ChangeId, ExecResponse, ExecResult, SqliteValue, Statement};
 use hickory_resolver::{
     error::{ResolveError, ResolveErrorKind},
@@ -345,7 +344,7 @@ impl CorrosionApiClient {
         &self,
         schema_paths: &[P],
     ) -> Result<Option<ExecResponse>, Error> {
-        let statements: Vec<Statement> = read_files_from_paths(schema_paths)
+        let statements: Vec<Statement> = corro_utils::read_files_from_paths(schema_paths)
             .await
             .map_err(|e| Error::ResponseError(e.to_string()))?
             .into_iter()

--- a/crates/corro-utils/Cargo.toml
+++ b/crates/corro-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "corro-utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eyre = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/crates/corro-utils/src/lib.rs
+++ b/crates/corro-utils/src/lib.rs
@@ -82,4 +82,3 @@ pub async fn read_files_from_paths<P: AsRef<Path>>(
 
     Ok(contents)
 }
-

--- a/crates/corro-utils/src/lib.rs
+++ b/crates/corro-utils/src/lib.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+use tracing::warn;
+
+pub async fn read_files_from_paths<P: AsRef<Path>>(
+    schema_paths: &[P],
+) -> eyre::Result<Vec<String>> {
+    let mut contents = vec![];
+
+    for schema_path in schema_paths.iter() {
+        match tokio::fs::metadata(schema_path).await {
+            Ok(meta) => {
+                if meta.is_dir() {
+                    match tokio::fs::read_dir(schema_path).await {
+                        Ok(mut dir) => {
+                            let mut entries = vec![];
+
+                            while let Ok(Some(entry)) = dir.next_entry().await {
+                                entries.push(entry);
+                            }
+
+                            let mut entries: Vec<_> = entries
+                                .into_iter()
+                                .filter_map(|entry| {
+                                    entry.path().extension().and_then(|ext| {
+                                        if ext == "sql" {
+                                            Some(entry)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                })
+                                .collect();
+
+                            entries.sort_by_key(|entry| entry.path());
+
+                            for entry in entries.iter() {
+                                match tokio::fs::read_to_string(entry.path()).await {
+                                    Ok(s) => {
+                                        contents.push(s);
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "could not read schema file '{}', error: {e}",
+                                            entry.path().display()
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "could not read dir '{}', error: {e}",
+                                schema_path.as_ref().display()
+                            );
+                        }
+                    }
+                } else if meta.is_file() {
+                    match tokio::fs::read_to_string(schema_path).await {
+                        Ok(s) => {
+                            contents.push(s);
+                            // pushed.push(schema_path.clone());
+                        }
+                        Err(e) => {
+                            warn!(
+                                "could not read schema file '{}', error: {e}",
+                                schema_path.as_ref().display()
+                            );
+                        }
+                    }
+                }
+            }
+
+            Err(e) => {
+                warn!(
+                    "could not read schema file meta '{}', error: {e}",
+                    schema_path.as_ref().display()
+                );
+            }
+        }
+    }
+
+    Ok(contents)
+}
+


### PR DESCRIPTION
This pulls way too much excessive stuff into the proxy and causes
it to fail automatic security audit.

Instead, move the utils that have to be shared between the agent and
the client into a separate small crate.
