### PR TITLE
fix 'occured' -> 'occurred' typos in corro-pg, corro-agent, corro-client

### DIFF
--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -737,7 +737,7 @@ pub async fn api_v1_table_stats(
             StatusCode::INTERNAL_SERVER_ERROR,
             axum::Json(TableStatResponse {
                 total_row_count: 0,
-                // Since we don't know what error occured or if any
+                // Since we don't know what error occurred or if any
                 // tables were valid, we just return an empty list
                 invalid_tables: vec![],
             }),

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -383,7 +383,7 @@ struct PooledClientInner {
     client: Option<CorrosionApiClient>,
     // Whether or not the chosen client has made a successful request
     had_success: bool,
-    // Time when the first fail occured after at least one successful call
+    // Time when the first fail occurred after at least one successful call
     first_fail_at: Option<Instant>,
     // Current client generation, incremented after each client change
     generation: u64,

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2658,7 +2658,7 @@ fn send_ready(
     let ready_status = if session.tx_state.is_implicit() {
         let permits = session.tx_state.end(); // do this first, in case of failure
         if discard_until_sync {
-            // an error occured, rollback implicit tx!
+            // an error occurred, rollback implicit tx!
             warn!("receive Sync message w/ an error to send, rolling back implicit tx");
             session.conn.execute_batch("ROLLBACK")?;
         } else {


### PR DESCRIPTION
Comments in three crates read `occured`:
- `crates/corro-pg/src/lib.rs` line 2661
- `crates/corro-agent/src/api/public/mod.rs` line 740
- `crates/corro-client/src/lib.rs` line 386

Fixed to `occurred`. Comment-only change.