### PR TITLE
Reduce metrics cardinality, bookie consistency check, antithesis assertions

### DIFF
--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fmt::Display,
     time::{Duration, Instant},
 };
@@ -6,7 +7,7 @@ use std::{
 use camino::Utf8PathBuf;
 use corro_types::{
     actor::{ActorId, ClusterId},
-    agent::{Agent, Bookie},
+    agent::{Agent, BookedVersions, Bookie},
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast::{FocaCmd, FocaInput},
     sqlite::SqlitePoolError,
@@ -113,6 +114,7 @@ pub enum Command {
 pub enum SyncCommand {
     Generate,
     ReconcileGaps,
+    CheckBookieConsistency,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -278,6 +280,54 @@ async fn handle_conn(
                         )
                         .await;
                         }
+                    }
+
+                    send_success(&mut stream).await;
+                }
+                Command::Sync(SyncCommand::CheckBookieConsistency) => {
+                    info_log(
+                        &mut stream,
+                        "checking in-memory and DB bookie consistency...",
+                    )
+                    .await;
+
+                    let rw_conn = match agent.pool().write_low().await {
+                        Ok(conn) => conn,
+                        Err(e) => {
+                            send_error(&mut stream, e).await;
+                            continue;
+                        }
+                    };
+
+                    let report = match block_in_place(|| check_bookie_consistency(&rw_conn, bookie))
+                    {
+                        Ok(report) => report,
+                        Err(e) => {
+                            send_error(&mut stream, e).await;
+                            continue;
+                        }
+                    };
+
+                    match serde_json::to_value(&report) {
+                        Ok(json) => send(&mut stream, Response::Json(json)).await,
+                        Err(e) => {
+                            send_error(&mut stream, e).await;
+                            continue;
+                        }
+                    }
+
+                    if !report.ok {
+                        send_error(
+                            &mut stream,
+                            format!(
+                                "bookie mismatch: value_mismatch={}, only_in_memory={}, only_in_db={}",
+                                report.value_mismatch_actors.len(),
+                                report.only_in_memory_actors.len(),
+                                report.only_in_db_actors.len()
+                            ),
+                        )
+                        .await;
+                        continue;
                     }
 
                     send_success(&mut stream).await;
@@ -706,4 +756,67 @@ fn collapse_gaps(
     })?;
 
     Ok((deleted, inserted))
+}
+
+#[derive(Debug, Serialize)]
+struct BookieConsistencyReport {
+    ok: bool,
+    in_memory_actors: usize,
+    db_actors: usize,
+    value_mismatch_actors: Vec<ActorId>,
+    only_in_memory_actors: Vec<ActorId>,
+    only_in_db_actors: Vec<ActorId>,
+}
+
+fn check_bookie_consistency(
+    conn: &rusqlite::Connection,
+    bookie: &Bookie,
+) -> rusqlite::Result<BookieConsistencyReport> {
+    let _bookie_write_guard = bookie.write_lock_blocking();
+
+    let db_map = BookedVersions::load_all_from_conn(conn)?;
+
+    let in_memory_map: HashMap<ActorId, BookedVersions> = {
+        let guard = bookie.owned_guard();
+        bookie
+            .iter(&guard)
+            .map(|(actor_id, booked)| {
+                let read = booked.read();
+                (*actor_id, (**read).clone())
+            })
+            .collect()
+    };
+
+    let mut value_mismatch_actors = Vec::new();
+    let mut only_in_memory_actors = Vec::new();
+    let mut only_in_db_actors = Vec::new();
+
+    for (actor_id, mem) in &in_memory_map {
+        match db_map.get(actor_id) {
+            Some(db) if db != mem => value_mismatch_actors.push(*actor_id),
+            Some(_) => {}
+            None => only_in_memory_actors.push(*actor_id),
+        }
+    }
+
+    for actor_id in db_map.keys() {
+        if !in_memory_map.contains_key(actor_id) {
+            only_in_db_actors.push(*actor_id);
+        }
+    }
+
+    value_mismatch_actors.sort_unstable();
+    only_in_memory_actors.sort_unstable();
+    only_in_db_actors.sort_unstable();
+
+    Ok(BookieConsistencyReport {
+        ok: value_mismatch_actors.is_empty()
+            && only_in_memory_actors.is_empty()
+            && only_in_db_actors.is_empty(),
+        in_memory_actors: in_memory_map.len(),
+        db_actors: db_map.len(),
+        value_mismatch_actors,
+        only_in_memory_actors,
+        only_in_db_actors,
+    })
 }

--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use camino::Utf8PathBuf;
 use corro_types::{
     actor::{ActorId, ClusterId},
-    agent::{Agent, BookedVersions, Bookie},
+    agent::{Agent, BookedVersions, Bookie, WriteConn},
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast::{FocaCmd, FocaInput},
     sqlite::SqlitePoolError,
@@ -299,7 +299,7 @@ async fn handle_conn(
                         }
                     };
 
-                    let report = match block_in_place(|| check_bookie_consistency(&rw_conn, bookie))
+                    let report = match block_in_place(|| check_bookie_consistency(rw_conn, bookie))
                     {
                         Ok(report) => report,
                         Err(e) => {
@@ -769,22 +769,29 @@ struct BookieConsistencyReport {
 }
 
 fn check_bookie_consistency(
-    conn: &rusqlite::Connection,
+    rw_conn: WriteConn,
     bookie: &Bookie,
 ) -> rusqlite::Result<BookieConsistencyReport> {
-    let _bookie_write_guard = bookie.write_lock_blocking();
+    let (in_memory_map, db_map): (
+        HashMap<ActorId, BookedVersions>,
+        HashMap<ActorId, BookedVersions>,
+    ) = {
+        let _bookie_write_guard: corro_types::agent::BookieWriteGuard =
+            bookie.write_lock_blocking();
+        let db_map = BookedVersions::load_all_from_conn(&rw_conn)?;
 
-    let db_map = BookedVersions::load_all_from_conn(conn)?;
-
-    let in_memory_map: HashMap<ActorId, BookedVersions> = {
         let guard = bookie.owned_guard();
-        bookie
+        let in_memory_map = bookie
             .iter(&guard)
             .map(|(actor_id, booked)| {
                 let read = booked.read();
                 (*actor_id, (**read).clone())
             })
-            .collect()
+            .collect();
+
+        // Release the locks asap
+        drop(rw_conn);
+        (in_memory_map, db_map)
     };
 
     let mut value_mismatch_actors = Vec::new();

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -169,6 +169,7 @@ pub fn spawn_rtt_handler(
                             let mut members = agent.members().write();
                             for (addr, rtt) in chunks {
                                 members.add_rtt(addr, rtt);
+                                histogram!("corro.transport.rtt.v2.seconds").record(rtt.as_secs_f64());
                             }
                         } else {
                             break;
@@ -299,9 +300,9 @@ pub async fn handle_gossip_to_send(
                     error!("could not write datagram {addr}: {e}");
                     return;
                 }
-                counter!("corro.peer.datagram.sent.total", "actor_id" => actor_id.to_string())
-                    .increment(1);
-                counter!("corro.peer.datagram.bytes.sent.total").increment(len as u64);
+                counter!("corro.peer.datagram.sent.total", "traffic" => "foca").increment(1);
+                counter!("corro.peer.datagram.bytes.sent.total", "traffic" => "foca")
+                    .increment(len as u64);
             }
             .instrument(debug_span!("send_swim_payload", %addr, %actor_id, buf_size = len)),
         );
@@ -340,10 +341,15 @@ pub async fn handle_notifications(
                     MemberAddedResult::NewMember | MemberAddedResult::Removed => {
                         if matches!(member_added_res, MemberAddedResult::Removed) {
                             debug!("Member Removed {actor:?} due to member id mismatch");
-                            counter!("corro.gossip.member.removed", "id" => actor.id().0.to_string(), "addr" => actor.addr().to_string()).increment(1);
+                            counter!(
+                                "corro.gossip.member.removed",
+                                "traffic" => "foca",
+                                "kind" => "member_id_mismatch"
+                            )
+                            .increment(1);
                         } else {
                             debug!("Member Added {actor:?}");
-                            counter!("corro.gossip.member.added", "id" => actor.id().0.to_string(), "addr" => actor.addr().to_string()).increment(1);
+                            counter!("corro.gossip.member.added", "traffic" => "foca").increment(1);
                         }
 
                         let members_len = { agent.members().read().states.len() as u32 };
@@ -386,7 +392,8 @@ pub async fn handle_notifications(
                 info!("Member Down {actor:?} (removed: {removed})");
                 if removed {
                     debug!("Member Down {actor:?}");
-                    counter!("corro.gossip.member.removed", "id" => actor.id().0.to_string(), "addr" => actor.addr().to_string()).increment(1);
+                    counter!("corro.gossip.member.removed", "traffic" => "foca", "kind" => "member_down")
+                        .increment(1);
                     // actually removed a member
                     // notify of new cluster size
                     let member_len = { agent.members().read().states.len() as u32 };
@@ -1065,13 +1072,12 @@ pub async fn handle_sync(
 ) -> Result<(), SyncClientError> {
     let sync_state = generate_sync(bookie, agent.actor_id()).await;
 
-    for (actor_id, needed) in sync_state.need.iter() {
-        gauge!("corro.sync.client.needed", "actor_id" => actor_id.to_string())
-            .set(needed.len() as f64);
-    }
-    for (actor_id, version) in sync_state.heads.iter() {
-        gauge!("corro.sync.client.head", "actor_id" => actor_id.to_string()).set(version.0 as f64);
-    }
+    let needed_total = sync_state
+        .need
+        .values()
+        .map(|needed| needed.len() as u64)
+        .sum::<u64>();
+    gauge!("corro.sync.client.needed.v2", "traffic" => "sync").set(needed_total as f64);
 
     let chosen: Vec<(ActorId, SocketAddr)> = {
         let candidates = {

--- a/crates/corro-agent/src/agent/metrics.rs
+++ b/crates/corro-agent/src/agent/metrics.rs
@@ -1,6 +1,8 @@
 use crate::transport::Transport;
-use corro_types::{actor::ActorId, agent::Agent};
+use antithesis_sdk::assert_always;
+use corro_types::agent::Agent;
 use metrics::gauge;
+use serde_json::json;
 use std::time::Duration;
 use tokio::task::block_in_place;
 use tracing::error;
@@ -8,6 +10,7 @@ use tripwire::Tripwire;
 
 pub async fn metrics_loop(agent: Agent, transport: Transport, mut tripwire: Tripwire) {
     let mut metrics_interval = tokio::time::interval(Duration::from_secs(10));
+    let on_antithesis = std::env::var("ANTITHESIS_OUTPUT_DIR").is_ok();
 
     loop {
         tokio::select! {
@@ -15,11 +18,11 @@ pub async fn metrics_loop(agent: Agent, transport: Transport, mut tripwire: Trip
             _ = &mut tripwire => break,
         }
 
-        block_in_place(|| collect_metrics(&agent, &transport));
+        block_in_place(|| collect_metrics(&agent, &transport, on_antithesis));
     }
 }
 
-pub fn collect_metrics(agent: &Agent, transport: &Transport) {
+pub fn collect_metrics(agent: &Agent, transport: &Transport, on_antithesis: bool) {
     agent.pool().emit_metrics();
     transport.emit_metrics();
 
@@ -50,38 +53,66 @@ pub fn collect_metrics(agent: &Agent, transport: &Transport) {
         }
     }
 
-    // TODO: collect from bookie?
+    // Buffered changes stats across all actors
     match conn
-        .prepare_cached("SELECT actor_id, (select count(site_id) FROM __corro_buffered_changes WHERE site_id = actor_id) FROM __corro_members")
+        .prepare_cached(
+            "
+            SELECT
+                COALESCE(json_extract(m.foca_state, '$.state'), 'orphan') AS peer_state,
+                count(*) AS total,
+                strftime('%s', 'now') - (min(bc.ts) >> 32) as oldest_age_seconds
+            FROM __corro_buffered_changes bc
+            LEFT JOIN __corro_members m ON m.actor_id = bc.site_id
+            GROUP BY peer_state
+            ",
+        )
         .and_then(|mut prepped| {
             prepped
-                .query_map((), |row| {
-                    Ok((row.get::<_, ActorId>(0)?, row.get::<_, i64>(1)?))
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
                 })
                 .and_then(|mapped| mapped.collect::<Result<Vec<_>, _>>())
         }) {
-        Ok(mapped) => {
-            for (actor_id, count) in mapped {
-                gauge!("corro.db.buffered.changes.rows.total", "actor_id" => actor_id.to_string()).set(count as f64)
+        Ok(rows) => {
+            for (peer_state, total_count, oldest_age_seconds) in rows {
+                // v2 has O(N) time series while the v1 metric had O(N^2) time series
+                // The name got changed on purpose so the metric has a fresh namespace
+                gauge!("corro.db.buffered.changes.v2.total", "peer_state" => peer_state.clone())
+                    .set(total_count as f64);
+                gauge!("corro.db.buffered.changes.v2.oldest_age_seconds", "peer_state" => peer_state)
+                    .set(oldest_age_seconds as f64);
             }
         }
         Err(e) => {
-            error!("could not query count for buffered changes: {e}");
+            error!("could not query buffered changes v2 stats: {e}");
         }
     }
 
     match conn
-        .prepare_cached("select actor_id, sum((end - start) + 1) from __corro_bookkeeping_gaps group by actor_id")
+        .prepare_cached(
+            "
+            SELECT
+                COALESCE(json_extract(m.foca_state, '$.state'), 'orphan') AS peer_state,
+                COALESCE(SUM((g.end - g.start) + 1), 0) AS gaps_sum
+            FROM __corro_bookkeeping_gaps g
+            LEFT JOIN __corro_members m ON m.actor_id = g.actor_id
+            GROUP BY peer_state
+            ",
+        )
         .and_then(|mut prepped| {
             prepped
-                .query_map((), |row| {
-                    Ok((row.get::<_, ActorId>(0)?, row.get::<_, u64>(1)?))
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, u64>(1)?))
                 })
                 .and_then(|mapped| mapped.collect::<Result<Vec<_>, _>>())
         }) {
-        Ok(mapped) => {
-            for (actor_id, sum) in mapped {
-                gauge!("corro.db.gaps.sum", "actor_id" => actor_id.to_string()).set(sum as f64)
+        Ok(rows) => {
+            for (peer_state, sum) in rows {
+                gauge!("corro.db.gaps.sum", "peer_state" => peer_state).set(sum as f64)
             }
         }
         Err(e) => {
@@ -107,6 +138,40 @@ pub fn collect_metrics(agent: &Agent, transport: &Transport) {
     if db_path.set_extension(format!("{}-wal", db_path.extension().unwrap_or_default())) {
         if let Ok(meta) = db_path.metadata() {
             gauge!("corro.db.wal.size").set(meta.len() as f64);
+        }
+    }
+
+    if on_antithesis {
+        let gaps = conn
+            .prepare_cached(
+                "SELECT COALESCE(SUM(end - start + 1), 0) FROM __corro_bookkeeping_gaps",
+            )
+            .and_then(|mut prepped| prepped.query_row([], |row| row.get::<_, i64>(0)));
+
+        if let Ok(gaps) = gaps {
+            const MAX_GAPS: i64 = 100;
+            const MAX_QUEUE: u64 = 16_000;
+            const MAX_P99_LAG: f64 = 3.0;
+
+            let p99_lag = agent.metrics_tracker().quantile_lag(0.99).unwrap_or(0.0);
+            let queue_size = agent.metrics_tracker().queue_size();
+            let is_healthy = gaps <= MAX_GAPS && queue_size <= MAX_QUEUE && p99_lag <= MAX_P99_LAG;
+            let details = json!({
+                "gaps": gaps,
+                "queue_size": queue_size,
+                "p99_lag": p99_lag,
+                "max_gaps": MAX_GAPS,
+                "max_queue": MAX_QUEUE,
+                "max_p99_lag": MAX_P99_LAG,
+            });
+
+            assert_always!(
+                is_healthy,
+                "Corrosion node remains healthy in antithesis",
+                &details
+            );
+        } else if let Err(e) = gaps {
+            error!("could not query gaps for antithesis health assertion: {e}");
         }
     }
 }

--- a/crates/corro-agent/src/api/peer/mod.rs
+++ b/crates/corro-agent/src/api/peer/mod.rs
@@ -978,6 +978,7 @@ async fn write_buf(send_buf: &mut BytesMut, write: &mut SendStream) -> Result<()
     let len = send_buf.len();
     write.write_chunk(send_buf.split().freeze()).await?;
     counter!("corro.sync.chunk.sent.bytes").increment(len as u64);
+    counter!("corro.transport.tx.bytes.v2.total", "traffic" => "sync").increment(len as u64);
 
     Ok(())
 }
@@ -1088,7 +1089,7 @@ pub async fn parallel_sync(
                     }
                     trace!(%actor_id, self_actor_id = %agent.actor_id(), "read clock payload");
 
-                    counter!("corro.sync.client.member", "id" => actor_id.to_string(), "addr" => addr.to_string()).increment(1);
+                    counter!("corro.sync.client.member", "traffic" => "sync").increment(1);
 
                     let needs = our_sync_state.compute_available_needs(&their_sync_state);
 
@@ -1117,9 +1118,8 @@ pub async fn parallel_sync(
             Err(e) => {
                 counter!(
                     "corro.sync.client.handshake.errors",
-                    "actor_id" => actor_id.to_string(),
-                    "addr" => addr.to_string(),
-                    "error" => e.to_string()
+                    "traffic" => "sync",
+                    "kind" => "handshake"
                 )
                 .increment(1);
                 match agg {
@@ -1294,7 +1294,8 @@ pub async fn parallel_sync(
                         continue 'servers;
                     }
 
-                    counter!("corro.sync.client.req.sent", "actor_id" => server_actor_id.to_string()).increment(req_len as u64);
+                    counter!("corro.sync.client.req.sent", "traffic" => "sync")
+                        .increment(req_len as u64);
                 }
 
                 if !send_buf.is_empty() {
@@ -1344,7 +1345,7 @@ pub async fn parallel_sync(
                             let changes_len = cmp::max(change.len(), 1);
                             // tracing::Span::current().record("changes_len", changes_len);
                             count += changes_len;
-                            counter!("corro.sync.changes.recv", "actor_id" => actor_id.to_string())
+                            counter!("corro.sync.changes.recv", "traffic" => "sync")
                                 .increment(changes_len as u64);
 
                             debug!(
@@ -1598,7 +1599,7 @@ pub async fn serve_sync(
 
             debug!(actor_id = %agent.actor_id(), "done writing sync messages (count: {count})");
 
-            counter!("corro.sync.changes.sent", "actor_id" => their_actor_id.to_string()).increment(count as u64);
+            counter!("corro.sync.changes.sent", "traffic" => "sync").increment(count as u64);
 
             Ok::<_, SyncError>(count)
         }.instrument(info_span!("process_versions_to_send")),
@@ -1649,7 +1650,7 @@ pub async fn serve_sync(
 
             debug!(actor_id = %agent.actor_id(), "done reading sync messages");
 
-            counter!("corro.sync.requests.recv", "actor_id" => their_actor_id.to_string()).increment(count as u64);
+            counter!("corro.sync.requests.recv", "traffic" => "sync").increment(count as u64);
 
             Ok(count)
         }.instrument(info_span!("process_version_requests"))

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -1102,7 +1102,7 @@ fn try_transmit_broadcast(
                 error!("could not write to uni stream to {addr}: {e}");
             }
             Ok(Ok(_)) => {
-                counter!("corro.peer.stream.bytes.sent.total", "type" => "uni")
+                counter!("corro.peer.stream.bytes.sent.total", "traffic" => "broadcast")
                     .increment(len as u64);
             }
         }

--- a/crates/corro-agent/src/transport.rs
+++ b/crates/corro-agent/src/transport.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
     net::SocketAddr,
-    sync::Arc,
+    sync::{Arc, Mutex as StdMutex},
     time::{Duration, Instant},
 };
 
@@ -30,6 +30,31 @@ struct TransportInner {
     endpoints: Vec<Endpoint>,
     conns: RwLock<HashMap<SocketAddr, Arc<Mutex<Option<Connection>>>>>,
     rtt_tx: mpsc::Sender<(SocketAddr, Duration)>,
+    path_snapshots: StdMutex<HashMap<SocketAddr, PathSnapshot>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PathSnapshot {
+    cwnd: u64,
+    congestion_events: u64,
+    black_holes_detected: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TrafficClass {
+    Sync,
+    Broadcast,
+    Foca,
+}
+
+impl TrafficClass {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sync => "sync",
+            Self::Broadcast => "broadcast",
+            Self::Foca => "foca",
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -74,24 +99,33 @@ impl Transport {
             endpoints,
             conns: Default::default(),
             rtt_tx,
+            path_snapshots: Default::default(),
         })))
     }
 
     #[tracing::instrument(skip(self, data), fields(buf_size = data.len()), level = "debug", err)]
     pub async fn send_datagram(&self, addr: SocketAddr, data: Bytes) -> Result<(), TransportError> {
-        let conn = self.connect(addr).await?;
+        let conn = self.connect(addr, TrafficClass::Foca).await?;
         trace!("connected to {addr}");
 
         match conn.send_datagram(data.clone()) {
-            Ok(send) => {
+            Ok(()) => {
                 trace!("sent datagram to {addr}");
-                return Ok(send);
             }
             Err(SendDatagramError::ConnectionLost(e)) => {
                 debug!("retryable error attempting to send datagram: {e}");
+
+                let conn = self.connect(addr, TrafficClass::Foca).await?;
+                debug!("re-connected to {addr}");
+                conn.send_datagram(data.clone())?;
             }
             Err(e) => {
-                counter!("corro.transport.send_datagram.errors", "addr" => addr.to_string(), "error" => e.to_string()).increment(1);
+                counter!(
+                    "corro.transport.send_datagram.errors.v2",
+                    "traffic" => TrafficClass::Foca.as_str(),
+                    "kind" => datagram_error_kind(&e)
+                )
+                .increment(1);
                 if matches!(e, SendDatagramError::TooLarge) {
                     warn!(%addr, "attempted to send a larger-than-PMTU datagram. len: {}, pmtu: {:?}", data.len(), conn.max_datagram_size());
                 }
@@ -99,14 +133,24 @@ impl Transport {
             }
         }
 
-        let conn = self.connect(addr).await?;
-        debug!("re-connected to {addr}");
-        Ok(conn.send_datagram(data)?)
+        counter!(
+            "corro.transport.tx.datagrams.v2.total",
+            "traffic" => TrafficClass::Foca.as_str()
+        )
+        .increment(1);
+        counter!(
+            "corro.transport.tx.bytes.v2.total",
+            "traffic" => TrafficClass::Foca.as_str()
+        )
+        .increment(data.len() as u64);
+
+        Ok(())
     }
 
     #[tracing::instrument(skip(self, data), fields(buf_size = data.len()), level = "debug", err)]
     pub async fn send_uni(&self, addr: SocketAddr, data: Bytes) -> Result<(), TransportError> {
-        let conn = self.connect(addr).await?;
+        let len = data.len();
+        let conn = self.connect(addr, TrafficClass::Broadcast).await?;
 
         let mut stream = match conn
             .open_uni()
@@ -119,7 +163,7 @@ impl Transport {
             }
             Err(e) => {
                 debug!("retryable error attempting to open unidirectional stream: {e}");
-                let conn = self.connect(addr).await?;
+                let conn = self.connect(addr, TrafficClass::Broadcast).await?;
                 conn.open_uni()
                     .instrument(debug_span!("quic_open_uni"))
                     .await?
@@ -140,6 +184,12 @@ impl Transport {
             .instrument(debug_span!("quic_stopped"))
             .await?;
 
+        counter!(
+            "corro.transport.tx.bytes.v2.total",
+            "traffic" => TrafficClass::Broadcast.as_str()
+        )
+        .increment(len as u64);
+
         Ok(())
     }
 
@@ -148,7 +198,7 @@ impl Transport {
         &self,
         addr: SocketAddr,
     ) -> Result<(SendStream, RecvStream), TransportError> {
-        let conn = self.connect(addr).await?;
+        let conn = self.connect(addr, TrafficClass::Sync).await?;
         match conn.open_bi().instrument(debug_span!("quic_open_bi")).await {
             Ok(send_recv) => return Ok(send_recv),
             Err(e @ ConnectionError::VersionMismatch) => {
@@ -160,7 +210,7 @@ impl Transport {
         }
 
         // retry, it should reconnect!
-        let conn = self.connect(addr).await?;
+        let conn = self.connect(addr, TrafficClass::Sync).await?;
         Ok(conn
             .open_bi()
             .instrument(debug_span!("quic_open_bi"))
@@ -171,6 +221,7 @@ impl Transport {
         &self,
         addr: SocketAddr,
         server_name: String,
+        traffic: TrafficClass,
     ) -> Result<Connection, TransportError> {
         let start = Instant::now();
 
@@ -179,27 +230,43 @@ impl Transport {
         let endpoint_idx = (hasher.finish() % self.0.endpoints.len() as u64) as usize;
 
         async {
-            match tokio::time::timeout(Duration::from_secs(5), self
-                .0
-                .endpoints[endpoint_idx]
-                .connect(addr, &server_name)?)
-                .await
+            match tokio::time::timeout(
+                Duration::from_secs(5),
+                self.0.endpoints[endpoint_idx].connect(addr, &server_name)?,
+            )
+            .await
             {
                 Ok(Ok(conn)) => {
-                    histogram!("corro.transport.connect.time.seconds").record(start.elapsed().as_secs_f64());
+                    histogram!(
+                        "corro.transport.connect.time.v2.seconds",
+                        "traffic" => traffic.as_str()
+                    )
+                    .record(start.elapsed().as_secs_f64());
                     tracing::Span::current().record("rtt", conn.rtt().as_secs_f64());
                     Ok(conn)
-                },
+                }
                 Ok(Err(e)) => {
-                    counter!("corro.transport.connect.errors", "addr" => server_name, "error" => e.to_string()).increment(1);
+                    counter!(
+                        "corro.transport.connect.errors.v2",
+                        "traffic" => traffic.as_str(),
+                        "kind" => "connect_error"
+                    )
+                    .increment(1);
                     Err(e.into())
                 }
                 Err(e) => {
-                    counter!("corro.transport.connect.errors", "addr" => server_name, "error" => "timed out").increment(1);
+                    counter!(
+                        "corro.transport.connect.errors.v2",
+                        "traffic" => traffic.as_str(),
+                        "kind" => "timed_out"
+                    )
+                    .increment(1);
                     Err(e.into())
                 }
             }
-        }.instrument(debug_span!("quic_connect", %addr, rtt = tracing::field::Empty)).await
+        }
+        .instrument(debug_span!("quic_connect", %addr, rtt = tracing::field::Empty))
+        .await
     }
 
     // this shouldn't block for long...
@@ -216,7 +283,11 @@ impl Transport {
     }
 
     #[tracing::instrument(skip(self), fields(tid = ?std::thread::current().id()), level = "debug", err)]
-    async fn connect(&self, addr: SocketAddr) -> Result<Connection, TransportError> {
+    async fn connect(
+        &self,
+        addr: SocketAddr,
+        traffic: TrafficClass,
+    ) -> Result<Connection, TransportError> {
         let conn_lock = self.get_lock(addr).await;
 
         let mut lock = conn_lock.lock().await;
@@ -233,7 +304,9 @@ impl Transport {
         // clear it, if there was one it didn't pass the test.
         *lock = None;
 
-        let conn = self.measured_connect(addr, addr.ip().to_string()).await?;
+        let conn = self
+            .measured_connect(addr, addr.ip().to_string(), traffic)
+            .await?;
         *lock = Some(conn.clone());
         Ok(conn)
     }
@@ -256,12 +329,39 @@ impl Transport {
         let stats = conns
             .iter()
             .fold(ConnectionStats::default(), |mut acc, (addr, stats)| {
-                gauge!("corro.transport.path.cwnd", "addr" => addr.to_string())
-                    .set(stats.path.cwnd as f64);
-                gauge!("corro.transport.path.congestion_events", "addr" => addr.to_string())
-                    .set(stats.path.congestion_events as f64);
-                gauge!("corro.transport.path.black_holes_detected", "addr" => addr.to_string())
-                    .set(stats.path.black_holes_detected as f64);
+                let current = PathSnapshot {
+                    cwnd: stats.path.cwnd,
+                    congestion_events: stats.path.congestion_events,
+                    black_holes_detected: stats.path.black_holes_detected,
+                };
+                let mut snapshots = self
+                    .0
+                    .path_snapshots
+                    .lock()
+                    .expect("path snapshots lock should not be poisoned");
+                if let Some(previous) = snapshots.get(addr).copied() {
+                    let cwnd_delta = current.cwnd.saturating_sub(previous.cwnd);
+                    let congestion_events_delta = current
+                        .congestion_events
+                        .saturating_sub(previous.congestion_events);
+                    let black_holes_detected_delta = current
+                        .black_holes_detected
+                        .saturating_sub(previous.black_holes_detected);
+
+                    if cwnd_delta > 0
+                        || congestion_events_delta > 0
+                        || black_holes_detected_delta > 0
+                    {
+                        info!(
+                            %addr,
+                            cwnd_delta,
+                            congestion_events_delta,
+                            black_holes_detected_delta,
+                            "transport path metrics increased"
+                        );
+                    }
+                }
+                snapshots.insert(*addr, current);
 
                 acc.path.lost_packets += stats.path.lost_packets;
                 acc.path.lost_bytes += stats.path.lost_bytes;
@@ -325,6 +425,14 @@ impl Transport {
 
                 acc
             });
+        {
+            let mut snapshots = self
+                .0
+                .path_snapshots
+                .lock()
+                .expect("path snapshots lock should not be poisoned");
+            snapshots.retain(|addr, _| conns.iter().any(|(active_addr, _)| active_addr == addr));
+        }
         gauge!("corro.transport.path.lost_packets").set(stats.path.lost_packets as f64);
         gauge!("corro.transport.path.lost_bytes").set(stats.path.lost_bytes as f64);
         gauge!("corro.transport.path.sent_packets").set(stats.path.sent_packets as f64);
@@ -426,6 +534,15 @@ impl Transport {
 }
 
 const NO_ERROR: quinn::VarInt = quinn::VarInt::from_u32(0);
+
+fn datagram_error_kind(e: &SendDatagramError) -> &'static str {
+    match e {
+        SendDatagramError::UnsupportedByPeer => "unsupported_by_peer",
+        SendDatagramError::Disabled => "disabled",
+        SendDatagramError::TooLarge => "too_large",
+        SendDatagramError::ConnectionLost(_) => "connection_lost",
+    }
+}
 
 fn test_conn(conn: &Connection) -> bool {
     match conn.close_reason() {

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -499,6 +499,13 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             ))
             .await?;
         }
+        Command::Sync(SyncCommand::CheckBookieConsistency) => {
+            let mut conn = AdminConn::connect(cli.admin_path()).await?;
+            conn.send_command(corro_admin::Command::Sync(
+                corro_admin::SyncCommand::CheckBookieConsistency,
+            ))
+            .await?;
+        }
         Command::Template { template, flags } => {
             command::tpl::run(cli.api_addr()?, template, flags).await?;
         }
@@ -780,6 +787,8 @@ enum ConsulCommand {
 enum SyncCommand {
     /// Generate a sync message from the current agent
     Generate,
+    /// Check in-memory bookie state against DB-loaded bookie state
+    CheckBookieConsistency,
     ReconcileGaps,
 }
 


### PR DESCRIPTION
- Introduces a new admin command (CheckBookieConsistency) that rebuilds bookie state from DB via BookedVersions::load_all_from_conn and compares it against in-memory bookie state to detect consistency drift.
- Runs the corrosion healtcheck on antithesis. This should catch sync performance degradation in antithesis.
- Changes corro.db.gaps.sum to bucket by peer_state instead of actor_id to avoid high-cardinality series.
- Introduces corro.db.buffered.changes.v2.total and corro.db.buffered.changes.v2.oldest_age_seconds for buffered-change visibility with bounded cardinality. The metric got renamed so the old metrics don't slow down grafana.
- Removes high-cardinality transport per-address metrics; keeps delta tracking and logs only increases for cwnd, congestion_events, and black_holes_detected.
- Buckets transport/connect/send metrics by traffic class (sync, broadcast, foca) and wires traffic tagging through open_bi, send_uni, and send_datagram. This way we can distinguish if sync or broadcast uses up more traffic. This tagging relies on the assumption that:
    * `open_bi` is used primarily in sync
    * `send_datagram` by FOCA/SWIM
    * `send_uni` by broadcast traffic
- Adds v2 to the name of some metrics to distinguish the old high cardinality series from the new low cardinality ones
- Introduces `corro.transport.rtt.v2.seconds` which is an histogram of the rtt of peers