### PR TITLE
Fix/workaround test timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,12 +4137,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]
@@ -4223,7 +4245,10 @@ name = "spawn"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook",
+ "signal-hook-tokio",
  "tokio",
  "tracing",
 ]

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -1678,6 +1678,7 @@ mod tests {
 
         tripwire_tx.send(()).await.ok();
         tripwire_worker.await;
+        ta1.agent.subs_manager().drop_handles().await;
         wait_for_all_pending_handles().await;
 
         Ok(())

--- a/crates/corro-types/Cargo.toml
+++ b/crates/corro-types/Cargo.toml
@@ -52,6 +52,7 @@ uhlc = { workspace = true }
 uuid = { workspace = true }
 strum = { workspace = true }
 antithesis_sdk = { workspace = true }
+
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
 corro-tests = { path = "../corro-tests" }
+tracing-subscriber = { workspace = true }

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -2425,17 +2425,20 @@ mod tests {
             tx.commit()?;
         }
 
-        let (handle, maybe_created) = subs.get_or_insert(
-            sql,
-            subscriptions_path.as_path(),
-            &schema,
-            &pool,
-            tripwire.clone(),
-        )?;
+        {
+            let (handle, maybe_created) = subs.get_or_insert(
+                sql,
+                subscriptions_path.as_path(),
+                &schema,
+                &pool,
+                tripwire.clone(),
+            )?;
 
-        assert!(maybe_created.is_some());
+            assert!(maybe_created.is_some());
 
-        handle.cleanup().await;
+            handle.cleanup().await;
+            subs.remove(&handle.id());
+        }
 
         tripwire_tx.send(()).await.ok();
         tripwire_worker.await;

--- a/crates/spawn/Cargo.toml
+++ b/crates/spawn/Cargo.toml
@@ -3,10 +3,13 @@ name = "spawn"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 futures = { workspace = true }
 pin-project-lite = { workspace = true }
+parking_lot.workspace = true
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.3"
+signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"] }


### PR DESCRIPTION
4d0b09a395866206222308ec7a4a97c66e7953eb caused the `match_buffered_changes` and `test_matcher` tests to fail with cargo nextest due to its default 60s timeout. The `test_matcher` issue was caused by the mpsc try_recv being replaced with a recv, which would block forever since the sender is not dropped, so I changed it to send a None when cancel is called. `match_buffered_changes` is weirder, I would have thought that dropping a streaming response would cancel subscriptions, but AFAICT that is not what occurs. I worked around it by manually dropping all the subscriptions.

I personally find async code extremely hard to follow, so I added some code in CountedFuture so that spawning one (when on unix and in debug mode) will capture a backtrace, and then print out any active counted future backtraces when a `SIGTERM` is received so that it's easier to understand what is blocking a test from finishing.

Also, this repository extensively uses tracing instead of e/println! for logging, but those logs are completely lost in tests since no subscriber is created, so I've added tracing-test which allows you to annotate tests so that tracing logs are also captured in tests.