### PR TITLE
Abort PG TCP connection loops when message-handling exits

### DIFF
--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1857,11 +1857,6 @@ pub async fn start(
                     }
                 }).await;
 
-                // The message-handling loop has completed, make sure we also abort the tasks
-                // handling the TCP connection
-                frontend_task.abort();
-                backend_task.abort();
-
                 match res {
                     Ok(Ok(_)) => {}
                     Ok(Err(e)) => {
@@ -1903,6 +1898,11 @@ pub async fn start(
                             .await;
                     }
                 }
+
+                // The message-handling loop has completed, make sure we also abort the tasks
+                // handling the TCP connection
+                frontend_task.abort();
+                backend_task.abort();
 
                 Ok::<_, BoxError>(())
             });


### PR DESCRIPTION
Ideally we should have a wrapper that aborts these automatically on drop, but for now this should fix the bug at hand.