### PR TITLE
Add support for multiple PostgreSQL endpoints and readonly mode

### DIFF
--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -63,13 +63,15 @@ async fn run(agent: Agent, opts: AgentOptions, pconf: PerfConfig) -> eyre::Resul
 
     //// Start PG server to accept query requests from PG clients
     // TODO: pull this out into a separate function?
-    if let Some(pg_conf) = agent.config().api.pg.clone() {
+    if let Some(pg_confs) = agent.config().api.pg.clone() {
         info!("Starting PostgreSQL wire-compatible server");
-        let pg_server = corro_pg::start(agent.clone(), pg_conf, tripwire.clone()).await?;
-        info!(
-            "Started PostgreSQL wire-compatible server, listening at {}",
-            pg_server.local_addr
-        );
+        for pg_conf in pg_confs {
+            let pg_server = corro_pg::start(agent.clone(), pg_conf, tripwire.clone()).await?;
+            info!(
+                "Started PostgreSQL wire-compatible server, listening at {}",
+                pg_server.local_addr
+            );
+        }
     }
 
     let (to_send_tx, to_send_rx) = bounded(pconf.to_send_channel_len, "to_send");

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -144,8 +144,9 @@ pub struct ApiConfig {
     pub bind_addr: Vec<SocketAddr>,
     #[serde(alias = "authz", default)]
     pub authorization: Option<AuthzConfig>,
+    #[serde_as(deserialize_as = "Option<OneOrMany<_, PreferOne>>")]
     #[serde(default)]
-    pub pg: Option<PgConfig>,
+    pub pg: Option<Vec<PgConfig>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -154,6 +154,8 @@ pub struct PgConfig {
     #[serde(alias = "addr")]
     pub bind_addr: SocketAddr,
     pub tls: Option<PgTlsConfig>,
+    #[serde(default)]
+    pub readonly: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
As the title says, this PR makes it possible to spawn multiple PostgreSQL server endpoints, some of which may be readonly. Readonly mode is implemented by setting the readonly flag on the underlying SQLite connection, so that there's absolutely no possibility of accidentally running a write transaction using a readonly server.