### PR TITLE
Corro-pg: use codec of peeking bytes when negotiating ssl

### DIFF
--- a/crates/corro-pg/src/codec.rs
+++ b/crates/corro-pg/src/codec.rs
@@ -128,8 +128,10 @@ impl codec::Decoder for PgWireMessageServerCodec {
             api::PgWireConnectionState::AwaitingSslRequest => {}
             api::PgWireConnectionState::AwaitingStartup => {
                 self.decode_context.awaiting_ssl = false;
+                self.decode_context.awaiting_startup = true;
             }
             _ => {
+                self.decode_context.awaiting_ssl = false;
                 self.decode_context.awaiting_startup = false;
             }
         }


### PR DESCRIPTION
This fixes a bug where we'd hit an infinite loop if we receive less than eight bytes when checking for ssl msg in the pg endpoint.