### PR TITLE
Burstable change processing

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -18,7 +18,7 @@ use crate::{
     api::peer::parallel_sync,
     transport::Transport,
 };
-use antithesis_sdk::assert_sometimes;
+use antithesis_sdk::{assert_always, assert_sometimes};
 use camino::Utf8Path;
 use corro_types::{
     actor::{Actor, ActorId},
@@ -43,7 +43,7 @@ use spawn::spawn_counted;
 use tokio::time::sleep;
 use tokio::{
     sync::mpsc::Receiver as TokioReceiver,
-    task::{block_in_place, JoinSet},
+    task::{block_in_place, JoinHandle},
 };
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tracing::{debug, debug_span, error, info, trace, warn, Instrument};
@@ -612,6 +612,260 @@ fn calc_busy_timeout(wal_size: u64, threshold: u64) -> u64 {
     timeout
 }
 
+/// State for dynamic batch processing
+struct HandleChangesState {
+    queue: VecDeque<(ChangeV1, ChangeSource, Instant)>,
+    buf_cost: usize,
+    current_batch_size: usize,
+    processing_task: Option<JoinHandle<Result<(), corro_types::agent::ChangeError>>>,
+    max_wait: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+    drop_log_count: u64,
+
+    // Configuration
+    max_queue_len: usize,
+    min_batch_size: usize,
+    step_base: usize,
+    max_batch_size: usize,
+    batch_threshold_ratio: f64,
+    timeout_duration: Duration,
+    tx_timeout: Duration,
+}
+
+impl HandleChangesState {
+    fn new(
+        min_batch_size: usize,
+        step_base: usize,
+        max_batch_size: usize,
+        batch_threshold_ratio: f64,
+        timeout_duration: Duration,
+        tx_timeout: Duration,
+        max_queue_len: usize,
+    ) -> Self {
+        Self {
+            queue: VecDeque::with_capacity(max_queue_len),
+            buf_cost: 0,
+            current_batch_size: min_batch_size,
+            processing_task: None,
+            max_wait: Some(Box::pin(tokio::time::sleep(timeout_duration))),
+            min_batch_size,
+            step_base,
+            max_batch_size,
+            batch_threshold_ratio,
+            timeout_duration,
+            tx_timeout,
+            max_queue_len,
+            drop_log_count: 0,
+        }
+    }
+
+    /// Calculate exponential batch size based on cost
+    fn calculate_batch_size(&self, cost: usize) -> usize {
+        if self.step_base == 0 || cost < self.step_base {
+            self.min_batch_size
+        } else {
+            let size = self.step_base * (1 << (cost / self.step_base).ilog2());
+            size.clamp(self.min_batch_size, self.max_batch_size)
+        }
+    }
+
+    /// Get the threshold for immediate spawning based on configured ratio
+    fn batch_threshold(&self) -> usize {
+        (self.current_batch_size as f64 * self.batch_threshold_ratio) as usize
+    }
+
+    /// Drain a batch from the queue and spawn processing task
+    fn drain_and_spawn(
+        &mut self,
+        agent: &Agent,
+        bookie: &Bookie,
+        target_size: usize,
+        reason: &str,
+    ) -> Option<usize> {
+        // Must complete previous task before spawning a new one
+        if self.processing_task.is_some() {
+            return None;
+        }
+
+        let mut batch = Vec::with_capacity(self.current_batch_size);
+        let mut batch_cost = 0;
+
+        while let Some((change, src, queued_at)) = self.queue.pop_front() {
+            let cost = change.processing_cost();
+            batch_cost += cost;
+            self.buf_cost -= cost;
+            batch.push((change, src, queued_at));
+            if batch_cost >= target_size {
+                break;
+            }
+        }
+
+        if batch.is_empty() {
+            return None;
+        }
+
+        debug!(count = %batch_cost, reason = %reason, batch_size = %self.current_batch_size, "spawning batch processing task");
+
+        let agent_clone = agent.clone();
+        let bookie_clone = bookie.clone();
+        self.processing_task = Some(tokio::spawn(process_multiple_changes(
+            agent_clone,
+            bookie_clone,
+            batch,
+            self.tx_timeout,
+        )));
+        counter!("corro.agent.changes.batch.spawned").increment(1);
+        gauge!("corro.agent.changes.batch_size").set(self.current_batch_size as f64);
+
+        Some(batch_cost)
+    }
+
+    /// Handle task completion and decide whether to spawn next batch
+    fn handle_task_completion(
+        &mut self,
+        agent: &Agent,
+        bookie: &Bookie,
+        result: Result<Result<(), corro_types::agent::ChangeError>, tokio::task::JoinError>,
+    ) {
+        // Handle task result
+        match result {
+            Ok(Ok(())) => {
+                debug!("batch processing completed successfully");
+            }
+            Ok(Err(e)) => {
+                let err_str = e.to_string();
+                error!("error processing batch: {e}");
+
+                // Check for memory errors and emergency reduce batch size
+                // TODO: requeue the changes
+                if err_str.contains("SQLITE_NOMEM") || err_str.contains("out of memory") {
+                    error!("memory error detected, halving batch size");
+                    self.current_batch_size =
+                        (self.current_batch_size / 2).max(self.min_batch_size);
+                }
+            }
+            Err(e) => {
+                error!("batch processing task panicked: {e}");
+            }
+        }
+
+        self.processing_task = None;
+
+        // Should we spawn immediately with queued changes?
+        if self.buf_cost >= self.batch_threshold() {
+            // YES - enough changes queued, spawn immediately
+            // Check if we might want to burst
+            if self.buf_cost > self.current_batch_size {
+                self.current_batch_size = self.calculate_batch_size(self.buf_cost);
+            }
+            if self
+                .drain_and_spawn(
+                    agent,
+                    bookie,
+                    self.current_batch_size,
+                    "immediate-after-completion",
+                )
+                .is_none()
+            {
+                unreachable!("Must spawn a batch");
+            }
+        } else {
+            // NO - not enough changes yet, start timeout
+            self.max_wait = Some(Box::pin(tokio::time::sleep(self.timeout_duration)));
+        }
+    }
+
+    /// Handle timeout - spawn whatever we have
+    /// The amount of changes MUST be smaller than the threshold
+    /// as otherwise other code paths would have spawned a batch
+    fn handle_timeout(&mut self, agent: &Agent, bookie: &Bookie) {
+        self.max_wait = None;
+
+        if !self.queue.is_empty() {
+            let actual_cost = self.buf_cost;
+            let threshold = self.batch_threshold();
+            // Other code paths should have spawned a batch by now!
+            assert_always!(actual_cost < threshold, "Timeout with too many changes");
+            // Just process whatever we have and then downsize the batch size
+            if self
+                .drain_and_spawn(agent, bookie, usize::MAX, "timeout")
+                .is_none()
+            {
+                unreachable!("Must spawn a batch");
+            }
+
+            assert_sometimes!(true, "Corrosion processes changes");
+            // Adjust batch size based on what we had processed
+            // This will decrease the batch size unless it's already at the minimum
+            self.current_batch_size = self.calculate_batch_size(actual_cost);
+        } else if self.processing_task.is_none() && self.max_wait.is_none() {
+            // Empty queue, no task running, no timeout set
+            self.current_batch_size = self.calculate_batch_size(0);
+            // If no task is running and no timeout is set, start timeout
+            // This ensures changes get processed even if they don't hit the threshold
+            self.max_wait = Some(Box::pin(tokio::time::sleep(self.timeout_duration)));
+        }
+    }
+
+    // Drops oldest items when the queue is full
+    fn maybe_drop_old_change(&mut self) -> Option<ChangeV1> {
+        let mut dropped_count = 0;
+
+        let maybe_dropped_change = if self.queue.len() >= self.max_queue_len {
+            if let Some((dropped_change, _, _)) = self.queue.pop_front() {
+                self.buf_cost -= dropped_change.processing_cost();
+                dropped_count += 1;
+
+                Some(dropped_change)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        counter!("corro.agent.changes.dropped").increment(dropped_count);
+        log_at_pow_10("dropped old change from queue", &mut self.drop_log_count);
+        maybe_dropped_change
+    }
+
+    /// Handle new change arrival - check if we should spawn immediately
+    fn handle_new_change(
+        &mut self,
+        agent: &Agent,
+        bookie: &Bookie,
+        change: ChangeV1,
+        src: ChangeSource,
+    ) {
+        let cost = change.processing_cost();
+        self.queue.push_back((change, src, Instant::now()));
+        self.buf_cost += cost;
+
+        // Check if we should spawn immediately (threshold-based)
+        if self.buf_cost >= self.batch_threshold() && self.processing_task.is_none() {
+            // Cancel any pending timeout
+            self.max_wait = None;
+
+            // Check if we might want to burst
+            if self.buf_cost > self.current_batch_size {
+                self.current_batch_size = self.calculate_batch_size(self.buf_cost);
+            }
+
+            // Drain and spawn
+            if self
+                .drain_and_spawn(
+                    agent,
+                    bookie,
+                    self.current_batch_size,
+                    "size-threshold-on-new-change",
+                )
+                .is_none()
+            {
+                unreachable!("Must spawn a batch");
+            }
+        }
+    }
+}
+
 /// Bundle incoming changes to optimise transaction sizes with SQLite
 ///
 /// *Performance tradeoff*: introduce latency (with a max timeout) to
@@ -624,19 +878,18 @@ pub async fn handle_changes(
     mut rx_changes: CorroReceiver<(ChangeV1, ChangeSource)>,
     mut tripwire: Tripwire,
 ) {
-    let max_changes_chunk: usize = agent.config().perf.apply_queue_len;
     let max_queue_len: usize = agent.config().perf.processing_queue_len;
-    let tx_timeout: Duration = Duration::from_secs(agent.config().perf.sql_tx_timeout as u64);
-    let mut queue: VecDeque<(ChangeV1, ChangeSource, Instant)> = VecDeque::new();
-    let mut buf = vec![];
-    let mut buf_cost = 0;
 
-    const MAX_CONCURRENT: usize = 5;
-    let mut join_set = JoinSet::new();
-
-    let mut max_wait = tokio::time::interval(Duration::from_millis(
-        agent.config().perf.apply_queue_timeout as u64,
-    ));
+    // Initialize batch processor state
+    let mut state = HandleChangesState::new(
+        agent.config().perf.apply_queue_min_batch_size,
+        agent.config().perf.apply_queue_step_base,
+        agent.config().perf.apply_queue_max_batch_size,
+        agent.config().perf.apply_queue_batch_threshold_ratio,
+        Duration::from_millis(agent.config().perf.apply_queue_timeout as u64),
+        Duration::from_secs(agent.config().perf.sql_tx_timeout as u64),
+        max_queue_len,
+    );
 
     let max_seen_cache_len: usize = max_queue_len;
     let metrics_tracker = agent.metrics_tracker();
@@ -650,86 +903,41 @@ pub async fn handle_changes(
     };
     let mut seen: IndexMap<_, RangeInclusiveSet<CrsqlSeq>> = IndexMap::new();
 
-    let mut drop_log_count: u64 = 0;
-    // complicated loop to process changes efficiently w/ a max concurrency
-    // and a minimum chunk size for bigger and faster SQLite transactions
     loop {
-        while (buf_cost >= max_changes_chunk || (!queue.is_empty() && join_set.is_empty()))
-            && join_set.len() < MAX_CONCURRENT
-        {
-            // Process if we hit the chunk size OR if we have any items and available capacity
-            let mut tmp_cost = 0;
-            while let Some((change, src, queued_at)) = queue.pop_front() {
-                tmp_cost += change.processing_cost();
-                buf.push((change, src, queued_at));
-                if tmp_cost >= max_changes_chunk {
-                    break;
-                }
-            }
-
-            if buf.is_empty() {
-                break;
-            }
-
-            debug!(count = %tmp_cost, "spawning processing multiple changes from beginning of loop");
-            let changes = std::mem::take(&mut buf);
-            let agent = agent.clone();
-            let bookie = bookie.clone();
-            join_set.spawn(process_multiple_changes(
-                agent,
-                bookie,
-                changes.clone(),
-                tx_timeout,
-            ));
-            counter!("corro.agent.changes.batch.spawned").increment(1);
-
-            buf_cost -= tmp_cost;
-        }
-
         let (change, src) = tokio::select! {
             biased;
 
-            // process these first, we don't care about the result,
-            // but we need to drain it to free up concurrency
-            res = join_set.join_next(), if !join_set.is_empty() => {
-                debug!("processed multiple changes concurrently");
-                if let Some(Ok(Err(e))) = res {
-                    error!("could not process multiple changes: {e}");
-                }
+            // Processing task finished
+            res = async { state.processing_task.as_mut().unwrap().await }, if state.processing_task.is_some() => {
+                state.handle_task_completion(&agent, &bookie, res);
                 continue;
             },
 
+            // New changes arrive
             maybe_change_src = rx_changes.recv() => match maybe_change_src {
                 Some((change, src)) => (change, src),
                 None => break,
             },
 
-            _ = max_wait.tick() => {
-                // got a wait interval tick...
-                gauge!("corro.agent.changes.in_queue").set(buf_cost as f64);
-                gauge!("corro.agent.changesets.in_queue").set(queue.len() as f64);
-                gauge!("corro.agent.changes.processing.jobs").set(join_set.len() as f64);
+            // Timeout fires
+            _ = async { state.max_wait.as_mut().unwrap().await }, if state.max_wait.is_some() => {
+                // Emit metrics
+                gauge!("corro.agent.changes.in_queue").set(state.buf_cost as f64);
+                gauge!("corro.agent.changesets.in_queue").set(state.queue.len() as f64);
+                gauge!("corro.agent.changes.processing.jobs").set(if state.processing_task.is_some() { 1.0 } else { 0.0 });
+                metrics_tracker.observe_queue_size(state.queue.len() as u64);
 
-                metrics_tracker.observe_queue_size(queue.len() as u64);
-                if buf_cost < max_changes_chunk && !queue.is_empty() && join_set.len() < MAX_CONCURRENT {
-                    // we can process this right away
-                    debug!(%buf_cost, "spawning processing multiple changes from max wait interval");
-                    assert_sometimes!(true, "Corrosion processes changes");
-                    let changes: Vec<_> = queue.drain(..).collect();
-                    let agent = agent.clone();
-                    let bookie = bookie.clone();
-                    join_set.spawn(process_multiple_changes(agent, bookie, changes.clone(), tx_timeout));
-                    counter!("corro.agent.changes.batch.spawned").increment(1);
-                    buf_cost = 0;
-                }
+                state.handle_timeout(&agent, &bookie);
 
+                // Cleanup seen cache
                 if seen.len() > max_seen_cache_len {
-                    // we don't want to keep too many entries in here.
                     seen.drain(..seen.len() - keep_seen_cache_size);
                 }
-                continue
+
+                continue;
             },
 
+            // Corrosion is shutting down
             _ = &mut tripwire => {
                 break;
             }
@@ -738,10 +946,12 @@ pub async fn handle_changes(
         let change_len = change.len();
         counter!("corro.agent.changes.recv").increment(std::cmp::max(change_len, 1) as u64); // count empties...
 
+        // Skip changes from ourselves
         if change.actor_id == agent.actor_id() {
             continue;
         }
 
+        // Skip changes we've already seen recently in the seen cache
         if let Some(mut seqs) = change.seqs() {
             let v = change.versions().start();
             if let Some(seen_seqs) = seen.get(&(change.actor_id, v)) {
@@ -759,6 +969,7 @@ pub async fn handle_changes(
             continue;
         }
 
+        // Update logical clock if needed
         let src_str: &'static str = src.into();
         let recv_lag = change.ts().and_then(|ts| {
             let mut our_ts = Timestamp::from(agent.clock().new_timestamp());
@@ -778,48 +989,31 @@ pub async fn handle_changes(
             counter!("corro.broadcast.recv.count", "kind" => "change").increment(1);
         }
 
-        let booked = {
-            bookie
-                .read("handle_change(get)", change.actor_id.as_simple())
-                .await
-                .get(&change.actor_id)
-                .cloned()
-        };
+        // Skip changes we've already seen in the bookie
+        // Do this in a new scope to avoid holding the bookie lock for too long
+        {
+            let booked = {
+                bookie
+                    .read("handle_change(get)", change.actor_id.as_simple())
+                    .await
+                    .get(&change.actor_id)
+                    .cloned()
+            };
 
-        if let Some(booked) = booked {
-            if booked
-                .read("handle_change(contains?)", change.actor_id.as_simple())
-                .await
-                .contains_all(change.versions(), change.seqs())
-            {
-                trace!("already seen, stop disseminating");
-                if matches!(src, ChangeSource::Broadcast) {
-                    counter!("corro.broadcast.duplicate.count", "from" => "bookie").increment(1);
+            if let Some(booked) = booked {
+                if booked
+                    .read("handle_change(contains?)", change.actor_id.as_simple())
+                    .await
+                    .contains_all(change.versions(), change.seqs())
+                {
+                    trace!("already seen, stop disseminating");
+                    if matches!(src, ChangeSource::Broadcast) {
+                        counter!("corro.broadcast.duplicate.count", "from" => "bookie")
+                            .increment(1);
+                    }
+                    continue;
                 }
-                continue;
             }
-        }
-
-        // drop old items when the queue is full.
-        if queue.len() >= max_queue_len {
-            let mut dropped_count = 0;
-            if let Some((dropped_change, _, _)) = queue.pop_front() {
-                for v in dropped_change.versions() {
-                    if let Entry::Occupied(mut entry) = seen.entry((change.actor_id, v)) {
-                        if let Some(seqs) = dropped_change.seqs() {
-                            entry.get_mut().remove(seqs.into());
-                        } else {
-                            entry.swap_remove_entry();
-                        }
-                    };
-                }
-
-                buf_cost -= dropped_change.processing_cost();
-                dropped_count += 1;
-            }
-            counter!("corro.agent.changes.dropped").increment(dropped_count);
-
-            log_at_pow_10("dropped old change from queue", &mut drop_log_count);
         }
 
         if let Some(recv_lag) = recv_lag {
@@ -827,6 +1021,20 @@ pub async fn handle_changes(
                 .record(recv_lag.as_secs_f64());
         }
 
+        // If we need to drop an old change, drop it from the seen cache aswell
+        while let Some(dropped_change) = state.maybe_drop_old_change() {
+            for v in dropped_change.versions() {
+                if let Entry::Occupied(mut entry) = seen.entry((change.actor_id, v)) {
+                    if let Some(seqs) = dropped_change.seqs() {
+                        entry.get_mut().remove(seqs.into());
+                    } else {
+                        entry.swap_remove_entry();
+                    }
+                };
+            }
+        }
+
+        // Register the new change in the seen cache
         // this will only run once for a non-empty changeset
         for v in change.versions() {
             let entry = seen.entry((change.actor_id, v)).or_default();
@@ -839,6 +1047,7 @@ pub async fn handle_changes(
             matches!(src, ChangeSource::Sync),
             "Corrosion receives changes through sync"
         );
+        // Rebroadcast changes received from broadcast
         if matches!(src, ChangeSource::Broadcast) && !change.is_empty() {
             assert_sometimes!(true, "Corrosion rebroadcasts changes");
             if let Err(_e) =
@@ -852,10 +1061,8 @@ pub async fn handle_changes(
             }
         }
 
-        let cost = change.processing_cost();
-        queue.push_back((change, src, Instant::now()));
-
-        buf_cost += cost; // tracks the cost, not number of changes
+        // Handle the new change - queue it and potentially spawn a batch
+        state.handle_new_change(&agent, &bookie, change, src);
     }
 }
 
@@ -1018,8 +1225,10 @@ mod tests {
             .gossip_addr("127.0.0.1:0".parse()?)
             .api_addr("127.0.0.1:0".parse()?)
             .build()?;
-        config.perf.apply_queue_len = 1;
         config.perf.processing_queue_len = 3;
+        config.perf.apply_queue_min_batch_size = 1;
+        config.perf.apply_queue_max_batch_size = 1;
+        config.perf.apply_queue_step_base = 0;
         config.perf.changes_channel_len = 1;
 
         let (agent, agent_options) = setup(config, tripwire.clone()).await?;
@@ -1085,10 +1294,21 @@ mod tests {
             .unwrap()
             .read::<&str, _>("test", None)
             .await;
-        assert!(booked.contains_all(dbvr!(6, 10), None));
+
+        // With batch_size=1 and queue_len=3, the behavior is:
+        // - Version 10 processes immediately (first change, hits threshold)
+        // - While 10 is blocked on write lock, versions 9-1 arrive
+        // - Queue fills (max 3): holds 9,8,7 then 8,7,6 then 7,6,5 then 6,5,4 then 5,4,3 then 4,3,2 then 3,2,1
+        // - After 10 completes, versions 3,2,1 process (what's left in queue)
+        // - Versions 9,8,7,6,5,4 were dropped (load shedding)
+        assert!(booked.contains_version(&CrsqlDbVersion(10)));
         assert!(booked.contains_all(dbvr!(1, 3), None));
-        assert!(!booked.contains_version(&CrsqlDbVersion(5)));
         assert!(!booked.contains_version(&CrsqlDbVersion(4)));
+        assert!(!booked.contains_version(&CrsqlDbVersion(5)));
+        assert!(!booked.contains_version(&CrsqlDbVersion(6)));
+        assert!(!booked.contains_version(&CrsqlDbVersion(7)));
+        assert!(!booked.contains_version(&CrsqlDbVersion(8)));
+        assert!(!booked.contains_version(&CrsqlDbVersion(9)));
 
         Ok(())
     }
@@ -1105,7 +1325,7 @@ mod tests {
 
         println!("temp db: {db_path:?}");
         let write_sema = Arc::new(Semaphore::new(1));
-        let pool = SplitPool::create(db_path, write_sema.clone()).await?;
+        let pool = SplitPool::create(db_path, write_sema.clone(), -1048576).await?;
 
         {
             let mut conn = pool.write_priority().await?;
@@ -1188,5 +1408,226 @@ mod tests {
 
     fn to_bytes(gb: u64) -> u64 {
         gb * 1024 * 1024 * 1024
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_handle_changes_batch_size_bursting() -> eyre::Result<()> {
+        _ = tracing_subscriber::fmt::try_init();
+        let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+        let dir = tempfile::tempdir()?;
+
+        let mut config = Config::builder()
+            .db_path(dir.path().join("corrosion.db").display().to_string())
+            .gossip_addr("127.0.0.1:0".parse()?)
+            .api_addr("127.0.0.1:0".parse()?)
+            .build()?;
+
+        // Configure for bursting test:
+        // - min_batch_size: 100
+        // - step_base: 500
+        // - max_batch_size: 16000
+        // - threshold_ratio: 0.9
+        config.perf.apply_queue_min_batch_size = 100;
+        config.perf.apply_queue_step_base = 500;
+        config.perf.apply_queue_max_batch_size = 16000;
+        config.perf.apply_queue_batch_threshold_ratio = 0.9;
+        config.perf.apply_queue_timeout = 10; // 10ms timeout
+        config.perf.processing_queue_len = 50000; // Large queue to avoid dropping old changes
+
+        let (agent, _agent_options) = setup(config.clone(), tripwire.clone()).await?;
+
+        let (status_code, _res) =
+            api_v1_db_schema(Extension(agent.clone()), Json(vec![TEST_SCHEMA.to_owned()])).await;
+        assert_eq!(status_code, StatusCode::OK);
+
+        let other_actor = ActorId(uuid::Uuid::new_v4());
+        let bookie = Bookie::new(Default::default());
+
+        // Create a HandleChangesState instance directly
+        let mut state = HandleChangesState::new(
+            config.perf.apply_queue_min_batch_size,
+            config.perf.apply_queue_step_base,
+            config.perf.apply_queue_max_batch_size,
+            config.perf.apply_queue_batch_threshold_ratio,
+            Duration::from_millis(config.perf.apply_queue_timeout as u64),
+            Duration::from_secs(config.perf.sql_tx_timeout as u64),
+            config.perf.processing_queue_len,
+        );
+
+        // Helper to create a mock change
+        let create_change = |version: u64| -> ChangeV1 {
+            let crsql_row = Change {
+                table: TableName("tests".into()),
+                pk: pack_columns(&vec![(version as i64).into()]).unwrap(),
+                cid: ColumnName("text".into()),
+                val: "test value".into(),
+                col_version: 1,
+                db_version: CrsqlDbVersion(version),
+                seq: CrsqlSeq(0),
+                site_id: other_actor.to_bytes(),
+                cl: 1,
+            };
+
+            let change = ChangeV1 {
+                actor_id: other_actor,
+                changeset: Changeset::Full {
+                    version: CrsqlDbVersion(version),
+                    changes: vec![crsql_row],
+                    seqs: dbsr!(0, 0),
+                    last_seq: CrsqlSeq(0),
+                    ts: agent.clock().new_timestamp().into(),
+                },
+            };
+
+            assert!(change.processing_cost() == 1);
+
+            change
+        };
+
+        let mut version = 1;
+        let mut simulate_burst = |state: &mut HandleChangesState, count: u64| {
+            for _ in 1..=count {
+                state.handle_new_change(
+                    &agent,
+                    &bookie,
+                    create_change(version),
+                    ChangeSource::Sync,
+                );
+                version += 1;
+            }
+        };
+
+        // Initial batch size should be min_batch_size
+        // Timer should be spawned
+        assert_eq!(state.current_batch_size, 100);
+        assert!(state.max_wait.is_some());
+        assert!(state.processing_task.is_none());
+        assert!(state.buf_cost == 0);
+        assert!(state.queue.is_empty());
+
+        // Timing out with no changes should not spawn a task
+        // The timer should be reset
+        state.handle_timeout(&agent, &bookie);
+        assert!(state.processing_task.is_none());
+        assert!(state.max_wait.is_some());
+        assert!(state.buf_cost == 0);
+        assert!(state.queue.is_empty());
+
+        // Phase 1: Add a few changes (5) - not enough to hit threshold
+        // Threshold = 100 * 0.9 = 90, we'll add 5 changes (cost = 5)
+        simulate_burst(&mut state, 5);
+
+        // Should not have spawned (buf_cost = 5 < threshold = 90)
+        assert!(state.processing_task.is_none());
+        assert_eq!(state.buf_cost, 5);
+        assert_eq!(state.queue.len(), 5);
+
+        // Phase 2: Trigger timeout processing
+        state.handle_timeout(&agent, &bookie);
+
+        // Should have spawned a task now
+        assert!(state.processing_task.is_some());
+        assert_eq!(state.buf_cost, 0); // All drained
+        assert_eq!(state.queue.len(), 0);
+
+        // Batch size should decrease because actual_cost (5) < threshold (90)
+        // when hitting the timeout. We're already at the min batch size, so it
+        // should stay at it
+        assert_eq!(state.current_batch_size, 100);
+
+        // Phase 3: While task is running, simulate a burst of changes
+        // Add 2001 changes (cost = 2001) - this is a burst!
+        simulate_burst(&mut state, 2001);
+
+        // Task is still running, so changes should be queued
+        assert!(state.processing_task.is_some());
+        assert_eq!(state.buf_cost, 2001);
+        assert_eq!(state.queue.len(), 2001);
+
+        // Phase 4: Complete the task successfully
+        // After completion with buf_cost=2001 >= threshold=90:
+        // - Should spawn immediately
+        // - Should burst to batch_size 2000
+        // - No timer should be spawned
+
+        let task = state.processing_task.take().unwrap();
+        let task_result = task.await;
+        state.handle_task_completion(&agent, &bookie, task_result);
+        assert_eq!(state.buf_cost, 1);
+        assert_eq!(state.queue.len(), 1); // Drained ~100
+        assert_eq!(state.current_batch_size, 2000);
+        assert!(state.max_wait.is_none());
+
+        // Phase 5: Complete the second task
+        // - We should not spawn another task cause we are below the threshold of 1800
+        // - The timer should be spawned
+        let task = state.processing_task.take().unwrap();
+        let task_result = task.await;
+        state.handle_task_completion(&agent, &bookie, task_result);
+        assert!(state.processing_task.is_none());
+        assert_eq!(state.buf_cost, 1);
+        assert_eq!(state.queue.len(), 1);
+        assert_eq!(state.current_batch_size, 2000);
+        assert!(state.max_wait.is_some());
+
+        // Phase 6: Simulate another burst of changes
+        // As the batch size is 2000, we should spawn a new task after 1800 changes
+        // The timer should be cancelled
+        simulate_burst(&mut state, 1900);
+        assert!(state.processing_task.is_some());
+        assert_eq!(state.buf_cost, 101);
+        assert_eq!(state.queue.len(), 101);
+        assert_eq!(state.current_batch_size, 2000);
+        assert!(state.max_wait.is_none());
+
+        // Phase 7: Complete the third task
+        // - We should not spawn another task cause we are below the threshold of 1800
+        // - The timer should be spawned
+        let task = state.processing_task.take().unwrap();
+        let task_result = task.await;
+        state.handle_task_completion(&agent, &bookie, task_result);
+        assert!(state.processing_task.is_none());
+        assert_eq!(state.buf_cost, 101);
+        assert_eq!(state.queue.len(), 101);
+        assert_eq!(state.current_batch_size, 2000);
+        assert!(state.max_wait.is_some());
+
+        // Phase 8: Burst below threshold
+        simulate_burst(&mut state, 1000);
+        assert!(state.processing_task.is_none());
+        assert_eq!(state.buf_cost, 1101);
+        assert_eq!(state.queue.len(), 1101);
+        assert_eq!(state.current_batch_size, 2000);
+        assert!(state.max_wait.is_some()); // Timer is still running
+
+        // Phase 9: We timed out, so the batch size should get decreased
+        state.handle_timeout(&agent, &bookie);
+        assert!(state.processing_task.is_some());
+        assert_eq!(state.buf_cost, 0);
+        assert_eq!(state.queue.len(), 0);
+        assert_eq!(state.current_batch_size, 1000);
+        assert!(state.max_wait.is_none());
+
+        // Phase 10: Complete the task
+        let task = state.processing_task.take().unwrap();
+        let task_result = task.await;
+        state.handle_task_completion(&agent, &bookie, task_result);
+        // No instant spawn
+        assert!(state.processing_task.is_none());
+        assert_eq!(state.buf_cost, 0);
+        assert_eq!(state.queue.len(), 0);
+        assert_eq!(state.current_batch_size, 1000);
+        // Timer should be spawned
+        assert!(state.max_wait.is_some());
+
+        // Phase 11: Batch size should return to normal
+        state.handle_timeout(&agent, &bookie);
+        assert!(state.processing_task.is_none());
+        assert_eq!(state.buf_cost, 0);
+        assert_eq!(state.queue.len(), 0);
+        assert_eq!(state.current_batch_size, 100);
+        assert!(state.max_wait.is_some());
+
+        Ok(())
     }
 }

--- a/crates/corro-agent/src/agent/reaper.rs
+++ b/crates/corro-agent/src/agent/reaper.rs
@@ -218,7 +218,7 @@ mod tests {
 
     async fn setup_test_db(path: std::path::PathBuf) -> eyre::Result<SplitPool> {
         let write_sema = Arc::new(Semaphore::new(1));
-        let pool = SplitPool::create(path, write_sema).await?;
+        let pool = SplitPool::create(path, write_sema, -1048576).await?;
 
         // Create test table
         let conn = pool.write_priority().await?;

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -93,7 +93,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
 
     let write_sema = Arc::new(Semaphore::new(1));
 
-    let pool = SplitPool::create(&conf.db.path, write_sema.clone()).await?;
+    let pool = SplitPool::create(&conf.db.path, write_sema.clone(), conf.db.cache_size_kib).await?;
 
     let clock = Arc::new(
         uhlc::HLCBuilder::default()

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -1096,11 +1096,15 @@ pub async fn process_multiple_changes(
 
     let mut change_chunk_size = 0;
 
-    for (_actor_id, changeset, db_version, _src) in changesets {
+    for (_actor_id, changeset, _db_version, _src) in &changesets {
         change_chunk_size += changeset.len();
-        match_changes(agent.subs_manager(), &changeset, db_version);
-        match_changes(agent.updates_manager(), &changeset, db_version);
     }
+    tokio::spawn(async move {
+        for (_actor_id, changeset, db_version, _src) in changesets {
+            match_changes(agent.subs_manager(), &changeset, db_version);
+            match_changes(agent.updates_manager(), &changeset, db_version);
+        }
+    });
 
     histogram!("corro.agent.changes.processing.time.seconds", "source" => "remote")
         .record(start.elapsed());

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -458,6 +458,7 @@ pub struct SplitPool(Arc<SplitPoolInner>);
 struct SplitPoolInner {
     path: PathBuf,
     write_sema: Arc<Semaphore>,
+    cache_size_kib: i64,
 
     read: SqlitePool,
     write: SqlitePool,
@@ -511,10 +512,11 @@ impl SplitPool {
     pub async fn create<P: AsRef<Path>>(
         path: P,
         write_sema: Arc<Semaphore>,
+        cache_size_kib: i64,
     ) -> Result<Self, SplitPoolCreateError> {
         let rw_pool = sqlite_pool::Config::new(path.as_ref())
             .max_size(1)
-            .create_pool_transform(rusqlite_to_crsqlite_write)?;
+            .create_pool_transform(move |conn| rusqlite_to_crsqlite_write(conn, cache_size_kib))?;
 
         debug!("built RW pool");
 
@@ -527,12 +529,19 @@ impl SplitPool {
         Ok(Self::new(
             path.as_ref().to_owned(),
             write_sema,
+            cache_size_kib,
             ro_pool,
             rw_pool,
         ))
     }
 
-    fn new(path: PathBuf, write_sema: Arc<Semaphore>, read: SqlitePool, write: SqlitePool) -> Self {
+    fn new(
+        path: PathBuf,
+        write_sema: Arc<Semaphore>,
+        cache_size_kib: i64,
+        read: SqlitePool,
+        write: SqlitePool,
+    ) -> Self {
         let (priority_tx, mut priority_rx) = bounded(256, "priority");
         let (normal_tx, mut normal_rx) = bounded(512, "normal");
         let (low_tx, mut low_rx) = bounded(1024, "low");
@@ -554,6 +563,7 @@ impl SplitPool {
         Self(Arc::new(SplitPoolInner {
             path,
             write_sema,
+            cache_size_kib,
             read,
             write,
             priority_tx,
@@ -603,7 +613,7 @@ impl SplitPool {
     #[tracing::instrument(skip(self), level = "debug")]
     pub fn client_dedicated(&self) -> rusqlite::Result<CrConn> {
         let conn = rusqlite::Connection::open(&self.0.path)?;
-        let cr_conn = rusqlite_to_crsqlite_write(conn)?;
+        let cr_conn = rusqlite_to_crsqlite_write(conn, self.0.cache_size_kib)?;
         trace_heavy_queries(cr_conn.conn())?;
         Ok(cr_conn)
     }

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -14,8 +14,24 @@ pub const DEFAULT_MAX_SYNC_BACKOFF: u32 = 2;
 #[cfg(not(test))]
 pub const DEFAULT_MAX_SYNC_BACKOFF: u32 = 15;
 
-const fn default_apply_queue() -> usize {
+const fn default_apply_batch_min() -> usize {
     100
+}
+
+const fn default_apply_batch_step() -> usize {
+    500
+}
+
+const fn default_apply_batch_max() -> usize {
+    16_000
+}
+
+const fn default_batch_threshold_ratio() -> f64 {
+    0.9
+}
+
+const fn default_cache_size_kib() -> i64 {
+    -1048576 // 1 GB (negative value means KiB)
 }
 
 const fn default_reaper_interval() -> usize {
@@ -129,6 +145,11 @@ pub struct DbConfig {
     pub schema_paths: Vec<Utf8PathBuf>,
     #[serde(default)]
     pub subscriptions_path: Option<Utf8PathBuf>,
+    /// SQLite page cache size in KiB for writes (negative value).
+    /// Default: -1048576 (1 GB). Larger values improve write performance but use more RAM.
+    /// WARNING: Setting this too low (<100MB) can severely degrade performance.
+    #[serde(default = "default_cache_size_kib")]
+    pub cache_size_kib: i64,
 }
 
 impl DbConfig {
@@ -227,20 +248,34 @@ pub struct PerfConfig {
     pub bcast_channel_len: usize,
     #[serde(default = "default_small_channel")]
     pub foca_channel_len: usize,
-    #[serde(default = "default_apply_timeout")]
-    pub apply_queue_timeout: usize,
-    #[serde(default = "default_apply_queue")]
-    pub apply_queue_len: usize,
     #[serde(default = "default_wal_threshold")]
     pub wal_threshold_mb: usize,
-    #[serde(default = "default_processing_queue")]
-    pub processing_queue_len: usize,
     #[serde(default = "default_sql_tx_timeout")]
     pub sql_tx_timeout: usize,
     #[serde(default = "default_min_sync_backoff")]
     pub min_sync_backoff: u32,
     #[serde(default = "default_max_sync_backoff")]
     pub max_sync_backoff: u32,
+    // How many unapplied changesets corrosion will buffer before starting to drop them
+    #[serde(default = "default_processing_queue")]
+    pub processing_queue_len: usize,
+    // How many ms corrosion will wait before proceeding to apply a batch of changes
+    // We wait either for apply_queue_timeout or untill at least apply_queue_min_batch_size changes accumulate
+    #[serde(default = "default_apply_timeout")]
+    pub apply_queue_timeout: usize,
+    // Minimum amount of changes corrosion will try to apply at once in the same transaction
+    #[serde(default = "default_apply_batch_min")]
+    pub apply_queue_min_batch_size: usize,
+    // batch_size = clamp(min_batch_size, step_base * 2 ** floor(log2(x/step_base)), max_batch_size)
+    #[serde(default = "default_apply_batch_step")]
+    pub apply_queue_step_base: usize,
+    // Maximum amount of changes corrosion will try to apply at once in the same transaction
+    #[serde(default = "default_apply_batch_max")]
+    pub apply_queue_max_batch_size: usize,
+    // Threshold ratio (0.0-1.0) for immediate batch spawning when queue reaches this fraction of batch size
+    // It's used to decide whether to wait for more changes for apply_queue_timeout ms or spawn a batch immediately
+    #[serde(default = "default_batch_threshold_ratio")]
+    pub apply_queue_batch_threshold_ratio: f64,
 }
 
 impl Default for PerfConfig {
@@ -255,13 +290,16 @@ impl Default for PerfConfig {
             clearbuf_channel_len: default_mid_channel(),
             bcast_channel_len: default_mid_channel(),
             foca_channel_len: default_small_channel(),
-            apply_queue_timeout: default_apply_timeout(),
-            apply_queue_len: default_apply_queue(),
             wal_threshold_mb: default_wal_threshold(),
-            processing_queue_len: default_processing_queue(),
             sql_tx_timeout: default_sql_tx_timeout(),
             min_sync_backoff: default_min_sync_backoff(),
             max_sync_backoff: default_max_sync_backoff(),
+            processing_queue_len: default_processing_queue(),
+            apply_queue_timeout: default_apply_timeout(),
+            apply_queue_min_batch_size: default_apply_batch_min(),
+            apply_queue_step_base: default_apply_batch_step(),
+            apply_queue_max_batch_size: default_apply_batch_max(),
+            apply_queue_batch_threshold_ratio: default_batch_threshold_ratio(),
         }
     }
 }
@@ -446,6 +484,7 @@ impl ConfigBuilder {
                 path: db_path,
                 schema_paths: self.schema_paths,
                 subscriptions_path: None,
+                cache_size_kib: default_cache_size_kib(),
             },
             api: ApiConfig {
                 bind_addr: self.api_addr,

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -2524,7 +2524,7 @@ mod tests {
         let subscriptions_path: Utf8PathBuf =
             tmpdir.path().join("subs").display().to_string().into();
 
-        let pool = SplitPool::create(db_path, Arc::new(Semaphore::new(1))).await?;
+        let pool = SplitPool::create(db_path, Arc::new(Semaphore::new(1)), -1048576).await?;
         let clock = Arc::new(uhlc::HLC::default());
 
         {
@@ -2644,7 +2644,7 @@ mod tests {
         let subscriptions_path: Utf8PathBuf =
             tmpdir.path().join("subs").display().to_string().into();
 
-        let pool = SplitPool::create(&db_path, Arc::new(Semaphore::new(1)))
+        let pool = SplitPool::create(&db_path, Arc::new(Semaphore::new(1)), -1048576)
             .await
             .unwrap();
         let mut conn = pool.write_priority().await.unwrap();

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -181,9 +181,19 @@ static CRSQL_EXT_DIR: Lazy<TempDir> = Lazy::new(|| {
     dir
 });
 
-pub fn rusqlite_to_crsqlite_write(conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
+pub fn rusqlite_to_crsqlite_write(
+    conn: rusqlite::Connection,
+    cache_size_kib: i64,
+) -> rusqlite::Result<CrConn> {
     let conn = rusqlite_to_crsqlite(conn)?;
-    conn.execute_batch("PRAGMA cache_size = -32000;")?;
+    conn.execute_batch(&format!(
+        "
+        PRAGMA cache_size = {};
+        PRAGMA temp_store = MEMORY;
+        PRAGMA cache_spill = FALSE;
+        ",
+        cache_size_kib
+    ))?;
 
     Ok(conn)
 }


### PR DESCRIPTION
This PR adjust the amount of changes we try to process at once in real time based on the backlog of changes to sync.
The batch size increases exponentially with the amount of pending changes to process. In the default config: 
```
changes -> batch_size
0-499 -> 100
500-999 -> 500
1000-1999 -> 1000
2000-3999 -> 2000
...
16000-Inf -> 16000
```
This scaling can be configured via `apply_queue_min_batch_size`, `apply_queue_max_batch_size`, `apply_queue_step_base` in the configuration file.

This PR allows for processing of changes to be started early before accumulating a full batch. The decision for that is made by the `apply_queue_batch_threshold_ratio` parameter which sets a ratio(0-1) of how full a batch needs to be to start processing it. By default that value is set to `0.9` For ex. with batch size 100 and 90 pending changes when we finish processing a batch we would instantly spawn another batch instead of waiting for changes to accumulate.

The current batch size is available as the `corro.agent.changes.batch_size` metric.