### PR TITLE
corro-agent: Add optional endpoint name validation

### DIFF
--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -46,26 +46,35 @@ use corro_types::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn http_api_requested_region_header_enforced() -> eyre::Result<()> {
+async fn http_api_requested_endpoint_name_header_enforced() -> eyre::Result<()> {
     _ = tracing_subscriber::fmt::try_init();
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
-    let ta1 = launch_test_agent(|conf| conf.region("us-east-1").build(), tripwire.clone()).await?;
+    let ta1 = launch_test_agent(
+        |conf| conf.endpoint_name("us-east-1").build(),
+        tripwire.clone(),
+    )
+    .await?;
+    let ta2 = launch_test_agent(|conf| conf.build(), tripwire.clone()).await?;
 
     let client = reqwest::Client::new();
     let req_body_1: Vec<Statement> = serde_json::from_value(json!([[
         "INSERT INTO tests (id,text) VALUES (?,?)",
-        [999_001, "region header test 1"]
+        [999_001, "endpoint header test 1"]
     ]]))?;
     let req_body_2: Vec<Statement> = serde_json::from_value(json!([[
         "INSERT INTO tests (id,text) VALUES (?,?)",
-        [999_002, "region header test 2"]
+        [999_002, "endpoint header test 2"]
     ]]))?;
     let req_body_3: Vec<Statement> = serde_json::from_value(json!([[
         "INSERT INTO tests (id,text) VALUES (?,?)",
-        [999_003, "region header test 3"]
+        [999_003, "endpoint header test 3"]
+    ]]))?;
+    let req_body_4: Vec<Statement> = serde_json::from_value(json!([[
+        "INSERT INTO tests (id,text) VALUES (?,?)",
+        [999_004, "endpoint header test 4"]
     ]]))?;
 
-    // No X-Corrosion-Requested-Region: accept all requests
+    // No X-Corrosion-Requested-Endpoint-Name: accept all requests
     let no_header_res = client
         .post(format!("http://{}/v1/transactions", ta1.agent.api_addr()))
         .header(hyper::header::CONTENT_TYPE, "application/json")
@@ -74,27 +83,40 @@ async fn http_api_requested_region_header_enforced() -> eyre::Result<()> {
         .await?;
     assert_eq!(no_header_res.status(), StatusCode::OK);
 
-    // w/ X-Corrosion-Requested-Region, matching
+    // w/ X-Corrosion-Requested-Endpoint-Name, matching
     let matching_header_res = client
         .post(format!("http://{}/v1/transactions", ta1.agent.api_addr()))
         .header(hyper::header::CONTENT_TYPE, "application/json")
-        .header("x-corrosion-requested-region", "us-east-1")
+        .header("x-corrosion-requested-endpoint-name", "us-east-1")
         .body(serde_json::to_vec(&req_body_2)?)
         .send()
         .await?;
     assert_eq!(matching_header_res.status(), StatusCode::OK);
 
-    // w/ X-Corrosion-Requested-Region, mismatching
+    // w/ X-Corrosion-Requested-Endpoint-Name, mismatching
     let mismatched_header_res = client
         .post(format!("http://{}/v1/transactions", ta1.agent.api_addr()))
         .header(hyper::header::CONTENT_TYPE, "application/json")
-        .header("x-corrosion-requested-region", "eu-west-1")
+        .header("x-corrosion-requested-endpoint-name", "eu-west-1")
         .body(serde_json::to_vec(&req_body_3)?)
         .send()
         .await?;
     assert_eq!(
         mismatched_header_res.status(),
         StatusCode::MISDIRECTED_REQUEST
+    );
+
+    // Endpoint header is ignored if node has no endpoint name configured
+    let header_ignored_when_unconfigured_res = client
+        .post(format!("http://{}/v1/transactions", ta2.agent.api_addr()))
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        .header("x-corrosion-requested-endpoint-name", "eu-west-1")
+        .body(serde_json::to_vec(&req_body_4)?)
+        .send()
+        .await?;
+    assert_eq!(
+        header_ignored_when_unconfigured_res.status(),
+        StatusCode::OK
     );
 
     tripwire_tx.send(()).await.ok();

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -69,7 +69,7 @@ use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, trace, warn};
 use tripwire::{Outcome, PreemptibleFutureExt, Tripwire};
 
-const REQUESTED_REGION_HEADER: &str = "x-corrosion-requested-region";
+const REQUESTED_ENDPOINT_NAME_HEADER: &str = "x-corrosion-requested-endpoint-name";
 
 pub async fn initialise_foca(agent: &Agent, states: Vec<(SocketAddr, Member<Actor>)>) {
     if !states.is_empty() {
@@ -386,21 +386,22 @@ async fn require_authz(
     request: axum::http::Request<axum::body::Body>,
     next: axum::middleware::Next,
 ) -> Result<axum::response::Response, axum::http::StatusCode> {
-    let maybe_requested_region = request
-        .headers()
-        .get(REQUESTED_REGION_HEADER)
-        .map(|v| v.to_str())
-        .transpose()
-        .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
+    if let Some(configured_endpoint_name) = agent.config().api.endpoint_name.as_deref() {
+        let maybe_requested_endpoint_name = request
+            .headers()
+            .get(REQUESTED_ENDPOINT_NAME_HEADER)
+            .map(|v| v.to_str())
+            .transpose()
+            .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
 
-    if maybe_requested_region
-        .is_some_and(|region| agent.config().api.region.as_deref() != Some(region))
-    {
-        warn!(
-            "Rejecting request intended for region {maybe_requested_region:?}, we are {:?}",
-            agent.config().api.region
-        );
-        return Err(axum::http::StatusCode::MISDIRECTED_REQUEST);
+        if let Some(requested_endpoint_name) = maybe_requested_endpoint_name {
+            if requested_endpoint_name != configured_endpoint_name {
+                warn!(
+                    "Rejecting request intended for endpoint {requested_endpoint_name}, we are {configured_endpoint_name}",
+                );
+                return Err(axum::http::StatusCode::MISDIRECTED_REQUEST);
+            }
+        }
     }
 
     let passed = if let Some(ref authz) = agent.config().api.authorization {

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -173,7 +173,7 @@ pub struct ApiConfig {
     #[serde_as(deserialize_as = "OneOrMany<_, PreferOne>")]
     pub bind_addr: Vec<SocketAddr>,
     #[serde(default)]
-    pub region: Option<String>,
+    pub endpoint_name: Option<String>,
     #[serde(alias = "authz", default)]
     pub authorization: Option<AuthzConfig>,
     #[serde_as(deserialize_as = "Option<OneOrMany<_, PreferOne>>")]
@@ -387,7 +387,7 @@ pub struct ConfigBuilder {
     pub db_path: Option<Utf8PathBuf>,
     gossip_addr: Option<SocketAddr>,
     api_addr: Vec<SocketAddr>,
-    region: Option<String>,
+    endpoint_name: Option<String>,
     external_addr: Option<SocketAddr>,
     admin_path: Option<Utf8PathBuf>,
     prometheus_addr: Option<SocketAddr>,
@@ -418,8 +418,8 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn region<S: Into<String>>(mut self, region: S) -> Self {
-        self.region = Some(region.into());
+    pub fn endpoint_name<S: Into<String>>(mut self, endpoint_name: S) -> Self {
+        self.endpoint_name = Some(endpoint_name.into());
         self
     }
 
@@ -496,7 +496,7 @@ impl ConfigBuilder {
             },
             api: ApiConfig {
                 bind_addr: self.api_addr,
-                region: self.region,
+                endpoint_name: self.endpoint_name,
                 authorization: None,
                 pg: None,
             },


### PR DESCRIPTION
In production we run Corrosion w/ multiple regional clusters, and systems need to ensure that they are writing to the correct cluster. We were depending on `fly-proxy` to do this via `fly-force-region`, but the proxy's balancer changes all the time and may introduce bugs here and there.

Let's validate this end-to-end by telling Corrosion which region it is (we use a more generic name `endpoint_name` here) and all users should set a header that's passed through to Corrosion, when present we'll validate the region matches what's in our config. This can optionally be extended to enforce validation on some endpoints if we so desire.