### PR TITLE
Record when corro channel goes above threshold capacity 

### DIFF
--- a/.buildkite-antithesis/scripts/test.sh
+++ b/.buildkite-antithesis/scripts/test.sh
@@ -22,9 +22,10 @@ response=$(curl --fail -u "flyio:${ANTITHESIS_PASSWORD}" -X POST https://flyio.a
 
 status=$(echo $response | jq -r '.statusCode')
 
-if [ "$status" != "200" ]; then
+if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+    echo "Launched Antithesis test $response"
+else
     echo "Failed to launch Antithesis test $response"
     exit 1
 fi
 
-echo "Launched Antithesis test $response"

--- a/crates/corro-types/src/channel.rs
+++ b/crates/corro-types/src/channel.rs
@@ -78,18 +78,22 @@ pub fn bounded<T: Send + 'static>(
         let mut ticks_since_report = 0;
         let mut tick = interval(Duration::from_secs(1));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut prev = inner_channel.capacity();
         loop {
             tick.tick().await;
             if inner_channel.is_closed() {
                 break;
             }
             let current = inner_channel.capacity();
-            if current < threshold || ticks_since_report >= 30 {
+            if prev != current
+                && (current < threshold || prev < threshold || ticks_since_report >= 30)
+            {
                 capacity_gauge.set(current as f64);
                 ticks_since_report = 0;
             } else {
                 ticks_since_report += 1;
             }
+            prev = current;
         }
     });
 

--- a/crates/corro-types/src/channel.rs
+++ b/crates/corro-types/src/channel.rs
@@ -85,8 +85,8 @@ pub fn bounded<T: Send + 'static>(
                 break;
             }
             let current = inner_channel.capacity();
-            if prev != current
-                && (current < threshold || prev < threshold || ticks_since_report >= 30)
+            if ticks_since_report >= 30
+                || (prev != current && (current < threshold || prev < threshold))
             {
                 capacity_gauge.set(current as f64);
                 ticks_since_report = 0;


### PR DESCRIPTION
Previously we skipped recording when capacity was above the threshold if fewer than 30 ticks had passed since the last record. This caused some recovereis from low capacity to be missed, leading to inaccurate metrics and false alerts. This PR fixes it by recording if previous capacity was below threshold too.