### PR TITLE
Systemd watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -826,7 +826,7 @@ checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
 dependencies = [
  "async-trait",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "serde",
  "toml",
@@ -1060,7 +1060,7 @@ name = "corro-devcluster"
 version = "0.1.0"
 dependencies = [
  "clap",
- "nom",
+ "nom 7.1.3",
  "rand 0.9.2",
  "serde",
  "serde_json",
@@ -1239,6 +1239,7 @@ dependencies = [
  "futures",
  "hostname",
  "hyper",
+ "libsystemd",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
@@ -1543,7 +1544,7 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -2792,6 +2793,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsystemd"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c97a761fc86953c5b885422b22c891dbf5bcb9dcc99d0110d6ce4c052759f0"
+dependencies = [
+ "hmac",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "nom 8.0.0",
+ "once_cell",
+ "serde",
+ "sha2",
+ "thiserror 2.0.16",
+ "uuid",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3137,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -3145,6 +3177,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4315,7 +4356,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4838,7 +4879,7 @@ dependencies = [
 name = "sqlite3-restore"
 version = "0.1.0"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "rusqlite",
  "tempfile",
  "thiserror 1.0.69",
@@ -6483,7 +6524,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "ring 0.16.20",
  "rusticata-macros",

--- a/crates/corrosion/Cargo.toml
+++ b/crates/corrosion/Cargo.toml
@@ -54,6 +54,7 @@ tripwire = { path = "../tripwire" }
 uuid = { workspace = true }
 shell-words = "1.1.0"
 metrics-util = { workspace = true }
+libsystemd = "0.7.0"
 
 [build-dependencies]
 build-info-build = { workspace = true }


### PR DESCRIPTION
If corrosion detects it runs under systemd it will send periodic keepalives. This will allow systemd to restart corrosion in case the tokio runtime deadlocks.