### PR TITLE
Use different endpoint for Antithesis and config wal_threshold as mb

### DIFF
--- a/.antithesis/corrosion/config.toml.tpl
+++ b/.antithesis/corrosion/config.toml.tpl
@@ -28,3 +28,6 @@ colors = false
 
 [consul.client]
 address = "localhost:8500"
+
+[perf]
+wal_threshold_mb = 5

--- a/.buildkite-antithesis/scripts/test.sh
+++ b/.buildkite-antithesis/scripts/test.sh
@@ -15,7 +15,7 @@ response=$(curl --fail -u "flyio:${ANTITHESIS_PASSWORD}" -X POST https://flyio.a
     \"antithesis.duration\":\"${CUSTOM_DURATION}\",
     \"antithesis.config_image\":\"antithesis-config:${COMMIT_HASH}\",
     \"antithesis.images\":\"corrosion:${COMMIT_HASH},corro-client:${COMMIT_HASH},consul:1.15.4\",
-    \"antithesis.report.recipients\":\"${EMAIL}\",
+    \"antithesis.report.recipients\":\"networking@fly.io\",
     \"antithesis.source\":\"${BUILDKITE_BRANCH}\"
 }}")
 

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -454,13 +454,13 @@ async fn vacuum_db(pool: &SplitPool, lim: u64) -> eyre::Result<()> {
 /// See `db_cleanup` and `vacuum_db`
 pub fn spawn_handle_db_maintenance(agent: &Agent) {
     let mut wal_path = agent.config().db.path.clone();
-    let wal_threshold = agent.config().perf.wal_threshold_gb as u64;
+    let wal_threshold = agent.config().perf.wal_threshold_mb as u64;
     wal_path.set_extension(format!("{}-wal", wal_path.extension().unwrap_or_default()));
 
     let pool = agent.pool().clone();
 
     tokio::spawn(async move {
-        let truncate_wal_threshold: u64 = wal_threshold * 1024 * 1024 * 1024;
+        let truncate_wal_threshold: u64 = wal_threshold * 1024 * 1024;
 
         // try to initially truncate the WAL
         match wal_checkpoint_over_threshold(wal_path.as_path(), &pool, truncate_wal_threshold).await

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -17,7 +17,8 @@ const fn default_apply_queue() -> usize {
 }
 
 const fn default_wal_threshold() -> usize {
-    5
+    // Default of 5GB
+    5 * 1024
 }
 
 const fn default_processing_queue() -> usize {
@@ -221,7 +222,7 @@ pub struct PerfConfig {
     #[serde(default = "default_apply_queue")]
     pub apply_queue_len: usize,
     #[serde(default = "default_wal_threshold")]
-    pub wal_threshold_gb: usize,
+    pub wal_threshold_mb: usize,
     #[serde(default = "default_processing_queue")]
     pub processing_queue_len: usize,
     #[serde(default = "default_sql_tx_timeout")]
@@ -246,7 +247,7 @@ impl Default for PerfConfig {
             foca_channel_len: default_small_channel(),
             apply_queue_timeout: default_apply_timeout(),
             apply_queue_len: default_apply_queue(),
-            wal_threshold_gb: default_wal_threshold(),
+            wal_threshold_mb: default_wal_threshold(),
             processing_queue_len: default_processing_queue(),
             sql_tx_timeout: default_sql_tx_timeout(),
             min_sync_backoff: default_min_sync_backoff(),


### PR DESCRIPTION
This pull requests changes the path for Antithesis tests and now accepts the wal_threshold in mb instead of gb so we can specify a lower threshold in tests.