### PR TITLE
Sqlite metrics for subscription matchers

### DIFF
--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -511,6 +511,7 @@ async fn handle_conn(
                                "id": k,
                                "hash": v.hash(),
                                 "sql": v.sql().lines().map(|c| c.trim()).collect::<Vec<_>>().join(" "),
+                                "ms_per_sec_cost": v.ms_per_sec(),
                             })
                         })
                         .collect::<Vec<_>>();
@@ -547,6 +548,7 @@ async fn handle_conn(
                                     "last_change_id": matcher.last_change_id_sent(),
                                     "original_query": matcher.sql().lines().map(|c| c.trim()).collect::<Vec<_>>().join(" "),
                                     "statements": statements,
+                                    "ms_per_sec_cost": matcher.ms_per_sec(),
                                 })),
                             )
                             .await;

--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -45,7 +45,7 @@ use crate::{
     api::QueryEvent,
     change::Change,
     schema::{Schema, Table},
-    sqlite::CrConn,
+    sqlite::{trace_heavy_queries_subs, CrConn},
     updates::HandleMetrics,
 };
 
@@ -278,6 +278,52 @@ struct InnerMatcherHandle {
     subs_path: String,
     cached_statements: HashMap<String, MatcherStmt>,
     metrics: HashMap<String, HandleMetrics>,
+    /// EMA of ms/s spent in handle_candidates
+    processing_stats: Arc<Mutex<ProcessingStats>>,
+}
+
+/// Tracks a moving average of ms/s for subscription processing cost.
+struct ProcessingStats {
+    /// Exponential moving average of ms/s
+    ema_ms_per_sec: f64,
+    /// Time of the last handle_candidates completion
+    last_process_time: Option<Instant>,
+}
+
+impl ProcessingStats {
+    /// Alpha for EMA smoothing. Higher = more responsive to recent data.
+    const ALPHA: f64 = 0.3;
+
+    /// Update the EMA with a new processing duration.
+    fn record(&mut self, elapsed: Duration) {
+        let now = Instant::now();
+        let ms = elapsed.as_secs_f64() * 1000.0;
+        let ms_per_sec = match self.last_process_time {
+            Some(prev) => {
+                let interval = (now - prev).as_secs_f64();
+                if interval > 0.0 {
+                    ms / interval
+                } else {
+                    0.0
+                }
+            }
+            None => 0.0,
+        };
+        self.ema_ms_per_sec = if self.ema_ms_per_sec == 0.0 {
+            ms_per_sec
+        } else {
+            Self::ALPHA * ms_per_sec + (1.0 - Self::ALPHA) * self.ema_ms_per_sec
+        };
+        self.last_process_time = Some(now);
+    }
+}
+
+impl std::fmt::Debug for ProcessingStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProcessingStats")
+            .field("ema_ms_per_sec", &self.ema_ms_per_sec)
+            .finish()
+    }
 }
 
 pub type MatchCandidates = IndexMap<TableName, IndexMap<Vec<u8>, i64>>;
@@ -378,6 +424,10 @@ impl MatcherHandle {
 
     pub fn pool(&self) -> &RusqlitePool {
         &self.inner.pool
+    }
+
+    pub fn ms_per_sec(&self) -> f64 {
+        self.inner.processing_stats.lock().ema_ms_per_sec
     }
 
     fn wait_for_running_state(&self) {
@@ -562,6 +612,7 @@ pub struct Matcher {
     last_change_tx: watch::Sender<ChangeId>,
     changes_rx: mpsc::Receiver<MatchCandidates>,
     purge_rx: mpsc::Receiver<oneshot::Sender<rusqlite::Result<usize>>>,
+    processing_stats: Arc<Mutex<ProcessingStats>>,
 }
 
 #[derive(Debug, Clone)]
@@ -611,6 +662,7 @@ impl Matcher {
         };
 
         let conn = Connection::open(&sub_db_path)?;
+        trace_heavy_queries_subs(&conn)?;
         conn.execute_batch(
             r#"
                 PRAGMA journal_mode = WAL;
@@ -819,9 +871,15 @@ impl Matcher {
                 cached_statements: statements.clone(),
                 subs_path: sub_path.to_string(),
                 metrics: counter_map,
+                processing_stats: Arc::new(Mutex::new(ProcessingStats {
+                    ema_ms_per_sec: 0.0,
+                    last_process_time: None,
+                })),
             }),
             state: state.clone(),
         };
+
+        let processing_stats = handle.inner.processing_stats.clone();
 
         let matcher = Self {
             id,
@@ -840,6 +898,7 @@ impl Matcher {
             last_change_tx,
             changes_rx,
             purge_rx,
+            processing_stats,
         };
 
         Ok((matcher, handle))
@@ -1222,6 +1281,8 @@ impl Matcher {
                     }
                     let elapsed = start.elapsed();
 
+                    self.processing_stats.lock().record(elapsed);
+
                     histogram!("corro.subs.changes.processing.duration.seconds", "sql_hash" => self.hash.clone()).record(elapsed);
 
                     if elapsed >= PROCESSING_WARN_THRESHOLD {
@@ -1278,6 +1339,7 @@ impl Matcher {
                 return;
             }
             let elapsed = start.elapsed();
+            self.processing_stats.lock().record(elapsed);
             info!(sub_id = %self.id, "handled final buffered candidates in {elapsed:?}");
         }
 
@@ -1290,6 +1352,7 @@ impl Matcher {
 
     async fn run(mut self, mut state_conn: CrConn, tripwire: Tripwire) -> Result<(), MatcherError> {
         info!(sub_id = %self.id, "Running initial query");
+
         self.evt_tx
             .send(QueryEvent::Columns(self.col_names.clone()))
             .await

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -30,6 +30,9 @@ type InFlightQueries = HashMap<String, Instant>;
 static QUERY_STATS: ThreadLocal<Mutex<QueryStats>> = ThreadLocal::new();
 pub static IN_FLIGHT_QUERIES: ThreadLocal<Mutex<InFlightQueries>> = ThreadLocal::new();
 
+// Aggregate stats for subscription matcher connections (no per-query breakdown)
+static SUBS_QUERY_STATS: ThreadLocal<Mutex<(u64, u128)>> = ThreadLocal::new(); // (count, nanos)
+
 pub async fn query_metrics_loop(mut tripwire: Tripwire) {
     let mut interval = tokio::time::interval(Duration::from_secs(10));
     let mut prev_tick = interval.tick().await;
@@ -39,6 +42,7 @@ pub async fn query_metrics_loop(mut tripwire: Tripwire) {
             let elapsed = t.duration_since(prev_tick);
             prev_tick = t;
             handle_query_metrics(elapsed);
+            handle_subs_query_metrics();
             },
             _ = &mut tripwire => break,
         }
@@ -190,6 +194,51 @@ pub fn trace_heavy_queries(conn: &Connection) -> rusqlite::Result<()> {
         }),
     );
     Ok(())
+}
+
+/// Install tracing on a connection used by subscription matchers.
+/// Writes to a separate SUBS_QUERY_STATS so subs sqlite time is
+/// bucketed into `corro.subs.db.query.ms` / `corro.subs.db.query.count`
+/// instead of the general `corro.db.query.*` metrics.
+pub fn trace_heavy_queries_subs(conn: &Connection) -> rusqlite::Result<()> {
+    conn.trace_v2(
+        TraceEventCodes::SQLITE_TRACE_PROFILE,
+        Some(tracing_callback_subs),
+    );
+    Ok(())
+}
+
+fn tracing_callback_subs(ev: rusqlite::trace::TraceEvent) {
+    if let rusqlite::trace::TraceEvent::Profile(stmt_ref, duration) = ev {
+        let dur = duration.as_nanos();
+        let sql = stmt_ref.sql().to_string();
+
+        let stats_mutex = SUBS_QUERY_STATS.get_or_default();
+        let mut stats = stats_mutex.lock();
+        stats.0 += 1;
+        stats.1 += dur;
+
+        if duration >= SLOW_QUERY_THRESHOLD {
+            drop(stats);
+            warn!("SLOW SUBS query {duration:?} => {sql}");
+        }
+    }
+}
+
+fn handle_subs_query_metrics() {
+    let mut total_count = 0u64;
+    let mut total_nanos = 0u128;
+
+    for stats_mutex in SUBS_QUERY_STATS.iter() {
+        let mut stats = stats_mutex.lock();
+        total_count += stats.0;
+        total_nanos += stats.1;
+        *stats = (0, 0);
+    }
+
+    let total_ms = (total_nanos / 1_000_000) as u64;
+    counter!("corro.subs.db.query.ms").increment(total_ms);
+    counter!("corro.subs.db.query.count").increment(total_count);
 }
 
 const CRSQL_EXT_GENERIC_NAME: &str = "crsqlite";


### PR DESCRIPTION
Tracks total subscription costs in terms of ms/s of time spent processing subs. Total aggregates are sent via metrics. The exact cost of a given subscription can be check via an admin command.