### PR TITLE
Optimize the seen cache in `handle_changes`

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -651,7 +651,7 @@ pub async fn handle_changes(
 
                 if seen.len() > max_seen_cache_len {
                     // we don't want to keep too many entries in here.
-                    seen = seen.split_off(seen.len() - keep_seen_cache_size);
+                    seen.drain(..seen.len() - keep_seen_cache_size);
                 }
                 continue
             },


### PR DESCRIPTION
The intent seems to be that latest changes are kept in `seen` when the cache is cleared with `IndexMap::split_off`, but `remove_entry` is the same thing as `swap_remove_entry` so it's possibly moving the latest seen change somewhere at the front of the map.

The removal will be slower (`O(n)` vs `O(1)`) but I assume that it does not grow too large as it seems to be trimmed every 10 ms to 2000 by default.

Alternatively, the entry could just not be removed at all to prevent both the move and move of the last element.

I've also replaced `split_off` with `drain` so that the map's allocation can be reused.