### PR TITLE
consul-client: Do not set http2_prior_knowledge

### DIFF
--- a/crates/consul-client/src/lib.rs
+++ b/crates/consul-client/src/lib.rs
@@ -67,7 +67,7 @@ impl Client {
                 .use_preconfigured_tls(tls_config)
                 .build()
         } else {
-            reqwest::ClientBuilder::new().http1_only().build()
+            reqwest::ClientBuilder::new().build()
         };
 
         Ok(Self {


### PR DESCRIPTION
reqwest will use HTTP/2 unless `http1_only` is set. Setting `http2_prior_knowledge` only causes it to not even attempt other HTTP versions.

`http1_only` is also removed for the non-SSL code path.