### PR TITLE
Pin mdbook version on push aswell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: mdbook,mdbook-linkcheck,mdbook-admonish
+          tool: mdbook@0.4.52,mdbook-linkcheck@0.7.7,mdbook-admonish@1.20.0
 
       - name: Build Book
         run: mdbook build


### PR DESCRIPTION
Didn't notice that there's a separate workflow for mdbook on push.