### PR TITLE
Clear empty versions from __corro_seq_bookkeeping

### DIFF
--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -873,13 +873,12 @@ pub async fn process_multiple_changes(
 
                 // optimizing this, insert later!
                 let known = if change.is_complete() && change.is_empty() {
-                    process_empty_version(&agent, &tx, change.actor_id, &max, change.versions()).map_err(
-                        |e| ChangeError::Rusqlite {
+                    process_empty_version(&agent, &tx, change.actor_id, &max, change.versions())
+                        .map_err(|e| ChangeError::Rusqlite {
                             source: e,
                             actor_id: Some(change.actor_id),
                             version: Some(change.versions().end()),
-                        },
-                    )?;
+                        })?;
                     KnownDbVersion::Cleared
                 } else {
                     if let Some(seqs) = change.seqs() {
@@ -1105,7 +1104,7 @@ pub fn process_empty_version<T: Deref<Target = rusqlite::Connection> + Committab
 ) -> rusqlite::Result<()> {
     // update db_version in db if it's greater than the max
     // since we aren't passing any changes to crsql
-    if max.is_some_and(|max| versions.end() > max) {
+    if max.is_none_or(|max| versions.end() > max) {
         let _ = tx
             .prepare_cached("SELECT crsql_set_db_version(?, ?)")?
             .query_row((actor_id, versions.end()), |row| row.get::<_, String>(0))?;


### PR DESCRIPTION
This pull request checks and clears any rows in the partials bookkeeping table for empty versions so we don't have left over metadata for a version we have already processed.