### PR TITLE
Add Changeset::FullV2 variant to reduce duplication of data in changeset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,6 @@ dependencies = [
  "compact_str 0.7.1",
  "config",
  "corro-pg",
- "corro-speedy",
  "corro-tests",
  "corro-types",
  "corro-utils",
@@ -791,6 +790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spawn",
+ "speedy",
  "sqlite-pool",
  "sqlite3-parser",
  "strum",
@@ -817,13 +817,13 @@ dependencies = [
  "async-trait",
  "camino",
  "compact_str 0.7.1",
- "corro-speedy",
  "deadpool",
  "hex",
  "rusqlite",
  "serde",
  "serde_json",
  "smallvec",
+ "speedy",
  "strum",
  "thiserror 1.0.69",
  "tokio",
@@ -836,7 +836,6 @@ dependencies = [
  "async-trait",
  "camino",
  "compact_str 0.7.1",
- "corro-speedy",
  "deadpool",
  "hex",
  "rangemap",
@@ -844,6 +843,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "speedy",
  "strum",
  "thiserror 1.0.69",
  "tokio",
@@ -922,19 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "corro-speedy"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbc8dd22992b785a0375e7065168b3a3b95599d3ffe2cf3d5d4a752278fdaba"
-dependencies = [
- "indexmap 1.9.3",
- "memoffset",
- "smallvec",
- "speedy-derive",
- "uuid",
-]
-
-[[package]]
 name = "corro-tests"
 version = "0.1.0"
 dependencies = [
@@ -990,7 +977,6 @@ dependencies = [
  "consul-client",
  "corro-api-types",
  "corro-base-types",
- "corro-speedy",
  "corro-tests",
  "deadpool",
  "enquote",
@@ -1013,6 +999,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "spawn",
+ "speedy",
  "sqlite-functions",
  "sqlite-pool",
  "sqlite3-parser",
@@ -2643,9 +2630,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -4194,10 +4181,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "speedy-derive"
-version = "0.8.6"
+name = "speedy"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d395866cb6778625150f77a430cc0af764ce0300f6a3d3413477785fa34b6c7"
+checksum = "da1992073f0e55aab599f4483c460598219b4f9ff0affa124b33580ab511e25a"
+dependencies = [
+ "indexmap 1.9.3",
+ "indexmap 2.11.0",
+ "memoffset",
+ "smallvec",
+ "speedy-derive",
+ "uuid",
+]
+
+[[package]]
+name = "speedy-derive"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f2ca5276b92c3dfd65fa88316b4e032ace68f88d7570b43967784c0bac5ac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde = "1.0.159"
 serde_json = { version = "1.0.95", features = ["raw_value"] }
 serde_with = "2.3.2"
 smallvec = { version = "1.11.0", features = ["serde", "write", "union"] }
-speedy = { version = "0.8.7", features = ["uuid", "smallvec", "indexmap"], package = "corro-speedy" }
+speedy = { version = "0.8.7", features = ["uuid", "smallvec", "indexmap", "indexmap_v2" ], package = "speedy" }
 sqlite3-parser = "0.12.0"
 strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.5.0"

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -1032,7 +1032,7 @@ pub async fn process_multiple_changes(
     let mut change_chunk_size = 0;
 
     for (_actor_id, changeset, db_version, _src) in changesets {
-        change_chunk_size += changeset.changes().len();
+        change_chunk_size += changeset.len();
         match_changes(agent.subs_manager(), changeset.changes(), db_version);
         match_changes(agent.updates_manager(), changeset.changes(), db_version);
     }

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -1033,8 +1033,8 @@ pub async fn process_multiple_changes(
 
     for (_actor_id, changeset, db_version, _src) in changesets {
         change_chunk_size += changeset.len();
-        match_changes(agent.subs_manager(), changeset.changes(), db_version);
-        match_changes(agent.updates_manager(), changeset.changes(), db_version);
+        match_changes(agent.subs_manager(), &changeset, db_version);
+        match_changes(agent.updates_manager(), &changeset, db_version);
     }
 
     histogram!("corro.agent.changes.processing.time.seconds", "source" => "remote")

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -772,7 +772,7 @@ mod tests {
         assert!(matches!(
             msg,
             BroadcastInput::AddBroadcast(BroadcastV1::Change(ChangeV1 {
-                changeset: Changeset::Full {
+                changeset: Changeset::FullV2 {
                     version: CrsqlDbVersion(1),
                     ..
                 },

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -13,7 +13,7 @@ use tracing::{debug, trace, warn};
 use crate::{
     agent::{Agent, BookedVersions, ChangeError, VersionsSnapshot},
     base::CrsqlSeq,
-    broadcast::Timestamp,
+    broadcast::{ChangesetPerTable, Timestamp},
 };
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Readable, Writable, PartialEq)]
@@ -34,17 +34,20 @@ impl Change {
     // be required on the wire
     pub fn estimated_byte_size(&self) -> usize {
         self.table.len() + self.pk.len() + self.cid.len() + self.val.estimated_byte_size() +
-        // col_version
-        8 +
         // db_version
+        8 +
+        self.estimated_column_byte_size() +
+        // site_id
+        16
+    }
+
+    pub fn estimated_column_byte_size(&self) -> usize {
+        self.cid.len() + self.val.estimated_byte_size() +
+        // col_version
         8 +
         // seq
         8 +
-        // site_id
-        16 +
         // cl
-        8 +
-        // site_version
         8
     }
 }
@@ -65,7 +68,7 @@ pub fn row_to_change(row: &Row) -> Result<Change, rusqlite::Error> {
 
 pub struct ChunkedChanges<I: Iterator> {
     iter: Peekable<I>,
-    changes: Vec<Change>,
+    changes: ChangesetPerTable,
     last_pushed_seq: CrsqlSeq,
     last_start_seq: CrsqlSeq,
     last_seq: CrsqlSeq,
@@ -81,7 +84,7 @@ where
     pub fn new(iter: I, start_seq: CrsqlSeq, last_seq: CrsqlSeq, max_buf_size: usize) -> Self {
         Self {
             iter: iter.peekable(),
-            changes: vec![],
+            changes: Default::default(),
             last_pushed_seq: CrsqlSeq(0),
             last_start_seq: start_seq,
             last_seq,
@@ -104,7 +107,7 @@ impl<I> Iterator for ChunkedChanges<I>
 where
     I: Iterator<Item = rusqlite::Result<Change>>,
 {
-    type Item = Result<(Vec<Change>, CrsqlSeqRange), rusqlite::Error>;
+    type Item = Result<(ChangesetPerTable, CrsqlSeqRange), rusqlite::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // previously marked as done because the Rows iterator returned None
@@ -130,9 +133,8 @@ where
 
                     self.last_pushed_seq = change.seq;
 
-                    self.buffered_size += change.estimated_byte_size();
-
-                    self.changes.push(change);
+                    let size = self.changes.insert(change);
+                    self.buffered_size += size;
 
                     if self.last_pushed_seq == self.last_seq {
                         // this was the last seq! break early
@@ -152,7 +154,7 @@ where
                         self.last_start_seq = self.last_pushed_seq + 1;
 
                         return Some(Ok((
-                            self.changes.drain(..).collect(),
+                            self.changes.drain(),
                             CrsqlSeqRange::new(start_seq, self.last_pushed_seq),
                         )));
                     }
@@ -269,7 +271,10 @@ mod tests {
         // empty interator
         let mut chunker = ChunkedChanges::new(vec![].into_iter(), CrsqlSeq(0), CrsqlSeq(100), 50);
 
-        assert_eq!(chunker.next(), Some(Ok((vec![], dbsr!(0, 100)))));
+        assert_eq!(
+            chunker.next(),
+            Some(Ok((ChangesetPerTable::default(), dbsr!(0, 100))))
+        );
         assert_eq!(chunker.next(), None);
 
         let changes: Vec<Change> = (0..100)
@@ -279,6 +284,8 @@ mod tests {
             })
             .collect();
 
+        let (changeset, size) =
+            mapped_changeset_from_changes(vec![changes[0].clone(), changes[1].clone()]);
         // 2 iterations
         let mut chunker = ChunkedChanges::new(
             vec![
@@ -289,54 +296,47 @@ mod tests {
             .into_iter(),
             CrsqlSeq(0),
             CrsqlSeq(100),
-            changes[0].estimated_byte_size() + changes[1].estimated_byte_size(),
+            size,
         );
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((
-                vec![changes[0].clone(), changes[1].clone()],
-                dbsr!(0, 1)
-            )))
-        );
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((vec![changes[2].clone()], dbsr!(2, 100))))
-        );
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(0, 1)))));
+
+        let (changeset, _) = mapped_changeset_from_changes(vec![changes[2].clone()]);
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(2, 100)))));
         assert_eq!(chunker.next(), None);
 
+        let (changeset, size) = mapped_changeset_from_changes(vec![changes[0].clone()]);
         let mut chunker = ChunkedChanges::new(
             vec![Ok(changes[0].clone()), Ok(changes[1].clone())].into_iter(),
             CrsqlSeq(0),
             CrsqlSeq(0),
-            changes[0].estimated_byte_size(),
+            size,
         );
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((vec![changes[0].clone()], dbsr!(0, 0))))
-        );
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(0, 0)))));
         assert_eq!(chunker.next(), None);
 
+        let (changeset, size) =
+            mapped_changeset_from_changes(vec![changes[0].clone(), changes[2].clone()]);
         // gaps
         let mut chunker = ChunkedChanges::new(
             vec![Ok(changes[0].clone()), Ok(changes[2].clone())].into_iter(),
             CrsqlSeq(0),
             CrsqlSeq(100),
-            changes[0].estimated_byte_size() + changes[2].estimated_byte_size(),
+            size,
         );
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((
-                vec![changes[0].clone(), changes[2].clone()],
-                dbsr!(0, 100)
-            )))
-        );
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(0, 100)))));
 
         assert_eq!(chunker.next(), None);
 
         // gaps
+        let (changeset, _) = mapped_changeset_from_changes(vec![
+            changes[2].clone(),
+            changes[4].clone(),
+            changes[7].clone(),
+            changes[8].clone(),
+        ]);
         let mut chunker = ChunkedChanges::new(
             vec![
                 Ok(changes[2].clone()),
@@ -350,22 +350,13 @@ mod tests {
             100000, // just send them all!
         );
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((
-                vec![
-                    changes[2].clone(),
-                    changes[4].clone(),
-                    changes[7].clone(),
-                    changes[8].clone()
-                ],
-                dbsr!(0, 100)
-            )))
-        );
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(0, 100)))));
 
         assert_eq!(chunker.next(), None);
 
         // gaps
+        let (changeset, size) =
+            mapped_changeset_from_changes(vec![changes[2].clone(), changes[4].clone()]);
         let mut chunker = ChunkedChanges::new(
             vec![
                 Ok(changes[2].clone()),
@@ -376,25 +367,24 @@ mod tests {
             .into_iter(),
             CrsqlSeq(0),
             CrsqlSeq(10),
-            changes[2].estimated_byte_size() + changes[4].estimated_byte_size(),
+            size,
         );
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((
-                vec![changes[2].clone(), changes[4].clone(),],
-                dbsr!(0, 4)
-            )))
-        );
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(0, 4)))));
 
-        assert_eq!(
-            chunker.next(),
-            Some(Ok((
-                vec![changes[7].clone(), changes[8].clone(),],
-                dbsr!(5, 10)
-            )))
-        );
+        let (changeset, _) =
+            mapped_changeset_from_changes(vec![changes[7].clone(), changes[8].clone()]);
+        assert_eq!(chunker.next(), Some(Ok((changeset, dbsr!(5, 10)))));
 
         assert_eq!(chunker.next(), None);
+    }
+
+    fn mapped_changeset_from_changes(changes: Vec<Change>) -> (ChangesetPerTable, usize) {
+        let mut changeset = ChangesetPerTable::default();
+        let mut size = 0;
+        for change in changes {
+            size += changeset.insert(change);
+        }
+        (changeset, size)
     }
 }

--- a/crates/corro-types/src/updates.rs
+++ b/crates/corro-types/src/updates.rs
@@ -1,6 +1,6 @@
 use crate::actor::ActorId;
 use crate::agent::SplitPool;
-use crate::change::Change;
+use crate::broadcast::Changeset;
 use crate::pubsub::{unpack_columns, MatchCandidates, MatchableChange, MatcherError};
 use crate::schema::Schema;
 use antithesis_sdk::assert_sometimes;
@@ -417,7 +417,7 @@ async fn batch_candidates(
     debug!(id = %id, "update loop is done");
 }
 
-pub fn match_changes<H>(manager: &impl Manager<H>, changes: &[Change], db_version: CrsqlDbVersion)
+pub fn match_changes<H>(manager: &impl Manager<H>, changes: &Changeset, db_version: CrsqlDbVersion)
 where
     H: Handle + Send + 'static,
 {
@@ -441,7 +441,7 @@ where
         trace!(sub_id = %id, %db_version, "attempting to match changes to a subscription");
         let mut candidates = MatchCandidates::new();
         let mut match_count = 0;
-        for change in changes.iter().map(MatchableChange::from) {
+        for change in changes.matchable_changes() {
             if handle.filter_matchable_change(&mut candidates, change) {
                 match_count += 1;
             }


### PR DESCRIPTION
This pull request adds a new variant to `Changeset` that stores Changes as a map of `TableName`s to rows (which itself is a map of primary keys to columns), rather than an array of changes from the `crsql_changes` table in the database. This reduces duplication and the size of the message sent.