### PR TITLE
Remove reliance on unstable traits

### DIFF
--- a/.antithesis/client/rust-load-generator/src/main.rs
+++ b/.antithesis/client/rust-load-generator/src/main.rs
@@ -198,7 +198,7 @@ async fn query(addr: String, tripwire: Tripwire) -> eyre::Result<()> {
                         .query_typed::<TeamStats>(
                             &Statement::WithParams(
                                 TEAM_QUERY.into(),
-                                vec![format!("%{}%", letter).into()],
+                                vec![format!("%{letter}%").into()],
                             ),
                             None,
                         )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,10 @@ codegen-units = 16
 # backtraces are super expensive to compute in development,
 # always optimize that crate
 opt-level = 2
+
+[workspace.lints.clippy]
+io_other_error = "allow"
+large_enum_variant = "allow"
+needless_option_take = "allow"
+result_large_err = "allow"
+unnecessary_map_or = "allow"

--- a/crates/corro-agent/Cargo.toml
+++ b/crates/corro-agent/Cargo.toml
@@ -3,6 +3,9 @@ name = "corro-agent"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 antithesis_sdk = { workspace = true }
 arc-swap = { workspace = true }

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -1024,7 +1024,7 @@ mod tests {
             db_conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL")?;
         }
 
-        println!("temp db: {:?}", db_path);
+        println!("temp db: {db_path:?}");
         let write_sema = Arc::new(Semaphore::new(1));
         let pool = SplitPool::create(db_path, write_sema.clone()).await?;
 

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -668,8 +668,8 @@ pub async fn handle_changes(
             continue;
         }
 
-        if let Some(mut seqs) = change.seqs().cloned() {
-            let v = *change.versions().start();
+        if let Some(mut seqs) = change.seqs() {
+            let v = change.versions().start();
             if let Some(seen_seqs) = seen.get(&(change.actor_id, v)) {
                 if seqs.all(|seq| seen_seqs.contains(&seq)) {
                     continue;
@@ -729,8 +729,8 @@ pub async fn handle_changes(
             if let Some((dropped_change, _, _)) = queue.pop_front() {
                 for v in dropped_change.versions() {
                     if let Entry::Occupied(mut entry) = seen.entry((change.actor_id, v)) {
-                        if let Some(seqs) = dropped_change.seqs().cloned() {
-                            entry.get_mut().remove(seqs);
+                        if let Some(seqs) = dropped_change.seqs() {
+                            entry.get_mut().remove(seqs.into());
                         } else {
                             entry.swap_remove_entry();
                         }
@@ -753,8 +753,8 @@ pub async fn handle_changes(
         // this will only run once for a non-empty changeset
         for v in change.versions() {
             let entry = seen.entry((change.actor_id, v)).or_default();
-            if let Some(seqs) = change.seqs().cloned() {
-                entry.extend([seqs]);
+            if let Some(seqs) = change.seqs() {
+                entry.extend([seqs.into()]);
             }
         }
 
@@ -900,7 +900,10 @@ mod tests {
     use corro_tests::TEST_SCHEMA;
     use corro_types::api::{ColumnName, TableName};
     use corro_types::{
-        base::CrsqlDbVersion, broadcast::Changeset, change::Change, config::Config,
+        base::{dbsr, dbvr, CrsqlDbVersion},
+        broadcast::Changeset,
+        change::Change,
+        config::Config,
         pubsub::pack_columns,
     };
     use rusqlite::Connection;
@@ -983,7 +986,7 @@ mod tests {
                         changeset: Changeset::Full {
                             version: CrsqlDbVersion(i as u64),
                             changes: vec![crsql_row.clone()],
-                            seqs: CrsqlSeq(0)..=CrsqlSeq(0),
+                            seqs: dbsr!(0, 0),
                             last_seq: CrsqlSeq(0),
                             ts: agent.clock().new_timestamp().into(),
                         },
@@ -1003,8 +1006,8 @@ mod tests {
             .unwrap()
             .read::<&str, _>("test", None)
             .await;
-        assert!(booked.contains_all(CrsqlDbVersion(6)..=CrsqlDbVersion(10), None));
-        assert!(booked.contains_all(CrsqlDbVersion(1)..=CrsqlDbVersion(3), None));
+        assert!(booked.contains_all(dbvr!(6, 10), None));
+        assert!(booked.contains_all(dbvr!(1, 3), None));
         assert!(!booked.contains_version(&CrsqlDbVersion(5)));
         assert!(!booked.contains_version(&CrsqlDbVersion(4)));
 

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -9,12 +9,7 @@ use metrics::counter;
 use parking_lot::RwLock;
 use rusqlite::{Connection, OptionalExtension};
 use serde_json::json;
-use std::{
-    net::SocketAddr,
-    ops::{DerefMut, RangeInclusive},
-    sync::Arc,
-    time::Duration,
-};
+use std::{net::SocketAddr, ops::DerefMut, sync::Arc, time::Duration};
 use tokio::{
     net::TcpListener,
     sync::{
@@ -41,7 +36,7 @@ use corro_types::{
     agent::{
         migrate, Agent, AgentConfig, Booked, BookedVersions, LockRegistry, LockState, SplitPool,
     },
-    base::CrsqlDbVersion,
+    base::{CrsqlDbVersion, CrsqlDbVersionRange},
     broadcast::{BroadcastInput, ChangeSource, ChangeV1, FocaInput},
     channel::{bounded, CorroReceiver},
     config::Config,
@@ -60,7 +55,7 @@ pub struct AgentOptions {
     pub api_listeners: Vec<TcpListener>,
     pub rx_bcast: CorroReceiver<BroadcastInput>,
     pub rx_apply: CorroReceiver<(ActorId, CrsqlDbVersion)>,
-    pub rx_clear_buf: CorroReceiver<(ActorId, RangeInclusive<CrsqlDbVersion>)>,
+    pub rx_clear_buf: CorroReceiver<(ActorId, CrsqlDbVersionRange)>,
     pub rx_changes: CorroReceiver<(ChangeV1, ChangeSource)>,
     pub rx_foca: CorroReceiver<FocaInput>,
     pub rtt_rx: TokioReceiver<(SocketAddr, Duration)>,

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -20,7 +20,7 @@ use corro_types::{
     actor::{Actor, ActorId},
     agent::{Agent, Bookie, ChangeError, CurrentVersion, KnownDbVersion, PartialVersion},
     api::TableName,
-    base::{CrsqlDbVersion, CrsqlSeq},
+    base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq},
     broadcast::{ChangeSource, ChangeV1, Changeset, ChangesetParts, FocaCmd, FocaInput},
     channel::CorroReceiver,
     config::AuthzConfig,
@@ -429,7 +429,7 @@ pub async fn apply_fully_buffered_changes_loop(
 /// Compact the database by finding cleared versions
 pub async fn clear_buffered_meta_loop(
     agent: Agent,
-    mut rx_partials: CorroReceiver<(ActorId, RangeInclusive<CrsqlDbVersion>)>,
+    mut rx_partials: CorroReceiver<(ActorId, CrsqlDbVersionRange)>,
 ) {
     let tx_timeout: Duration = Duration::from_secs(agent.config().perf.sql_tx_timeout as u64);
 
@@ -630,7 +630,10 @@ pub async fn process_fully_buffered_changes(
                 info!(%actor_id, %version, "No buffered rows, skipped insertion into crsql_changes");
             }
 
-            if let Err(e) = agent.tx_clear_buf().try_send((actor_id, version..=version)) {
+            if let Err(e) = agent
+                .tx_clear_buf()
+                .try_send((actor_id, CrsqlDbVersionRange::single(version)))
+            {
                 error!("could not schedule buffered data clear: {e}");
             }
 
@@ -713,7 +716,7 @@ pub async fn process_multiple_changes(
         let versions = change.versions();
         let seqs = change.seqs();
 
-        if !seen.insert((change.actor_id, versions, seqs.cloned())) {
+        if !seen.insert((change.actor_id, versions, seqs)) {
             continue;
         }
 
@@ -796,10 +799,10 @@ pub async fn process_multiple_changes(
 
                 // check if we've seen this version here...
                 if versions.clone().all(|version| match seqs {
-                    Some(check_seqs) => match seen.get(&version) {
+                    Some(mut check_seqs) => match seen.get(&version) {
                         Some(maybe_partial) => match maybe_partial {
                             Some(PartialVersion { seqs, .. }) => {
-                                check_seqs.clone().all(|seq| seqs.contains(&seq))
+                                check_seqs.all(|seq| seqs.contains(&seq))
                             }
                             // other kind of known version
                             None => true,
@@ -814,7 +817,7 @@ pub async fn process_multiple_changes(
                 // optimizing this, insert later!
                 let known = if change.is_complete() && change.is_empty() {
                     let versions = change.versions();
-                    let end = *versions.end();
+                    let end = versions.end();
                     // update db_version in db if it's greater than the max
                     // since we aren't passing any changes to crsql
                     if Some(end) > max {
@@ -880,7 +883,7 @@ pub async fn process_multiple_changes(
                     _ => None,
                 };
 
-                seen.insert(versions.clone(), partial.clone());
+                seen.insert(versions.into(), partial.clone());
                 processed
                     .entry(actor_id)
                     .or_default()
@@ -924,7 +927,7 @@ pub async fn process_multiple_changes(
                 &tx,
                 processed
                     .iter()
-                    .map(|(versions, _)| versions.clone())
+                    .map(|(versions, _)| versions.into())
                     .collect(),
             )
             .map_err(|source| ChangeError::Rusqlite {
@@ -989,7 +992,7 @@ pub async fn process_multiple_changes(
             }
 
             for (versions, partial) in processed {
-                let version = *versions.start();
+                let version = versions.start();
                 if let Some(partial) = partial {
                     let PartialVersion { seqs, last_seq, .. } =
                         booked_write.insert_partial(version, partial);
@@ -1143,8 +1146,8 @@ pub fn process_incomplete_version<T: Deref<Target = rusqlite::Connection> + Comm
             named_params![
                 ":actor_id": actor_id,
                 ":db_version": version,
-                ":start": seqs.start(),
-                ":end": seqs.end(),
+                ":start": seqs.start_int(),
+                ":end": seqs.end_int(),
             ],
             |row| Ok(row.get(0)?..=row.get(1)?),
         )
@@ -1152,7 +1155,7 @@ pub fn process_incomplete_version<T: Deref<Target = rusqlite::Connection> + Comm
 
     // re-compute the ranges
     let mut new_ranges = RangeInclusiveSet::from_iter(deleted);
-    new_ranges.insert(seqs.clone());
+    new_ranges.insert((*seqs).into());
 
     let details = json!({"new_ranges": new_ranges});
     assert_always!(
@@ -1195,7 +1198,7 @@ pub fn process_complete_version<T: Deref<Target = rusqlite::Connection> + Commit
     agent: Agent,
     sp: &InterruptibleTransaction<T>,
     actor_id: ActorId,
-    versions: RangeInclusive<CrsqlDbVersion>,
+    versions: CrsqlDbVersionRange,
     parts: ChangesetParts,
 ) -> rusqlite::Result<(KnownDbVersion, Changeset, BTreeMap<TableName, u64>)> {
     let ChangesetParts {
@@ -1210,13 +1213,13 @@ pub fn process_complete_version<T: Deref<Target = rusqlite::Connection> + Commit
 
     debug!(%actor_id, %version, "complete change, applying right away! seqs: {seqs:?}, last_seq: {last_seq}, changes len: {len}, db version: {version}");
 
-    let details = json!({"len": len, "seqs": seqs.start().0, "seqs_end": seqs.end().0});
+    let details = json!({"len": len, "seqs": seqs.start_int(), "seqs_end": seqs.end_int()});
     assert_always!(
-        len <= (seqs.end().0 - seqs.start().0 + 1) as usize,
+        len <= seqs.len(),
         "number of changes is greater than the seq num",
         &details
     );
-    debug_assert!(len <= (seqs.end().0 - seqs.start().0 + 1) as usize, "change from actor {actor_id} version {version} has len {len} but seqs range is {seqs:?} and last_seq is {last_seq}");
+    debug_assert!(len <= seqs.len(), "change from actor {actor_id} version {version} has len {len} but seqs range is {seqs:?} and last_seq is {last_seq}");
 
     let mut impactful_changeset = vec![];
 
@@ -1297,7 +1300,7 @@ pub fn process_complete_version<T: Deref<Target = rusqlite::Connection> + Commit
 pub fn check_buffered_meta_to_clear(
     conn: &Connection,
     actor_id: ActorId,
-    versions: RangeInclusive<CrsqlDbVersion>,
+    versions: CrsqlDbVersionRange,
 ) -> rusqlite::Result<bool> {
     let should_clear: bool = conn.prepare_cached("SELECT EXISTS(SELECT 1 FROM __corro_buffered_changes WHERE site_id = ? AND db_version >= ? AND db_version <= ?)")?.query_row(params![actor_id, versions.start(), versions.end()], |row| row.get(0))?;
     if should_clear {

--- a/crates/corro-agent/src/api/peer/mod.rs
+++ b/crates/corro-agent/src/api/peer/mod.rs
@@ -751,7 +751,7 @@ fn send_change_chunks<I: Iterator<Item = rusqlite::Result<Change>>>(
             Some(Ok((changes, seqs))) => {
                 let start = Instant::now();
 
-                if changes.is_empty() && *seqs.start() == CrsqlSeq(0) && *seqs.end() == last_seq {
+                if changes.is_empty() && seqs.start() == CrsqlSeq(0) && seqs.end() == last_seq {
                     warn!(%actor_id, %version, "got an empty changes we should've had");
                     return Ok(());
                 } else {
@@ -760,7 +760,7 @@ fn send_change_chunks<I: Iterator<Item = rusqlite::Result<Change>>>(
                         changeset: Changeset::Full {
                             version,
                             changes,
-                            seqs: seqs.into(),
+                            seqs,
                             last_seq,
                             ts,
                         },

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -704,7 +704,6 @@ pub async fn api_v1_table_stats(
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
     use corro_types::{
         api::RowId,
         base::CrsqlDbVersion,
@@ -712,8 +711,7 @@ mod tests {
         config::Config,
         schema::SqliteType,
     };
-    use futures::Stream;
-    use http_body::{combinators::UnsyncBoxBody, Body};
+    use http_body::Body;
     use tokio::sync::mpsc::error::TryRecvError;
     use tokio_util::codec::{Decoder, LinesCodec};
     use tripwire::Tripwire;
@@ -721,19 +719,6 @@ mod tests {
     use super::*;
 
     use crate::agent::setup;
-
-    struct UnsyncBodyStream(std::pin::Pin<Box<UnsyncBoxBody<Bytes, axum::Error>>>);
-
-    impl Stream for UnsyncBodyStream {
-        type Item = Result<Bytes, axum::Error>;
-
-        fn poll_next(
-            mut self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Self::Item>> {
-            self.0.as_mut().poll_data(cx)
-        }
-    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_api_db_execute() -> eyre::Result<()> {

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -884,7 +884,7 @@ mod tests {
     use corro_types::actor::ActorId;
     use corro_types::api::NotifyEvent;
     use corro_types::api::{ColumnName, TableName};
-    use corro_types::base::{CrsqlDbVersion, CrsqlSeq};
+    use corro_types::base::{dbsr, CrsqlDbVersion, CrsqlSeq};
     use corro_types::broadcast::{ChangeSource, ChangeV1, Changeset};
     use corro_types::change::Change;
     use corro_types::pubsub::pack_columns;
@@ -896,7 +896,6 @@ mod tests {
     use http_body::Body;
     use serde::de::DeserializeOwned;
     use spawn::wait_for_all_pending_handles;
-    use std::ops::RangeInclusive;
     use std::time::Instant;
     use tokio::time::timeout;
     use tokio_util::codec::{Decoder, LinesCodec};
@@ -1505,7 +1504,7 @@ mod tests {
             changeset: Changeset::Full {
                 version: CrsqlDbVersion(1),
                 changes: vec![change1, change2],
-                seqs: RangeInclusive::new(CrsqlSeq(0), CrsqlSeq(1)),
+                seqs: dbsr!(0, 1),
                 last_seq: CrsqlSeq(1),
                 ts: Default::default(),
             },
@@ -1602,7 +1601,7 @@ mod tests {
             changeset: Changeset::Full {
                 version: CrsqlDbVersion(2),
                 changes: vec![change3],
-                seqs: RangeInclusive::new(CrsqlSeq(0), CrsqlSeq(0)),
+                seqs: dbsr!(0, 0),
                 last_seq: CrsqlSeq(1),
                 ts: Default::default(),
             },
@@ -1644,7 +1643,7 @@ mod tests {
             changeset: Changeset::Full {
                 version: CrsqlDbVersion(2),
                 changes: vec![change4],
-                seqs: RangeInclusive::new(CrsqlSeq(1), CrsqlSeq(1)),
+                seqs: dbsr!(1, 1),
                 last_seq: CrsqlSeq(1),
                 ts: Default::default(),
             },

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -1047,7 +1047,7 @@ mod tests {
     use crate::agent::spawn_unipayload_handler;
     use corro_tests::launch_test_agent;
     use corro_types::{
-        base::{CrsqlDbVersion, CrsqlSeq},
+        base::{dbsr, CrsqlDbVersion, CrsqlSeq},
         broadcast::{BroadcastV1, ChangeV1, Changeset},
     };
     use uuid::Uuid;
@@ -1134,7 +1134,7 @@ mod tests {
             changeset: Changeset::Full {
                 version: CrsqlDbVersion(0),
                 changes: vec![],
-                seqs: CrsqlSeq(0)..=CrsqlSeq(0),
+                seqs: dbsr!(0, 0),
                 last_seq: CrsqlSeq(0),
                 ts: Default::default(),
             },
@@ -1167,7 +1167,7 @@ mod tests {
                     changeset: Changeset::Full {
                         version: CrsqlDbVersion(i),
                         changes: vec![],
-                        seqs: CrsqlSeq(0)..=CrsqlSeq(0),
+                        seqs: dbsr!(0, 0),
                         last_seq: CrsqlSeq(0),
                         ts: Default::default(),
                     },
@@ -1187,7 +1187,10 @@ mod tests {
                 let changes = tokio::time::timeout(Duration::from_secs(5), rx_changes.recv())
                     .await?
                     .unwrap();
-                assert_eq!(changes.0.versions(), CrsqlDbVersion(i)..=CrsqlDbVersion(i));
+                assert_eq!(
+                    changes.0.versions(),
+                    (CrsqlDbVersion(i)..=CrsqlDbVersion(i)).into()
+                );
             }
         }
 

--- a/crates/corro-agent/src/lib.rs
+++ b/crates/corro-agent/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(step_trait)]
 pub mod agent;
 pub mod api;
 pub mod broadcast;

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -511,7 +511,7 @@ impl SqliteValue {
         }
     }
 
-    pub fn as_ref(&self) -> SqliteValueRef {
+    pub fn as_ref(&self) -> SqliteValueRef<'_> {
         match self {
             SqliteValue::Null => SqliteValueRef(ValueRef::Null),
             SqliteValue::Integer(i) => SqliteValueRef(ValueRef::Integer(*i)),

--- a/crates/corro-base-types/src/lib.rs
+++ b/crates/corro-base-types/src/lib.rs
@@ -294,20 +294,17 @@ macro_rules! range {
             /// The length of this range, ie the number of values
             /// that would be yielded on iteration
             #[inline]
-            pub fn len(self) -> usize {
-                if let Some(end) = self.end.map(|e| e.get()) {
-                    if end > self.start {
-                        (end - self.start) as usize + 1
-                    } else {
-                        0
-                    }
+            pub fn len(&self) -> usize {
+                let end = self.end.map_or(0, |e| e.get());
+                if end >= self.start {
+                    (end - self.start) as usize + 1
                 } else {
                     0
                 }
             }
 
             #[inline]
-            pub fn is_empty(self) -> bool {
+            pub fn is_empty(&self) -> bool {
                 self.len() == 0
             }
         }

--- a/crates/corro-base-types/src/lib.rs
+++ b/crates/corro-base-types/src/lib.rs
@@ -1,9 +1,6 @@
-#![feature(step_trait)]
-
 use std::{
     fmt,
-    iter::Step,
-    ops::{Add, Sub},
+    ops::{Add, RangeInclusive, Sub},
 };
 
 use rangemap::StepLite;
@@ -11,23 +8,84 @@ use rusqlite::{types::FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use speedy::{Context, Readable, Writable};
 
+#[macro_export]
+macro_rules! dbvr {
+    ($start:literal, $end:literal) => {
+        $crate::CrsqlDbVersionRange::new(
+            $crate::CrsqlDbVersion($start),
+            $crate::CrsqlDbVersion($end),
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! dbvri {
+    ($start:literal, $end:literal) => {
+        $crate::CrsqlDbVersion($start)..=$crate::CrsqlDbVersion($end)
+    };
+}
+
+#[macro_export]
+macro_rules! dbsr {
+    ($start:literal, $end:literal) => {
+        $crate::CrsqlSeqRange::new($crate::CrsqlSeq($start), $crate::CrsqlSeq($end))
+    };
+}
+
+#[macro_export]
+macro_rules! dbsri {
+    ($start:literal, $end:literal) => {
+        $crate::CrsqlSeq($start)..=$crate::CrsqlSeq($end)
+    };
+}
+
 #[derive(
     Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize,
 )]
 #[serde(transparent)]
 pub struct CrsqlDbVersion(pub u64);
 
-impl Step for CrsqlDbVersion {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        u64::steps_between(&start.0, &end.0)
+impl CrsqlDbVersion {
+    #[inline]
+    pub fn chunked_iter(
+        range: CrsqlDbVersionRange,
+        chunk_size: usize,
+    ) -> ChunkedCrsqlDbVersionIterator {
+        ChunkedCrsqlDbVersionIterator {
+            current: range.start_int(),
+            end: range.end_int(),
+            chunk_size: chunk_size as u64,
+        }
     }
+}
 
-    fn forward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::forward_checked(start.0, count).map(Self)
-    }
+pub struct ChunkedCrsqlDbVersionIterator {
+    current: u64,
+    end: u64,
+    chunk_size: u64,
+}
 
-    fn backward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::backward_checked(start.0, count).map(Self)
+impl Iterator for ChunkedCrsqlDbVersionIterator {
+    type Item = CrsqlDbVersionRange;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current > self.end {
+            return None;
+        }
+
+        // Avoid overflows if the end of the range happens to be within chunk_size
+        // of u64::MAX
+        let next_step = self.current.saturating_add(self.chunk_size);
+
+        let next = CrsqlDbVersionRange::new(
+            CrsqlDbVersion(self.current),
+            CrsqlDbVersion(next_step.min(self.end)),
+        );
+
+        self.current = next_step;
+
+        Some(next)
     }
 }
 
@@ -108,17 +166,11 @@ impl fmt::Display for CrsqlDbVersion {
 #[serde(transparent)]
 pub struct CrsqlSeq(pub u64);
 
-impl Step for CrsqlSeq {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        u64::steps_between(&start.0, &end.0)
-    }
-
-    fn forward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::forward_checked(start.0, count).map(Self)
-    }
-
-    fn backward_checked(start: Self, count: usize) -> Option<Self> {
-        u64::backward_checked(start.0, count).map(Self)
+impl CrsqlSeq {
+    #[inline]
+    pub fn iter(range: RangeInclusive<Self>) -> impl Iterator<Item = Self> {
+        let (start, end) = range.into_inner();
+        (start.0..=end.0).map(Self)
     }
 }
 
@@ -184,5 +236,282 @@ where
 impl fmt::Display for CrsqlSeq {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+macro_rules! range {
+    ($inner:ident, $name:ident, $iter:ident) => {
+        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+        pub struct $name {
+            start: u64,
+            end: Option<std::num::NonZeroU64>,
+        }
+
+        impl $name {
+            /// Equivalent of `(<start>..=<end>).into()`
+            #[inline]
+            pub fn new(start: $inner, end: $inner) -> Self {
+                Self {
+                    start: start.0,
+                    end: std::num::NonZeroU64::new(end.0),
+                }
+            }
+
+            /// Creates an empty range
+            #[inline]
+            pub fn empty() -> Self {
+                Self {
+                    start: 0,
+                    end: None,
+                }
+            }
+
+            /// Creates a range that starts and ends at the specified value
+            #[inline]
+            pub fn single(single: $inner) -> Self {
+                Self {
+                    start: single.0,
+                    end: std::num::NonZeroU64::new(single.0),
+                }
+            }
+
+            /// The typed start of the range
+            #[inline]
+            pub fn start(&self) -> $inner {
+                $inner(self.start)
+            }
+
+            /// The typed end of the range
+            #[inline]
+            pub fn end(&self) -> $inner {
+                $inner(self.end_int())
+            }
+
+            /// The u64 at the beginning of the range
+            #[inline]
+            pub fn start_int(&self) -> u64 {
+                self.start
+            }
+
+            /// The u64 at the end of the range
+            #[inline]
+            pub fn end_int(&self) -> u64 {
+                self.end.map_or(0, |e| e.get())
+            }
+
+            /// The length of this range, ie the number of values
+            /// that would be yielded on iteration
+            #[inline]
+            pub fn len(self) -> usize {
+                if let Some(end) = self.end.map(|e| e.get()) {
+                    if end > self.start {
+                        (end - self.start) as usize + 1
+                    } else {
+                        0
+                    }
+                } else {
+                    0
+                }
+            }
+
+            #[inline]
+            pub fn is_empty(self) -> bool {
+                self.len() == 0
+            }
+        }
+
+        impl From<RangeInclusive<$inner>> for $name {
+            #[inline]
+            fn from(r: RangeInclusive<$inner>) -> Self {
+                let (start, end) = r.into_inner();
+                Self {
+                    start: start.0,
+                    end: std::num::NonZeroU64::new(end.0),
+                }
+            }
+        }
+
+        impl<'s> From<&'s RangeInclusive<$inner>> for $name {
+            #[inline]
+            fn from(r: &'s RangeInclusive<$inner>) -> Self {
+                Self {
+                    start: r.start().0,
+                    end: std::num::NonZeroU64::new(r.end().0),
+                }
+            }
+        }
+
+        impl From<$name> for RangeInclusive<$inner> {
+            #[inline]
+            fn from(r: $name) -> Self {
+                Self::new(r.start(), r.end())
+            }
+        }
+
+        impl<'s> From<&'s $name> for RangeInclusive<$inner> {
+            #[inline]
+            fn from(r: &'s $name) -> Self {
+                Self::new(r.start(), r.end())
+            }
+        }
+
+        impl Iterator for $name {
+            type Item = $inner;
+
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {
+                let end = self.end?;
+
+                let next = if self.start < end.get() {
+                    let n = $inner(self.start);
+                    self.start += 1;
+                    n
+                } else {
+                    self.end = None;
+                    $inner(self.start)
+                };
+
+                Some(next)
+            }
+
+            #[inline]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                let Some(end) = self.end else {
+                    return (0, Some(0));
+                };
+                if self.start < end.get() {
+                    let diff = (end.get() - self.start) as usize;
+                    (diff, Some(diff))
+                } else {
+                    (0, Some(0))
+                }
+            }
+        }
+
+        impl<'a, C: speedy::Context> Readable<'a, C> for $name {
+            #[inline]
+            fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+                let start = reader.read_value()?;
+                let end = reader.read_value()?;
+                Ok(Self { start, end })
+            }
+
+            #[inline]
+            fn minimum_bytes_needed() -> usize {
+                <u64 as Readable<'a, C>>::minimum_bytes_needed() * 2
+            }
+        }
+
+        impl<C: speedy::Context> Writable<C> for $name {
+            #[inline]
+            fn write_to<W: ?Sized + speedy::Writer<C>>(
+                &self,
+                writer: &mut W,
+            ) -> Result<(), C::Error> {
+                self.start.write_to(writer)?;
+                self.end.write_to(writer)
+            }
+
+            #[inline]
+            fn bytes_needed(&self) -> Result<usize, C::Error> {
+                Ok(Writable::<C>::bytes_needed(&self.start)?
+                    + Writable::<C>::bytes_needed(&self.end)?)
+            }
+        }
+    };
+}
+
+range!(CrsqlDbVersion, CrsqlDbVersionRange, CrsqlDbVersionIter);
+range!(CrsqlSeq, CrsqlSeqRange, CrsqlSeqIter);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn chunked_iter() {
+        /// This was the original implementation in corro-agent::api::peer, reproduced
+        /// here in stable form to validate the range implementation matches
+        fn chunk_range(
+            range: RangeInclusive<u64>,
+            chunk_size: usize,
+        ) -> impl Iterator<Item = RangeInclusive<u64>> {
+            let end = *range.end();
+            range.step_by(chunk_size).map(move |block_start| {
+                let block_end = (block_start + chunk_size as u64).min(end);
+                block_start..=block_end
+            })
+        }
+
+        #[track_caller]
+        fn matches_step_by(range: RangeInclusive<u64>, chunk_size: usize) {
+            let mut ours = CrsqlDbVersion::chunked_iter(
+                CrsqlDbVersionRange::new(
+                    CrsqlDbVersion(*range.start()),
+                    CrsqlDbVersion(*range.end()),
+                ),
+                chunk_size,
+            );
+            let mut stds = chunk_range(range, chunk_size);
+
+            loop {
+                match (ours.next(), stds.next()) {
+                    (Some(o), Some(s)) => {
+                        assert_eq!(o.start_int(), *s.start());
+                        assert_eq!(o.end_int(), *s.end());
+                    }
+                    (None, None) => {
+                        break;
+                    }
+                    (Some(o), None) => {
+                        panic!("step_by was done but we still had {o:?}");
+                    }
+                    (None, Some(s)) => {
+                        panic!("we were done but step_by still had {s:?}");
+                    }
+                }
+            }
+        }
+
+        // a range is always emitted, even on empty ranges
+        {
+            matches_step_by(0..=0, 10);
+            matches_step_by(1987..=1987, 1);
+
+            // ...unless the start > end
+            #[allow(clippy::reversed_empty_ranges)]
+            matches_step_by(2..=0, 1);
+        }
+
+        // exact
+        {
+            matches_step_by(1..=10, 11);
+            matches_step_by(0..=1, 1);
+            matches_step_by(1..=13, 14);
+        }
+
+        // remainder
+        {
+            matches_step_by(2001..=11000, 13);
+        }
+    }
+
+    #[test]
+    fn ranges() {
+        let r = dbsr!(1, 1000);
+        assert_eq!(r.len(), 1000);
+
+        let ri = RangeInclusive::from(r);
+        assert_eq!(ri.start(), &r.start());
+        assert_eq!(ri.end(), &r.end());
+
+        for (i, (ours, theirs)) in r.zip(r.start_int()..=r.end_int()).enumerate() {
+            assert_eq!(ours.0, theirs, "oops {i}");
+        }
+
+        let max =
+            CrsqlDbVersionRange::from(CrsqlDbVersion(u64::MAX - 1)..=CrsqlDbVersion(u64::MAX));
+        assert_eq!(max.len(), 2);
+        assert_eq!(max.into_iter().count(), 2);
     }
 }

--- a/crates/corro-base-types/src/lib.rs
+++ b/crates/corro-base-types/src/lib.rs
@@ -166,14 +166,6 @@ impl fmt::Display for CrsqlDbVersion {
 #[serde(transparent)]
 pub struct CrsqlSeq(pub u64);
 
-impl CrsqlSeq {
-    #[inline]
-    pub fn iter(range: RangeInclusive<Self>) -> impl Iterator<Item = Self> {
-        let (start, end) = range.into_inner();
-        (start.0..=end.0).map(Self)
-    }
-}
-
 impl StepLite for CrsqlSeq {
     fn add_one(&self) -> Self {
         Self(self.0 + 1)
@@ -376,15 +368,8 @@ macro_rules! range {
 
             #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
-                let Some(end) = self.end else {
-                    return (0, Some(0));
-                };
-                if self.start < end.get() {
-                    let diff = (end.get() - self.start) as usize;
-                    (diff, Some(diff))
-                } else {
-                    (0, Some(0))
-                }
+                let len = self.len();
+                (len, Some(len))
             }
         }
 

--- a/crates/corro-client/Cargo.toml
+++ b/crates/corro-client/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 description = "client to interact with corrosion"
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 bytes = { workspace = true }

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -53,9 +53,7 @@ impl CorrosionApiClient {
         statement: &Statement,
         timeout: Option<u64>,
     ) -> Result<QueryStream<T>, Error> {
-        let params = timeout
-            .map(|t| format!("?timeout={}", t))
-            .unwrap_or_default();
+        let params = timeout.map(|t| format!("?timeout={t}")).unwrap_or_default();
         let req = hyper::Request::builder()
             .method(hyper::Method::POST)
             .uri(format!("http://{}/v1/queries{}", self.api_addr, params))
@@ -115,7 +113,7 @@ impl CorrosionApiClient {
             )
             .try_into()?
         } else {
-            format!("/v1/subscriptions?skip_rows={}", skip_rows).try_into()?
+            format!("/v1/subscriptions?skip_rows={skip_rows}").try_into()?
         };
         let url = hyper::Uri::builder()
             .scheme("http")
@@ -179,7 +177,7 @@ impl CorrosionApiClient {
             )
             .try_into()?
         } else {
-            format!("/v1/subscriptions/{id}?skip_rows={}", skip_rows).try_into()?
+            format!("/v1/subscriptions/{id}?skip_rows={skip_rows}").try_into()?
         };
         let url = hyper::Uri::builder()
             .scheme("http")
@@ -227,7 +225,7 @@ impl CorrosionApiClient {
         &self,
         table: &str,
     ) -> Result<UpdatesStream<T>, Error> {
-        let p_and_q: PathAndQuery = format!("/v1/updates/{}", table).try_into()?;
+        let p_and_q: PathAndQuery = format!("/v1/updates/{table}").try_into()?;
 
         let url = hyper::Uri::builder()
             .scheme("http")

--- a/crates/corro-devcluster/src/main.rs
+++ b/crates/corro-devcluster/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
 }
 
 fn run_simple_topology(topo: Simple, bin_path: String, state_dir: PathBuf, schema_dir: PathBuf) {
-    println!("//// Creating topology: \n{:#?}", topo);
+    println!("//// Creating topology: \n{topo:#?}");
     let nodes = topo.get_all_nodes();
 
     let mut port_map = BTreeMap::default();
@@ -140,10 +140,7 @@ fn run_simple_topology(topo: Simple, bin_path: String, state_dir: PathBuf, schem
             bootstrap_set,
         );
 
-        println!(
-            "Generated config for node '{}': \n{}",
-            node_name, node_config
-        );
+        println!("Generated config for node '{node_name}': \n{node_config}",);
 
         let mut config_file = File::create(node_state.join("config.toml"))
             .expect("failed to create node config file");

--- a/crates/corro-pg/Cargo.toml
+++ b/crates/corro-pg/Cargo.toml
@@ -3,6 +3,9 @@ name = "corro-pg"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 bytes = { workspace = true }
 compact_str = { workspace = true }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2554,7 +2554,7 @@ enum ParamKind<'a> {
     Positional,
 }
 
-fn as_param(expr: &Expr) -> Option<ParamKind> {
+fn as_param(expr: &Expr) -> Option<ParamKind<'_>> {
     if let Expr::Variable(name) = expr {
         if name.is_empty() {
             Some(ParamKind::Positional)
@@ -2595,7 +2595,7 @@ enum SqliteName {
     DoublyQualified(Name, Name, Name),
 }
 
-fn expr_to_name(expr: &Expr) -> Option<SqliteNameRef> {
+fn expr_to_name(expr: &Expr) -> Option<SqliteNameRef<'_>> {
     match expr {
         Expr::Id(id) => Some(SqliteNameRef::Id(id)),
         Expr::Name(name) => Some(SqliteNameRef::Name(name)),

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "common types for corrosion"
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 arc-swap = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -1377,10 +1377,8 @@ impl BookedVersions {
     pub fn contains(&self, version: CrsqlDbVersion, seqs: Option<CrsqlSeqRange>) -> bool {
         self.contains_version(&version)
             && seqs
-                .map(|check_seqs| match self.partials.get(&version) {
-                    Some(partial) => check_seqs
-                        .into_iter()
-                        .all(|seq| partial.seqs.contains(&seq)),
+                .map(|mut check_seqs| match self.partials.get(&version) {
+                    Some(partial) => check_seqs.all(|seq| partial.seqs.contains(&seq)),
                     // if `contains_version` is true but we don't have a partial version,
                     // then we must have it as a fully applied or cleared version
                     None => true,

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -1140,7 +1140,7 @@ impl VersionsSnapshot {
             }
             let details = json!({"count": count, "range": range});
             assert_always!(count == 1, "ineffective deletion of gaps in-db", &details);
-            for version in CrsqlDbVersionRange::from(range.clone()) {
+            for version in CrsqlDbVersionRange::from(&range) {
                 self.partials.remove(&version);
             }
             self.needed.remove(range);

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -1578,7 +1578,7 @@ impl Bookie {
         &self,
         label: &'static str,
         extra: E,
-    ) -> CountedTokioRwLockReadGuard<BookieInner> {
+    ) -> CountedTokioRwLockReadGuard<'_, BookieInner> {
         self.0.read(label, extra).await
     }
 
@@ -1586,7 +1586,7 @@ impl Bookie {
         &self,
         label: &'static str,
         extra: E,
-    ) -> CountedTokioRwLockWriteGuard<BookieInner> {
+    ) -> CountedTokioRwLockWriteGuard<'_, BookieInner> {
         self.0.write(label, extra).await
     }
 
@@ -1594,7 +1594,7 @@ impl Bookie {
         &self,
         label: &'static str,
         extra: E,
-    ) -> CountedTokioRwLockWriteGuard<BookieInner> {
+    ) -> CountedTokioRwLockWriteGuard<'_, BookieInner> {
         self.0.blocking_write(label, extra)
     }
 

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -43,7 +43,7 @@ use tripwire::Tripwire;
 
 use crate::{
     actor::{Actor, ActorId, ClusterId},
-    base::{CrsqlDbVersion, CrsqlSeq},
+    base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq, CrsqlSeqRange},
     broadcast::{BroadcastInput, ChangeSource, ChangeV1, FocaInput, Timestamp},
     channel::{bounded, CorroSender},
     config::Config,
@@ -75,7 +75,7 @@ pub struct AgentConfig {
 
     pub tx_bcast: CorroSender<BroadcastInput>,
     pub tx_apply: CorroSender<(ActorId, CrsqlDbVersion)>,
-    pub tx_clear_buf: CorroSender<(ActorId, RangeInclusive<CrsqlDbVersion>)>,
+    pub tx_clear_buf: CorroSender<(ActorId, CrsqlDbVersionRange)>,
     pub tx_changes: CorroSender<(ChangeV1, ChangeSource)>,
     pub tx_foca: CorroSender<FocaInput>,
 
@@ -103,7 +103,7 @@ pub struct AgentInner {
     booked: Booked,
     tx_bcast: CorroSender<BroadcastInput>,
     tx_apply: CorroSender<(ActorId, CrsqlDbVersion)>,
-    tx_clear_buf: CorroSender<(ActorId, RangeInclusive<CrsqlDbVersion>)>,
+    tx_clear_buf: CorroSender<(ActorId, CrsqlDbVersionRange)>,
     tx_changes: CorroSender<(ChangeV1, ChangeSource)>,
     tx_foca: CorroSender<FocaInput>,
     write_sema: Arc<Semaphore>,
@@ -193,7 +193,7 @@ impl Agent {
         &self.0.tx_changes
     }
 
-    pub fn tx_clear_buf(&self) -> &CorroSender<(ActorId, RangeInclusive<CrsqlDbVersion>)> {
+    pub fn tx_clear_buf(&self) -> &CorroSender<(ActorId, CrsqlDbVersionRange)> {
         &self.0.tx_clear_buf
     }
 
@@ -1140,7 +1140,7 @@ impl VersionsSnapshot {
             }
             let details = json!({"count": count, "range": range});
             assert_always!(count == 1, "ineffective deletion of gaps in-db", &details);
-            for version in range.clone() {
+            for version in CrsqlDbVersionRange::from(range.clone()) {
                 self.partials.remove(&version);
             }
             self.needed.remove(range);
@@ -1374,15 +1374,13 @@ impl BookedVersions {
         self.partials.get(version)
     }
 
-    pub fn contains(
-        &self,
-        version: CrsqlDbVersion,
-        seqs: Option<&RangeInclusive<CrsqlSeq>>,
-    ) -> bool {
+    pub fn contains(&self, version: CrsqlDbVersion, seqs: Option<CrsqlSeqRange>) -> bool {
         self.contains_version(&version)
             && seqs
                 .map(|check_seqs| match self.partials.get(&version) {
-                    Some(partial) => check_seqs.clone().all(|seq| partial.seqs.contains(&seq)),
+                    Some(partial) => check_seqs
+                        .into_iter()
+                        .all(|seq| partial.seqs.contains(&seq)),
                     // if `contains_version` is true but we don't have a partial version,
                     // then we must have it as a fully applied or cleared version
                     None => true,
@@ -1390,12 +1388,13 @@ impl BookedVersions {
                 .unwrap_or(true)
     }
 
+    #[inline]
     pub fn contains_all(
         &self,
-        mut versions: RangeInclusive<CrsqlDbVersion>,
-        seqs: Option<&RangeInclusive<CrsqlSeq>>,
+        versions: impl Into<CrsqlDbVersionRange>,
+        seqs: Option<CrsqlSeqRange>,
     ) -> bool {
-        versions.all(|version| self.contains(version, seqs))
+        versions.into().all(|version| self.contains(version, seqs))
     }
 
     pub fn last(&self) -> Option<CrsqlDbVersion> {
@@ -1609,6 +1608,7 @@ impl Bookie {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::{dbvr, dbvri};
     use rangemap::range_inclusive_set;
 
     #[test]
@@ -1629,7 +1629,7 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(1)..=CrsqlDbVersion(20)],
+            range_inclusive_set![dbvri!(1, 20)],
         )?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
@@ -1637,7 +1637,7 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(1)..=CrsqlDbVersion(10)],
+            range_inclusive_set![dbvri!(1, 10)],
         )?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
@@ -1650,27 +1650,16 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![
-                CrsqlDbVersion(1)..=CrsqlDbVersion(1),
-                CrsqlDbVersion(4)..=CrsqlDbVersion(4)
-            ],
+            range_inclusive_set![dbvri!(1, 1), dbvri!(4, 4)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(2)..=CrsqlDbVersion(3)],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(2, 3)])?;
 
         // fill gap
         insert_everywhere(
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![
-                CrsqlDbVersion(3)..=CrsqlDbVersion(3),
-                CrsqlDbVersion(2)..=CrsqlDbVersion(2)
-            ],
+            range_inclusive_set![dbvri!(3, 3), dbvri!(2, 2)],
         )?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
@@ -1683,79 +1672,36 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(5)..=CrsqlDbVersion(20)],
+            range_inclusive_set![dbvri!(5, 20)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(1)..=CrsqlDbVersion(4)],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(1, 4)])?;
 
         // insert a further change that does not overlap a gap
-        insert_everywhere(
-            &conn,
-            &mut bv,
-            &mut all,
-            range_inclusive_set![CrsqlDbVersion(6)..=CrsqlDbVersion(7)],
-        )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(1)..=CrsqlDbVersion(4)],
-        )?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![dbvri!(6, 7)])?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(1, 4)])?;
 
         // insert a further change that does overlap a gap
-        insert_everywhere(
-            &conn,
-            &mut bv,
-            &mut all,
-            range_inclusive_set![CrsqlDbVersion(3)..=CrsqlDbVersion(7)],
-        )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(1)..=CrsqlDbVersion(2)],
-        )?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![dbvri!(3, 7)])?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(1, 2)])?;
 
-        insert_everywhere(
-            &conn,
-            &mut bv,
-            &mut all,
-            range_inclusive_set![CrsqlDbVersion(1)..=CrsqlDbVersion(2)],
-        )?;
+        insert_everywhere(&conn, &mut bv, &mut all, range_inclusive_set![dbvri!(1, 2)])?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
         insert_everywhere(
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(25)..=CrsqlDbVersion(25)],
+            range_inclusive_set![dbvri!(25, 25)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(21)..=CrsqlDbVersion(24)],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(21, 24)])?;
 
         insert_everywhere(
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(30)..=CrsqlDbVersion(35)],
+            range_inclusive_set![dbvri!(30, 35)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![
-                CrsqlDbVersion(21)..=CrsqlDbVersion(24),
-                CrsqlDbVersion(26)..=CrsqlDbVersion(29),
-            ],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(21, 24), dbvr!(26, 29)])?;
 
         // NOTE: overlapping partially from the end
 
@@ -1763,17 +1709,9 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(19)..=CrsqlDbVersion(22)],
+            range_inclusive_set![dbvri!(19, 22)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![
-                CrsqlDbVersion(23)..=CrsqlDbVersion(24),
-                CrsqlDbVersion(26)..=CrsqlDbVersion(29),
-            ],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(23, 24), dbvr!(26, 29)])?;
 
         // NOTE: overlapping partially from the start
 
@@ -1781,17 +1719,9 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(24)..=CrsqlDbVersion(25)],
+            range_inclusive_set![dbvri!(24, 25)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![
-                CrsqlDbVersion(23)..=CrsqlDbVersion(23),
-                CrsqlDbVersion(26)..=CrsqlDbVersion(29),
-            ],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(23, 23), dbvr!(26, 29)])?;
 
         // NOTE: overlapping 2 ranges
 
@@ -1799,14 +1729,9 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(23)..=CrsqlDbVersion(27)],
+            range_inclusive_set![dbvri!(23, 27)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(28)..=CrsqlDbVersion(29)],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(28, 29)])?;
 
         // NOTE: ineffective insert of already known ranges
 
@@ -1814,14 +1739,9 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(1)..=CrsqlDbVersion(20)],
+            range_inclusive_set![dbvri!(1, 20)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![CrsqlDbVersion(28)..=CrsqlDbVersion(29)],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(28, 29)])?;
 
         // NOTE: overlapping no ranges, but encompassing a full range
 
@@ -1829,7 +1749,7 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(27)..=CrsqlDbVersion(30)],
+            range_inclusive_set![dbvri!(27, 30)],
         )?;
         expect_gaps(&conn, &bv, &all, vec![])?;
 
@@ -1840,31 +1760,23 @@ mod tests {
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(40)..=CrsqlDbVersion(45)],
+            range_inclusive_set![dbvri!(40, 45)],
         )?;
         // create gap 46..=49
         insert_everywhere(
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(50)..=CrsqlDbVersion(55)],
+            range_inclusive_set![dbvri!(50, 55)],
         )?;
 
         insert_everywhere(
             &conn,
             &mut bv,
             &mut all,
-            range_inclusive_set![CrsqlDbVersion(38)..=CrsqlDbVersion(47)],
+            range_inclusive_set![dbvri!(38, 47)],
         )?;
-        expect_gaps(
-            &conn,
-            &bv,
-            &all,
-            vec![
-                CrsqlDbVersion(36)..=CrsqlDbVersion(37),
-                CrsqlDbVersion(48)..=CrsqlDbVersion(49),
-            ],
-        )?;
+        expect_gaps(&conn, &bv, &all, vec![dbvr!(36, 37), dbvr!(48, 49)])?;
 
         // test loading a bv from the conn, they should be identical!
         let mut bv2 = BookedVersions::from_conn(&conn, actor_id)?;
@@ -1893,7 +1805,7 @@ mod tests {
         conn: &Connection,
         bv: &BookedVersions,
         all_versions: &RangeInclusiveSet<CrsqlDbVersion>,
-        expected: Vec<RangeInclusive<CrsqlDbVersion>>,
+        expected: Vec<CrsqlDbVersionRange>,
     ) -> rusqlite::Result<()> {
         let gaps: Vec<(ActorId, CrsqlDbVersion, CrsqlDbVersion)> = conn
             .prepare_cached("SELECT actor_id, start, end FROM __corro_bookkeeping_gaps")?
@@ -1905,7 +1817,7 @@ mod tests {
             expected
                 .clone()
                 .into_iter()
-                .map(|expected| (bv.actor_id, *expected.start(), *expected.end()))
+                .map(|expected| (bv.actor_id, expected.start(), expected.end()))
                 .collect::<Vec<_>>()
         );
 
@@ -1922,7 +1834,7 @@ mod tests {
 
         assert_eq!(
             bv.max,
-            all_versions.iter().last().map(|range| *range.end()),
+            all_versions.iter().next_back().map(|range| *range.end()),
             "expected last version not to increment"
         );
 

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -170,7 +170,7 @@ impl Changeset {
             // todo: this returns dummy version because empty set has an array of versions.
             // probably shouldn't be doing this
             Changeset::EmptySet { .. } => CrsqlDbVersionRange::empty(),
-            Changeset::Full { version, .. } => (*version..=*version).into(),
+            Changeset::Full { version, .. } => CrsqlDbVersionRange::single(*version),
         }
     }
 
@@ -549,7 +549,7 @@ pub async fn broadcast_changes(
                                     changeset: Changeset::Full {
                                         version: db_version,
                                         changes,
-                                        seqs: seqs.into(),
+                                        seqs,
                                         last_seq,
                                         ts,
                                     },

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -262,21 +262,19 @@ pub fn insert_local_changes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::dbsri;
 
     #[test]
     fn test_change_chunker() {
         // empty interator
         let mut chunker = ChunkedChanges::new(vec![].into_iter(), CrsqlSeq(0), CrsqlSeq(100), 50);
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((vec![], CrsqlSeq(0)..=CrsqlSeq(100))))
-        );
+        assert_eq!(chunker.next(), Some(Ok((vec![], dbsri!(0, 100)))));
         assert_eq!(chunker.next(), None);
 
-        let changes: Vec<Change> = (CrsqlSeq(0)..CrsqlSeq(100))
+        let changes: Vec<Change> = (0..100)
             .map(|seq| Change {
-                seq,
+                seq: CrsqlSeq(seq),
                 ..Default::default()
             })
             .collect();
@@ -298,12 +296,12 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[0].clone(), changes[1].clone()],
-                CrsqlSeq(0)..=CrsqlSeq(1)
+                dbsri!(0, 1)
             )))
         );
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[2].clone()], CrsqlSeq(2)..=CrsqlSeq(100))))
+            Some(Ok((vec![changes[2].clone()], dbsri!(2, 100))))
         );
         assert_eq!(chunker.next(), None);
 
@@ -316,7 +314,7 @@ mod tests {
 
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[0].clone()], CrsqlSeq(0)..=CrsqlSeq(0))))
+            Some(Ok((vec![changes[0].clone()], dbsri!(0, 0))))
         );
         assert_eq!(chunker.next(), None);
 
@@ -332,7 +330,7 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[0].clone(), changes[2].clone()],
-                CrsqlSeq(0)..=CrsqlSeq(100)
+                dbsri!(0, 100)
             )))
         );
 
@@ -361,7 +359,7 @@ mod tests {
                     changes[7].clone(),
                     changes[8].clone()
                 ],
-                CrsqlSeq(0)..=CrsqlSeq(100)
+                dbsri!(0, 100)
             )))
         );
 
@@ -385,7 +383,7 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[2].clone(), changes[4].clone(),],
-                CrsqlSeq(0)..=CrsqlSeq(4)
+                dbsri!(0, 4)
             )))
         );
 
@@ -393,7 +391,7 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[7].clone(), changes[8].clone(),],
-                CrsqlSeq(5)..=CrsqlSeq(10)
+                dbsri!(5, 10)
             )))
         );
 

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -1,9 +1,9 @@
-use std::{iter::Peekable, ops::RangeInclusive};
+use std::iter::Peekable;
 
 use antithesis_sdk::assert_always;
 pub use corro_api_types::SqliteValue;
 use corro_api_types::{ColumnName, TableName};
-use corro_base_types::CrsqlDbVersion;
+use corro_base_types::{CrsqlDbVersion, CrsqlSeqRange};
 use rusqlite::{Connection, Row};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -104,7 +104,7 @@ impl<I> Iterator for ChunkedChanges<I>
 where
     I: Iterator<Item = rusqlite::Result<Change>>,
 {
-    type Item = Result<(Vec<Change>, RangeInclusive<CrsqlSeq>), rusqlite::Error>;
+    type Item = Result<(Vec<Change>, CrsqlSeqRange), rusqlite::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // previously marked as done because the Rows iterator returned None
@@ -153,7 +153,7 @@ where
 
                         return Some(Ok((
                             self.changes.drain(..).collect(),
-                            start_seq..=self.last_pushed_seq,
+                            CrsqlSeqRange::new(start_seq, self.last_pushed_seq),
                         )));
                     }
                 }
@@ -171,8 +171,8 @@ where
 
         // return buffered changes
         Some(Ok((
-            self.changes.clone(),                // no need to drain here like before
-            self.last_start_seq..=self.last_seq, // even if empty, this is all we have still applied
+            self.changes.clone(), // no need to drain here like before
+            CrsqlSeqRange::new(self.last_start_seq, self.last_seq), // even if empty, this is all we have still applied
         )))
     }
 }
@@ -262,14 +262,14 @@ pub fn insert_local_changes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::dbsri;
+    use crate::base::dbsr;
 
     #[test]
     fn test_change_chunker() {
         // empty interator
         let mut chunker = ChunkedChanges::new(vec![].into_iter(), CrsqlSeq(0), CrsqlSeq(100), 50);
 
-        assert_eq!(chunker.next(), Some(Ok((vec![], dbsri!(0, 100)))));
+        assert_eq!(chunker.next(), Some(Ok((vec![], dbsr!(0, 100)))));
         assert_eq!(chunker.next(), None);
 
         let changes: Vec<Change> = (0..100)
@@ -296,12 +296,12 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[0].clone(), changes[1].clone()],
-                dbsri!(0, 1)
+                dbsr!(0, 1)
             )))
         );
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[2].clone()], dbsri!(2, 100))))
+            Some(Ok((vec![changes[2].clone()], dbsr!(2, 100))))
         );
         assert_eq!(chunker.next(), None);
 
@@ -314,7 +314,7 @@ mod tests {
 
         assert_eq!(
             chunker.next(),
-            Some(Ok((vec![changes[0].clone()], dbsri!(0, 0))))
+            Some(Ok((vec![changes[0].clone()], dbsr!(0, 0))))
         );
         assert_eq!(chunker.next(), None);
 
@@ -330,7 +330,7 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[0].clone(), changes[2].clone()],
-                dbsri!(0, 100)
+                dbsr!(0, 100)
             )))
         );
 
@@ -359,7 +359,7 @@ mod tests {
                     changes[7].clone(),
                     changes[8].clone()
                 ],
-                dbsri!(0, 100)
+                dbsr!(0, 100)
             )))
         );
 
@@ -383,7 +383,7 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[2].clone(), changes[4].clone(),],
-                dbsri!(0, 4)
+                dbsr!(0, 4)
             )))
         );
 
@@ -391,7 +391,7 @@ mod tests {
             chunker.next(),
             Some(Ok((
                 vec![changes[7].clone(), changes[8].clone(),],
-                dbsri!(5, 10)
+                dbsr!(5, 10)
             )))
         );
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -2845,7 +2845,7 @@ mod tests {
             let mut rx = created.evt_rx;
 
             let matcher_id = matcher.id().as_simple().to_string();
-            println!("matcher restored w/ id: {}", matcher_id);
+            println!("matcher restored w/ id: {matcher_id}");
 
             let (catch_up_tx, mut catch_up_rx) = mpsc::channel(1);
 

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -287,7 +287,7 @@ impl Handle for MatcherHandle {
         self.inner.id
     }
 
-    fn cancelled(&self) -> WaitForCancellationFuture {
+    fn cancelled(&self) -> WaitForCancellationFuture<'_> {
         self.inner.cancel.cancelled()
     }
 
@@ -2318,7 +2318,7 @@ pub enum UnpackError {
     Misuse,
 }
 
-pub fn unpack_columns(mut buf: &[u8]) -> Result<Vec<SqliteValueRef>, UnpackError> {
+pub fn unpack_columns(mut buf: &[u8]) -> Result<Vec<SqliteValueRef<'_>>, UnpackError> {
     let mut ret = vec![];
     let num_columns = buf.get_u8();
 

--- a/crates/corro-types/src/schema.rs
+++ b/crates/corro-types/src/schema.rs
@@ -500,7 +500,7 @@ pub fn apply_schema(
                         }
                         .into());
                     }
-                    tx.execute_batch(&format!("ALTER TABLE {name} ADD COLUMN {}", col))?;
+                    tx.execute_batch(&format!("ALTER TABLE {name} ADD COLUMN {col}"))?;
                 }
 
                 if require_migration {

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -72,7 +72,7 @@ impl CrConn {
         Ok(Self(conn))
     }
 
-    pub fn immediate_transaction(&mut self) -> rusqlite::Result<Transaction> {
+    pub fn immediate_transaction(&mut self) -> rusqlite::Result<Transaction<'_>> {
         self.0
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
     }

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 use crate::{
     actor::ActorId,
     agent::{Booked, Bookie},
-    base::{CrsqlDbVersion, CrsqlSeq},
+    base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq, CrsqlSeqRange},
     broadcast::{ChangeV1, Timestamp},
 };
 
@@ -167,7 +167,7 @@ impl SyncStateV1 {
                         let start = cmp::max(range.start(), overlap.start());
                         let end = cmp::min(range.end(), overlap.end());
                         needs.entry(*actor_id).or_default().push(SyncNeedV1::Full {
-                            versions: *start..=*end,
+                            versions: (*start..=*end).into(),
                         })
                     }
                 }
@@ -181,7 +181,7 @@ impl SyncStateV1 {
                             .or_default()
                             .push(SyncNeedV1::Partial {
                                 version: *v,
-                                seqs: seqs.clone(),
+                                seqs: seqs.iter().map(CrsqlSeqRange::from).collect(),
                             });
                     } else if let Some(other_seqs) = other
                         .partial_need
@@ -204,16 +204,13 @@ impl SyncStateV1 {
                             let seqs = seqs
                                 .iter()
                                 .flat_map(|range| {
-                                    other_seqs_haves
-                                        .overlapping(range)
-                                        .map(|overlap| {
-                                            let start = cmp::max(range.start(), overlap.start());
-                                            let end = cmp::min(range.end(), overlap.end());
-                                            *start..=*end
-                                        })
-                                        .collect::<Vec<RangeInclusive<CrsqlSeq>>>()
+                                    other_seqs_haves.overlapping(range).map(|overlap| {
+                                        let start = cmp::max(range.start(), overlap.start());
+                                        let end = cmp::min(range.end(), overlap.end());
+                                        CrsqlSeqRange::new(*start, *end)
+                                    })
                                 })
-                                .collect::<Vec<RangeInclusive<CrsqlSeq>>>();
+                                .collect::<Vec<CrsqlSeqRange>>();
 
                             if !seqs.is_empty() {
                                 needs
@@ -238,10 +235,9 @@ impl SyncStateV1 {
             };
 
             if let Some(missing) = missing {
-                needs
-                    .entry(*actor_id)
-                    .or_default()
-                    .push(SyncNeedV1::Full { versions: missing });
+                needs.entry(*actor_id).or_default().push(SyncNeedV1::Full {
+                    versions: missing.into(),
+                });
             }
         }
 
@@ -252,11 +248,11 @@ impl SyncStateV1 {
 #[derive(Debug, Clone, PartialEq, Readable, Writable)]
 pub enum SyncNeedV1 {
     Full {
-        versions: RangeInclusive<CrsqlDbVersion>,
+        versions: CrsqlDbVersionRange,
     },
     Partial {
         version: CrsqlDbVersion,
-        seqs: Vec<RangeInclusive<CrsqlSeq>>,
+        seqs: Vec<CrsqlSeqRange>,
     },
     Empty {
         ts: Option<Timestamp>,
@@ -264,9 +260,10 @@ pub enum SyncNeedV1 {
 }
 
 impl SyncNeedV1 {
+    #[inline]
     pub fn count(&self) -> usize {
         match self {
-            SyncNeedV1::Full { versions } => (versions.end().0 - versions.start().0) as usize + 1,
+            SyncNeedV1::Full { versions } => versions.len(),
             SyncNeedV1::Partial { .. } => 1,
             SyncNeedV1::Empty { .. } => 1,
         }
@@ -379,6 +376,7 @@ impl SyncMessage {
 
 #[cfg(test)]
 mod tests {
+    use crate::base::{dbsr, dbsri, dbvr, dbvri};
     use uuid::Uuid;
 
     use super::*;
@@ -398,22 +396,14 @@ mod tests {
             [(
                 actor1,
                 vec![SyncNeedV1::Full {
-                    versions: CrsqlDbVersion(11)..=CrsqlDbVersion(13)
+                    versions: dbvr!(11, 13)
                 }]
             )]
             .into()
         );
 
-        our_state
-            .need
-            .entry(actor1)
-            .or_default()
-            .push(CrsqlDbVersion(2)..=CrsqlDbVersion(5));
-        our_state
-            .need
-            .entry(actor1)
-            .or_default()
-            .push(CrsqlDbVersion(7)..=CrsqlDbVersion(7));
+        our_state.need.entry(actor1).or_default().push(dbvri!(2, 5));
+        our_state.need.entry(actor1).or_default().push(dbvri!(7, 7));
 
         assert_eq!(
             our_state.compute_available_needs(&other_state),
@@ -421,13 +411,13 @@ mod tests {
                 actor1,
                 vec![
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(2)..=CrsqlDbVersion(5)
+                        versions: dbvr!(2, 5)
                     },
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(7)..=CrsqlDbVersion(7)
+                        versions: dbvr!(7, 7)
                     },
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(11)..=CrsqlDbVersion(13)
+                        versions: dbvr!(11, 13)
                     }
                 ]
             )]
@@ -436,11 +426,7 @@ mod tests {
 
         our_state.partial_need.insert(
             actor1,
-            [(
-                CrsqlDbVersion(9),
-                vec![CrsqlSeq(100)..=CrsqlSeq(120), CrsqlSeq(130)..=CrsqlSeq(132)],
-            )]
-            .into(),
+            [(CrsqlDbVersion(9), vec![dbsri!(100, 120), dbsri!(130, 132)])].into(),
         );
 
         assert_eq!(
@@ -449,17 +435,17 @@ mod tests {
                 actor1,
                 vec![
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(2)..=CrsqlDbVersion(5)
+                        versions: dbvr!(2, 5)
                     },
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(7)..=CrsqlDbVersion(7)
+                        versions: dbvr!(7, 7)
                     },
                     SyncNeedV1::Partial {
                         version: CrsqlDbVersion(9),
-                        seqs: vec![CrsqlSeq(100)..=CrsqlSeq(120), CrsqlSeq(130)..=CrsqlSeq(132)]
+                        seqs: vec![dbsr!(100, 120), dbsr!(130, 132)]
                     },
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(11)..=CrsqlDbVersion(13)
+                        versions: dbvr!(11, 13)
                     }
                 ]
             )]
@@ -468,11 +454,7 @@ mod tests {
 
         other_state.partial_need.insert(
             actor1,
-            [(
-                CrsqlDbVersion(9),
-                vec![CrsqlSeq(100)..=CrsqlSeq(110), CrsqlSeq(130)..=CrsqlSeq(130)],
-            )]
-            .into(),
+            [(CrsqlDbVersion(9), vec![dbsri!(100, 110), dbsri!(130, 130)])].into(),
         );
 
         assert_eq!(
@@ -481,17 +463,17 @@ mod tests {
                 actor1,
                 vec![
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(2)..=CrsqlDbVersion(5)
+                        versions: dbvr!(2, 5)
                     },
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(7)..=CrsqlDbVersion(7)
+                        versions: dbvr!(7, 7)
                     },
                     SyncNeedV1::Partial {
                         version: CrsqlDbVersion(9),
-                        seqs: vec![CrsqlSeq(111)..=CrsqlSeq(120), CrsqlSeq(131)..=CrsqlSeq(132)]
+                        seqs: vec![dbsr!(111, 120), dbsr!(131, 132)]
                     },
                     SyncNeedV1::Full {
-                        versions: CrsqlDbVersion(11)..=CrsqlDbVersion(13)
+                        versions: dbvr!(11, 13)
                     }
                 ]
             )]

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -167,7 +167,7 @@ impl SyncStateV1 {
                         let start = cmp::max(range.start(), overlap.start());
                         let end = cmp::min(range.end(), overlap.end());
                         needs.entry(*actor_id).or_default().push(SyncNeedV1::Full {
-                            versions: (*start..=*end).into(),
+                            versions: CrsqlDbVersionRange::new(*start, *end),
                         })
                     }
                 }

--- a/crates/corro-types/src/updates.rs
+++ b/crates/corro-types/src/updates.rs
@@ -35,7 +35,7 @@ pub trait Manager<H> {
 #[async_trait]
 pub trait Handle {
     fn id(&self) -> Uuid;
-    fn cancelled(&self) -> WaitForCancellationFuture;
+    fn cancelled(&self) -> WaitForCancellationFuture<'_>;
     fn filter_matchable_change(
         &self,
         candidates: &mut MatchCandidates,
@@ -85,7 +85,7 @@ impl Handle for UpdateHandle {
         self.inner.id
     }
 
-    fn cancelled(&self) -> WaitForCancellationFuture {
+    fn cancelled(&self) -> WaitForCancellationFuture<'_> {
         self.inner.cancel.cancelled()
     }
 

--- a/crates/sqlite-pool/src/lib.rs
+++ b/crates/sqlite-pool/src/lib.rs
@@ -157,7 +157,10 @@ where
         res
     }
 
-    pub fn prepare(&self, sql: &str) -> Result<InterruptibleStatement<Statement>, rusqlite::Error> {
+    pub fn prepare(
+        &self,
+        sql: &str,
+    ) -> Result<InterruptibleStatement<Statement<'_>>, rusqlite::Error> {
         let stmt = self.conn.prepare(sql)?;
         self.current_sql.store(Arc::new(Some(sql.to_string())));
         Ok(InterruptibleStatement::new(
@@ -171,7 +174,7 @@ where
     pub fn prepare_cached(
         &self,
         sql: &str,
-    ) -> Result<InterruptibleStatement<CachedStatement>, rusqlite::Error> {
+    ) -> Result<InterruptibleStatement<CachedStatement<'_>>, rusqlite::Error> {
         let stmt = self.conn.prepare_cached(sql)?;
         self.current_sql.store(Arc::new(Some(sql.to_string())));
         Ok(InterruptibleStatement::new(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.88"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,0 @@
-[toolchain]
-channel = "nightly-2024-09-05"
-targets = [
-    "x86_64-apple-darwin",
-    "x86_64-unknown-linux-gnu"
-]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.88"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- **Remove need for iter::Step from CrsqlDbVersion**
- **Same for CrsqlSeq**
- **Remove no longer needed toolchain spec**
- **cargo fmt**

This PR removes the need for nightly by providing a simple implementation of a chunked iterator. I've implemented it on top of a simple `InclusiveRange` type that is convertible to and from `std::ops::RangeInclusive<u64>`. This could also be done via a regular function, since the use of the chunked iteration is only called in one location, let me know if you want me to change to that instead. The code was not formatted due to the reliance on the (almost year old) nightly version used, let me know if you want me to revert that commit to make the PR smaller.