### PR TITLE
Clean up sub when broadcaster was not created

### DIFF
--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -629,6 +629,8 @@ pub async fn upsert_sub(
 ) -> Result<Uuid, MatcherUpsertError> {
     if let Some(created) = maybe_created {
         if params.from.is_some() {
+            handle.cleanup().await;
+            subs.remove(&handle.id());
             return Err(MatcherUpsertError::SubFromWithoutMatcher);
         }
 


### PR DESCRIPTION
Fixes the bug where an failed resubscription attempt can cause the inability to subscribe to the given query in the future.