### PR TITLE
Fix deserialization of `ExecResult`

### DIFF
--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -224,11 +224,14 @@ pub struct ExecResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "ty")]
 pub enum ExecResult {
+    #[serde(rename = "x")]
     Execute { rows_affected: usize, time: f64 },
+    #[serde(rename = "e")]
     Error { error: String },
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TableStatRequest {
     pub tables: Vec<String>,


### PR DESCRIPTION
If corrosion is used in a Rust project and the `abitrary_precision` feature of serde_json was turned on, this untagged enum would fail to deserialize with serde_json. There are probably other cases of this bug.

https://github.com/serde-rs/serde/issues/2903