### PR TITLE
Allow to create CorrosionClient with user-provided SQLite pool

### DIFF
--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -376,6 +376,13 @@ impl CorrosionClient {
         }
     }
 
+    pub fn with_sqlite_pool(api_addr: SocketAddr, pool: sqlite_pool::RusqlitePool) -> Self {
+        Self {
+            api_client: CorrosionApiClient::new(api_addr),
+            pool,
+        }
+    }
+
     pub fn pool(&self) -> &sqlite_pool::RusqlitePool {
         &self.pool
     }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,10 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        rust-latest = fenix.packages."${system}".latest;
+        rust-toolchain = fenix.packages."${system}".fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          sha256 = "sha256-3aoA7PuH09g8F+60uTUQhnHrb/ARDLueSOD08ZVsWe0=";
+        };
       in
         {
           packages.mdbook-shell = pkgs.mkShell {
@@ -63,7 +66,7 @@
                 pkgs.pkg-config
                 pkgs.mold
                 pkgs.clang
-                rust-latest.toolchain
+                rust-toolchain
               ];
 
               ## Dependencies for the linked binary


### PR DESCRIPTION
- flake.nix: use Rust toolchain specified in rust-toolchain.toml
- corro-client: add a function to create Corrosion client with user-provided pool
