### PR TITLE
Add documentation for public crates

### DIFF
--- a/crates/consul-client/Cargo.toml
+++ b/crates/consul-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "consul-client"
 version = "0.1.0-alpha.0"
 description = "Consul client"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/consul-client/README.md
+++ b/crates/consul-client/README.md
@@ -1,0 +1,39 @@
+# consul-client
+
+Minimal HTTP client for the local [HashiCorp Consul] agent.
+
+[Corrosion] uses this crate to read the list of services and health checks
+registered against the Consul agent running on the same host, then propagates
+that state through the cluster. The client only implements the handful of
+agent endpoints required for that purpose (`agent_services` and
+`agent_checks`); it is not a general-purpose Consul SDK. If you just want to 
+sync consul checks and services to Corrosion, use `corrosion consul sync` command.
+
+The client supports both plain HTTP and mutual TLS, configured via `Config`
+and `config::TlsConfig`. When TLS is enabled the CA bundle, client
+certificate, and private key are loaded from disk at construction time.
+
+## Example
+
+```rust
+use consul_client::{Client, Config};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let client = Client::new(Config {
+    address: "127.0.0.1:8500".to_string(),
+    tls: None,
+})?;
+
+let services = client.agent_services().await?;
+for (id, svc) in services {
+    println!("{id}: {}@{}:{}", svc.name, svc.address, svc.port);
+}
+# Ok(()) }
+```
+
+## License
+
+Licensed under the [Apache License, Version 2.0](../../LICENSE).
+
+[HashiCorp Consul]: https://developer.hashicorp.com/consul
+[Corrosion]: https://github.com/superfly/corrosion

--- a/crates/consul-client/src/config.rs
+++ b/crates/consul-client/src/config.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 
-/// HashiCorp Consul client configuration
+/// HashiCorp Consul client configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     /// Vault address

--- a/crates/consul-client/src/lib.rs
+++ b/crates/consul-client/src/lib.rs
@@ -86,8 +86,7 @@ impl Client {
 
     /// Fetch the services registered on the local Consul agent.
     ///
-    /// Wraps the
-    /// [`/v1/agent/services`](https://developer.hashicorp.com/consul/api-docs/agent/service#list-services)
+    /// Wraps the [`/v1/agent/services`](https://developer.hashicorp.com/consul/api-docs/agent/service#list-services)
     /// endpoint. The returned map is keyed by service ID.
     pub async fn agent_services(&self) -> ConsulResult<HashMap<String, AgentService>> {
         self.request("/v1/agent/services").await
@@ -95,8 +94,7 @@ impl Client {
 
     /// Fetch the health checks registered on the local Consul agent.
     ///
-    /// Wraps the
-    /// [`/v1/agent/checks`](https://developer.hashicorp.com/consul/api-docs/agent/check#list-checks)
+    /// Wraps the [`/v1/agent/checks`](https://developer.hashicorp.com/consul/api-docs/agent/check#list-checks)
     /// endpoint. The returned map is keyed by check ID.
     pub async fn agent_checks(&self) -> ConsulResult<HashMap<String, AgentCheck>> {
         self.request("/v1/agent/checks").await

--- a/crates/consul-client/src/lib.rs
+++ b/crates/consul-client/src/lib.rs
@@ -13,8 +13,10 @@ use rusqlite::types::{FromSql, FromSqlError, ValueRef};
 pub mod config;
 pub use config::Config;
 
+/// Convenience alias for results returned by this crate.
 pub type ConsulResult<T> = std::result::Result<T, Error>;
 
+/// HTTP client for the local Consul agent API.
 #[derive(Debug, Clone)]
 pub struct Client {
     client: reqwest::Client,
@@ -22,6 +24,12 @@ pub struct Client {
 }
 
 impl Client {
+    /// Build a new client from the given [`Config`].
+    ///
+    /// If [`Config::tls`] is set the corresponding CA, certificate and key
+    /// files are read eagerly and used to configure rustls. Errors from
+    /// reading or parsing those files are returned via [`Error::TlsSetup`]
+    /// and the rustls/PEM error variants.
     pub fn new(config: Config) -> ConsulResult<Self> {
         use rustls::pki_types::pem::PemObject as _;
 
@@ -76,10 +84,20 @@ impl Client {
         })
     }
 
+    /// Fetch the services registered on the local Consul agent.
+    ///
+    /// Wraps the
+    /// [`/v1/agent/services`](https://developer.hashicorp.com/consul/api-docs/agent/service#list-services)
+    /// endpoint. The returned map is keyed by service ID.
     pub async fn agent_services(&self) -> ConsulResult<HashMap<String, AgentService>> {
         self.request("/v1/agent/services").await
     }
 
+    /// Fetch the health checks registered on the local Consul agent.
+    ///
+    /// Wraps the
+    /// [`/v1/agent/checks`](https://developer.hashicorp.com/consul/api-docs/agent/check#list-checks)
+    /// endpoint. The returned map is keyed by check ID.
     pub async fn agent_checks(&self) -> ConsulResult<HashMap<String, AgentCheck>> {
         self.request("/v1/agent/checks").await
     }
@@ -101,26 +119,39 @@ impl Client {
     }
 }
 
+/// Errors produced by the Consul client.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// HTTP transport-level error from `reqwest`.
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
+    /// The Consul agent returned a non-`200 OK` response.
     #[error("bad status code: {0}")]
     BadStatusCode(http::StatusCode),
+    /// The configured agent address could not be parsed as a URI.
     #[error(transparent)]
     InvalidUri(#[from] http::uri::InvalidUri),
+    /// The response body could not be deserialized as JSON.
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
+    /// One of the TLS material files (CA, cert, key) could not be opened.
     #[error("tls setup: {0}")]
     TlsSetup(std::io::Error),
+    /// The rustls client configuration could not be built.
     #[error(transparent)]
     Rustls(#[from] rustls::Error),
+    /// A PEM-encoded TLS file failed to parse.
     #[error(transparent)]
     Pem(#[from] rustls::pki_types::pem::Error),
+    /// A certificate failed WebPKI validation.
     #[error(transparent)]
     Webpki(#[from] webpki::Error),
 }
 
+/// A service registered on the local Consul agent.
+///
+/// Mirrors the subset of fields that Corrosion cares about from Consul's
+/// `AgentService` JSON object.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
 #[serde(rename_all(deserialize = "PascalCase"))]
 pub struct AgentService {
@@ -136,6 +167,7 @@ pub struct AgentService {
     pub address: String,
 }
 
+/// A health check registered on the local Consul agent.
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all(deserialize = "PascalCase"))]
@@ -152,6 +184,7 @@ pub struct AgentCheck {
     pub notes: Option<String>,
 }
 
+/// Status of a Consul health check.
 #[derive(Debug, Copy, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConsulCheckStatus {

--- a/crates/corro-api-types/Cargo.toml
+++ b/crates/corro-api-types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "corro-api-types"
 version = "0.1.0-alpha.1"
 description = "common API types for corrosion"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/corro-api-types/README.md
+++ b/crates/corro-api-types/README.md
@@ -1,0 +1,36 @@
+# corro-api-types
+
+Wire-format types shared between [Corrosion]'s HTTP API server and clients.
+
+This crate is intentionally lightweight: it only contains types that need to
+be (de)serialized across the API boundary, plus the `SqliteValue` /
+`SqliteParam` helpers used to round-trip SQLite values through JSON and the
+[Speedy] binary format. It is consumed by both
+[`corro-client`](../corro-client) (the public Rust client) and the agent
+itself.
+
+## Highlights
+
+- `TypedQueryEvent` / `QueryEvent` — frames returned by the `/v1/queries`
+  and `/v1/subscriptions` streaming endpoints.
+- `TypedNotifyEvent` / `NotifyEvent` — frames returned by the `/v1/updates`
+  streaming endpoint.
+- `ExecResponse` / `ExecResult` — responses from `/v1/transactions` and
+  `/v1/migrations`.
+- `SqliteValue` / `SqliteValueRef` / `SqliteParam` — typed wrappers around
+  SQLite values for reading rows and binding parameters.
+- `RowId`, `ChangeId`, `TableName`, `ColumnName` — strongly typed newtypes
+  used throughout the API.
+- `Statement` — the JSON-serialized form of a SQL statement plus its bound
+  parameters.
+
+Most types implement `Serialize`/`Deserialize` and (where appropriate)
+`speedy::Readable`/`speedy::Writable` so they can be sent over the cluster's
+binary protocol as well as the HTTP API.
+
+## License
+
+Licensed under the [Apache License, Version 2.0](../../LICENSE).
+
+[Corrosion]: https://github.com/superfly/corrosion
+[Speedy]: https://github.com/koute/speedy

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -19,7 +19,6 @@ use sqlite::ChangeType;
 
 pub mod sqlite;
 
-
 /// HTTP response header that carries the UUID of a subscription or update stream.
 /// Set by the server on every successful `/v1/queries`, `/v1/subscriptions`, and
 /// `/v1/updates` response so callers can re-attach to the same stream by ID.

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -19,20 +19,32 @@ use sqlite::ChangeType;
 
 pub mod sqlite;
 
+/// Untyped variant of [`TypedQueryEvent`], where each row is a `Vec` of
+/// [`SqliteValue`].
 pub type QueryEvent = TypedQueryEvent<Vec<SqliteValue>>;
 
+/// `TypedQueryEvent` represents the different events that a query
+/// or subscription can produce. It wraps `T` which is the type used to represent a row.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TypedQueryEvent<T> {
+    /// Names of the columns in the result set.
     Columns(Vec<ColumnName>),
+    /// A row in the initial result set, identified by its [`RowId`].
     Row(RowId, T),
+    /// Marker indicating that the initial query has finished. `time` is the
+    /// query duration in seconds; `change_id` is the latest change observed
+    /// at the time of the snapshot for subscriptions.
     #[serde(rename = "eoq")]
     EndOfQuery {
         time: f64,
         #[serde(skip_serializing_if = "Option::is_none")]
         change_id: Option<ChangeId>,
     },
+    /// A row was inserted, updated or deleted in the subscription, with a
+    /// monotonically increasing [`ChangeId`].
     Change(ChangeType, RowId, T, ChangeId),
+    /// A non-recoverable error occurred while producing the stream.
     Error(CompactString),
 }
 
@@ -48,6 +60,8 @@ impl<T> TypedQueryEvent<T> {
     }
 }
 
+/// Lightweight enum describing a [`TypedQueryEvent`] without the row
+/// payload.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum QueryEventMeta {
     Columns,
@@ -58,8 +72,11 @@ pub enum QueryEventMeta {
     Notify,
 }
 
+/// Untyped variant of [`TypedNotifyEvent`], where each payload is a `Vec` of
+/// [`SqliteValue`].
 pub type NotifyEvent = TypedNotifyEvent<Vec<SqliteValue>>;
 
+/// `TypedNotifyEvent` represents the different events that an update stream can produce.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TypedNotifyEvent<T> {
@@ -185,6 +202,7 @@ impl std::ops::Add<Self> for ChangeId {
     }
 }
 
+/// A SQL statement, optionally with bound parameters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Statement {
@@ -215,6 +233,8 @@ impl From<&str> for Statement {
     }
 }
 
+/// Response returned by the `/v1/transactions` and `/v1/migrations` endpoints.
+///
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExecResponse {
     pub results: Vec<ExecResult>,
@@ -223,12 +243,22 @@ pub struct ExecResponse {
     pub actor_id: Option<String>,
 }
 
+/// Result of executing a single statement.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExecResult {
-    Execute { rows_affected: usize, time: f64 },
+    /// The statement executed successfully.
+    Execute {
+        /// Number of rows affected by the statement.
+        rows_affected: usize,
+        /// Per-statement processing time in seconds.
+        time: f64,
+    },
+    /// The statement failed; the server returned an error message.
     Error { error: String },
 }
+
+/// Request body for the `/v1/table-stats` endpoint.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TableStatRequest {
     pub tables: Vec<String>,
@@ -241,6 +271,10 @@ pub struct TableStatResponse {
     pub invalid_tables: Vec<String>,
 }
 
+/// `HealthQuery` represents the query string for the `/v1/health` endpoint.
+///
+/// Each field acts as a threshold: if the corresponding metric exceeds the
+/// supplied value, the agent responds with `failure_status` or `503` by default.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HealthQuery {
     pub gaps: Option<i64>,
@@ -319,6 +353,9 @@ impl<'a> Hash for SqliteValueRef<'a> {
     }
 }
 
+/// SQLite storage class for a column or value.
+///
+/// Mirrors the five storage classes defined by SQLite
 #[derive(PartialEq, Debug)]
 pub enum ColumnType {
     Integer = 1,
@@ -368,6 +405,7 @@ impl FromSql for ColumnType {
     }
 }
 
+/// A parameter value that can be bound to a `Statement`
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -770,6 +808,7 @@ where
     }
 }
 
+/// Sqlite table name, stored as a [`CompactString`].
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct TableName(pub CompactString);
@@ -793,6 +832,7 @@ impl From<&str> for TableName {
     }
 }
 
+/// An SQL column name, stored as a [`CompactString`].
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct ColumnName(pub CompactString);

--- a/crates/corro-api-types/src/lib.rs
+++ b/crates/corro-api-types/src/lib.rs
@@ -60,8 +60,7 @@ impl<T> TypedQueryEvent<T> {
     }
 }
 
-/// Lightweight enum describing a [`TypedQueryEvent`] without the row
-/// payload.
+/// Lightweight enum describing a [`TypedQueryEvent`]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum QueryEventMeta {
     Columns,

--- a/crates/corro-client/Cargo.toml
+++ b/crates/corro-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "corro-client"
 version = "0.1.0-alpha.1"
 description = "client to interact with corrosion"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/corro-client/README.md
+++ b/crates/corro-client/README.md
@@ -1,0 +1,56 @@
+# corro-client
+
+Async Rust client for the [Corrosion] HTTP API.
+
+This crate is the recommended way to talk to a running Corrosion agent from
+Rust. It speaks the JSON over HTTP/2 protocol exposed at `/v1/queries`,
+`/v1/subscriptions`, `/v1/updates`, `/v1/transactions` and `/v1/migrations`,
+and re-exports the wire-level types from
+[`corro-api-types`](../corro-api-types).
+
+## Clients
+
+Three client types are provided:
+
+- **`CorrosionApiClient`** — the lowest-level handle, wrapping a single
+  `reqwest::Client` pointed at one `SocketAddr`.
+- **`CorrosionClient`** — adds a local `sqlite_pool::RusqlitePool` for
+  reading directly from the on-disk SQLite database without going through
+  the HTTP API. Dereferences to `CorrosionApiClient`.
+- **`CorrosionPooledClient`** — accepts a list of agent addresses, resolves
+  them through DNS and retries failed requests against the next available
+  peer with configurable stickiness.
+
+All read endpoints return [`futures::Stream`]s (`QueryStream`,
+`SubscriptionStream`, `UpdatesStream`) that yield
+`corro_api_types::TypedQueryEvent` / `corro_api_types::TypedNotifyEvent`
+frames. Subscriptions automatically reconnect with the last seen `ChangeId`
+when the underlying HTTP connection drops, so most callers can simply
+iterate the stream and ignore transient network failures.
+
+## Example
+
+```rust
+use corro_client::CorrosionApiClient;
+use corro_api_types::Statement;
+use futures::StreamExt;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let client = CorrosionApiClient::new("127.0.0.1:8081".parse()?)?;
+
+let mut rows = client
+    .query(&Statement::Simple("SELECT id, name FROM users".into()), None)
+    .await?;
+
+while let Some(event) = rows.next().await {
+    println!("{:?}", event?);
+}
+# Ok(()) }
+```
+
+## License
+
+Licensed under the [Apache License, Version 2.0](../../LICENSE).
+
+[Corrosion]: https://github.com/superfly/corrosion
+[`futures::Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -25,6 +25,8 @@ const DNS_RESOLVE_TIMEOUT: Duration = Duration::from_secs(3);
 
 type Resolver = hickory_resolver::Resolver<hickory_resolver::net::runtime::TokioRuntimeProvider>;
 
+/// Single-address Corrosion HTTP API client.
+///
 #[derive(Clone)]
 pub struct CorrosionApiClient {
     api_addr: SocketAddr,
@@ -44,6 +46,15 @@ impl CorrosionApiClient {
         })
     }
 
+    /// Run a one-shot query, deserializing each row into `T`. Accepts a
+    /// statement and a timeout.
+    ///
+    /// Wraps `POST /v1/queries` endpoint.
+    ///
+    /// Returns [`sub::QueryStream`] yields a
+    /// [`corro_api_types::TypedQueryEvent::Columns`] frame, then one
+    /// [`corro_api_types::TypedQueryEvent::Row`] per row, then a final
+    /// [`corro_api_types::TypedQueryEvent::EndOfQuery`].
     pub async fn query_typed<T: DeserializeOwned + Unpin>(
         &self,
         statement: &Statement,
@@ -93,6 +104,8 @@ impl CorrosionApiClient {
         Ok(QueryStream::new(res.into()))
     }
 
+    /// Same as [`Self::query_typed`], but returns each row as a
+    /// `Vec<SqliteValue>`.
     pub async fn query(
         &self,
         statement: &Statement,
@@ -101,6 +114,16 @@ impl CorrosionApiClient {
         self.query_typed(statement, timeout).await
     }
 
+    /// Creates a new subscription and streams query updates, deserializing rows into T.
+    ///
+    /// Wraps `POST /v1/subscriptions` endpoint. After the initial result set the agent
+    /// will push a [`corro_api_types::TypedQueryEvent::Change`] frame for
+    /// every row that enters, leaves or is updated within the query.
+    ///
+    /// * `skip_rows` — when `true`, the initial rows are skipped and
+    ///   only changes are streamed.
+    /// * `from` — when set, resume the subscription past the given
+    ///   `ChangeId` instead of producing a fresh snapshot.
     pub async fn subscribe_typed<T: DeserializeOwned + Unpin>(
         &self,
         statement: &Statement,
@@ -150,6 +173,8 @@ impl CorrosionApiClient {
         ))
     }
 
+    /// Same as [`Self::subscribe_typed`], but returns each row as a
+    /// `Vec<SqliteValue>`.
     pub async fn subscribe(
         &self,
         statement: &Statement,
@@ -159,6 +184,7 @@ impl CorrosionApiClient {
         self.subscribe_typed(statement, skip_rows, from).await
     }
 
+    /// Reconnect to an existing subscription identified by its `Uuid`.
     pub async fn subscription_typed<T: DeserializeOwned + Unpin>(
         &self,
         id: Uuid,
@@ -200,6 +226,8 @@ impl CorrosionApiClient {
         ))
     }
 
+    /// Same as [`Self::subscription_typed`], but returns each row as a
+    /// `Vec<SqliteValue>`.
     pub async fn subscription(
         &self,
         id: Uuid,
@@ -209,6 +237,9 @@ impl CorrosionApiClient {
         self.subscription_typed(id, skip_rows, from).await
     }
 
+    /// Subscribe to row-level changes on a single table.
+    ///
+    /// Wraps `POST /v1/updates/{table}` endpoint.
     pub async fn updates_typed<T: DeserializeOwned + Unpin>(
         &self,
         table: &str,
@@ -235,15 +266,18 @@ impl CorrosionApiClient {
         Ok(UpdatesStream::new(id, res.into()))
     }
 
+    /// Same as [`Self::updates_typed`], but returns each row as a
+    /// `Vec<SqliteValue>`.
     pub async fn updates(&self, table: &str) -> Result<UpdatesStream<Vec<SqliteValue>>, Error> {
         self.updates_typed(table).await
     }
 
-    pub async fn execute(
-        &self,
-        statements: &[Statement],
-        timeout: Option<u64>,
-    ) -> Result<ExecResponse, Error> {
+    /// Execute a transaction containing one or more SQL statements.
+    ///
+    /// Wraps `POST /v1/transactions` endpoint. The slice is sent as a JSON array; the
+    /// agent applies the statements in a single transaction and
+    /// returns one `ExecResult` per statement in order.
+    pub async fn execute(&self, statements: &[Statement], timeout: Option<u64>) -> Result<ExecResponse, Error> {
         let uri = if let Some(timeout) = timeout {
             format!("http://{}/v1/transactions?timeout={timeout}", self.api_addr)
         } else {
@@ -293,6 +327,9 @@ impl CorrosionApiClient {
         Ok(serde_json::from_slice(&res.bytes().await?)?)
     }
 
+    /// Update the schema on the Corrosion node.
+    ///
+    /// Wraps `POST /v1/migrations` endpoint
     pub async fn schema(&self, statements: &[Statement]) -> Result<ExecResponse, Error> {
         let res = self
             .api_client
@@ -310,6 +347,12 @@ impl CorrosionApiClient {
         Ok(serde_json::from_slice(&res.bytes().await?)?)
     }
 
+    /// Read schema files from disk and submit them via [`Self::schema`].
+    ///
+    /// Each path can be a single `.sql` file or a directory of files; the
+    /// helper [`corro_utils::read_files_from_paths`] handles enumeration and
+    /// ordering. Returns `Ok(None)` when the supplied paths produce no
+    /// statements.
     pub async fn schema_from_paths<P: AsRef<Path>>(
         &self,
         schema_paths: &[P],
@@ -329,6 +372,8 @@ impl CorrosionApiClient {
     }
 }
 
+/// Convenience client that combines a [`CorrosionApiClient`] with a local
+/// SQLite connection pool.
 #[derive(Clone)]
 pub struct CorrosionClient {
     api_client: CorrosionApiClient,
@@ -356,6 +401,7 @@ impl CorrosionClient {
         })
     }
 
+    /// Borrow the SQLite connection pool used for direct reads.
     pub fn pool(&self) -> &sqlite_pool::RusqlitePool {
         &self.pool
     }
@@ -369,6 +415,12 @@ impl Deref for CorrosionClient {
     }
 }
 
+/// Client to connect to a pool of Corrosion nodes.
+///
+/// Selects the first address from the list and tries to connect to it.
+/// On I/O errors the client falls back to the next address; once a request succeeds the client
+/// "sticks" to that peer until it has been failing continuously for the
+/// configured `stickiness_timeout`.
 #[derive(Clone)]
 pub struct CorrosionPooledClient {
     inner: Arc<RwLock<PooledClientInner>>,
@@ -390,6 +442,17 @@ struct PooledClientInner {
 }
 
 impl CorrosionPooledClient {
+    /// Build a new pooled client.
+    ///
+    /// * `addrs` — ordered list of agent addresses. Each entry can be either
+    ///   a `host:port` string (resolved through `resolver`) or an already
+    ///   resolved `SocketAddr` formatted as a string. Entries are tried in
+    ///   the supplied order; once a peer has been successful the client
+    ///   prefers it for as long as it stays healthy.
+    /// * `stickiness_timeout` — how long the client keeps retrying a
+    ///   previously successful peer after it starts failing before rotating
+    ///   to the next address.
+    /// * `resolver` — DNS resolver used to translate hostnames to addresses.
     pub fn new(addrs: Vec<String>, stickiness_timeout: time::Duration, resolver: Resolver) -> Self {
         Self {
             inner: Arc::new(RwLock::new(PooledClientInner {
@@ -404,6 +467,9 @@ impl CorrosionPooledClient {
         }
     }
 
+    /// Run a one-shot query against the currently selected peer.
+    ///
+    /// Equivalent to [`CorrosionApiClient::query_typed`]
     pub async fn query_typed<T: DeserializeOwned + Unpin>(
         &self,
         statement: &Statement,
@@ -427,6 +493,8 @@ impl CorrosionPooledClient {
         response
     }
 
+    /// Open a new subscription against the currently selected peer.
+    ///
     pub async fn subscribe_typed<T: DeserializeOwned + Unpin>(
         &self,
         statement: &Statement,
@@ -451,6 +519,8 @@ impl CorrosionPooledClient {
         response
     }
 
+    /// Reconnect to an existing subscription by id against the currently
+    /// selected peer. See [`CorrosionApiClient::subscription_typed`].
     pub async fn subscription_typed<T: DeserializeOwned + Unpin>(
         &self,
         id: Uuid,
@@ -630,6 +700,7 @@ impl AddrPicker {
     }
 }
 
+/// Errors returned by [`CorrosionApiClient`] and [`CorrosionPooledClient`].
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -46,7 +46,7 @@ impl CorrosionApiClient {
         })
     }
 
-    /// Executes a single query against a Corrosion node, deserializing each row into `T`. 
+    /// Execute a single query against a Corrosion node, deserializing each row into `T`. 
     /// Optionally accepts a timeout for the request.
     ///
     /// Calls the `/v1/queries` endpoint (<https://superfly.github.io/corrosion/api/queries.html>).
@@ -109,7 +109,7 @@ impl CorrosionApiClient {
         self.query_typed(statement, timeout).await
     }
 
-    /// Creates a new subscription and streams query updates, deserializing rows into T.
+    /// Create a new subscription and stream query updates, deserializing rows into T.
     /// * `skip_rows` — when `true`, the initial rows are skipped and only changes are streamed.
     /// * `from` — when set, resume the subscription past the given `ChangeId` instead of producing a fresh snapshot.
     ///

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -46,15 +46,10 @@ impl CorrosionApiClient {
         })
     }
 
-    /// Run a one-shot query, deserializing each row into `T`. Accepts a
-    /// statement and a timeout.
+    /// Executes a single query against a Corrosion node, deserializing each row into `T`. 
+    /// Optionally accepts a timeout for the request.
     ///
-    /// Wraps `POST /v1/queries` endpoint.
-    ///
-    /// Returns [`sub::QueryStream`] yields a
-    /// [`corro_api_types::TypedQueryEvent::Columns`] frame, then one
-    /// [`corro_api_types::TypedQueryEvent::Row`] per row, then a final
-    /// [`corro_api_types::TypedQueryEvent::EndOfQuery`].
+    /// Calls the `/v1/queries` endpoint (<https://superfly.github.io/corrosion/api/queries.html>).
     pub async fn query_typed<T: DeserializeOwned + Unpin>(
         &self,
         statement: &Statement,
@@ -115,15 +110,10 @@ impl CorrosionApiClient {
     }
 
     /// Creates a new subscription and streams query updates, deserializing rows into T.
+    /// * `skip_rows` — when `true`, the initial rows are skipped and only changes are streamed.
+    /// * `from` — when set, resume the subscription past the given `ChangeId` instead of producing a fresh snapshot.
     ///
-    /// Wraps `POST /v1/subscriptions` endpoint. After the initial result set the agent
-    /// will push a [`corro_api_types::TypedQueryEvent::Change`] frame for
-    /// every row that enters, leaves or is updated within the query.
-    ///
-    /// * `skip_rows` — when `true`, the initial rows are skipped and
-    ///   only changes are streamed.
-    /// * `from` — when set, resume the subscription past the given
-    ///   `ChangeId` instead of producing a fresh snapshot.
+    /// Calls the `/v1/subscriptions` endpoint (<https://superfly.github.io/corrosion/api/subscriptions.html>).
     pub async fn subscribe_typed<T: DeserializeOwned + Unpin>(
         &self,
         statement: &Statement,
@@ -239,7 +229,7 @@ impl CorrosionApiClient {
 
     /// Subscribe to row-level changes on a single table.
     ///
-    /// Wraps `POST /v1/updates/{table}` endpoint.
+    /// Calls the `/v1/updates/{table}` endpoint (<https://superfly.github.io/corrosion/api/updates.html>).
     pub async fn updates_typed<T: DeserializeOwned + Unpin>(
         &self,
         table: &str,
@@ -272,12 +262,14 @@ impl CorrosionApiClient {
         self.updates_typed(table).await
     }
 
-    /// Execute a transaction containing one or more SQL statements.
+    /// Execute one or more SQL statements in a single transaction.
     ///
-    /// Wraps `POST /v1/transactions` endpoint. The slice is sent as a JSON array; the
-    /// agent applies the statements in a single transaction and
-    /// returns one `ExecResult` per statement in order.
-    pub async fn execute(&self, statements: &[Statement], timeout: Option<u64>) -> Result<ExecResponse, Error> {
+    /// Calls the `/v1/transactions` endpoint (<https://superfly.github.io/corrosion/api/transactions.html>).
+    pub async fn execute(
+        &self,
+        statements: &[Statement],
+        timeout: Option<u64>,
+    ) -> Result<ExecResponse, Error> {
         let uri = if let Some(timeout) = timeout {
             format!("http://{}/v1/transactions?timeout={timeout}", self.api_addr)
         } else {
@@ -349,10 +341,7 @@ impl CorrosionApiClient {
 
     /// Read schema files from disk and submit them via [`Self::schema`].
     ///
-    /// Each path can be a single `.sql` file or a directory of files; the
-    /// helper [`corro_utils::read_files_from_paths`] handles enumeration and
-    /// ordering. Returns `Ok(None)` when the supplied paths produce no
-    /// statements.
+    /// Each path can be a single `.sql` file or a directory of files;
     pub async fn schema_from_paths<P: AsRef<Path>>(
         &self,
         schema_paths: &[P],

--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -46,7 +46,7 @@ impl CorrosionApiClient {
         })
     }
 
-    /// Execute a single query against a Corrosion node, deserializing each row into `T`. 
+    /// Execute a single query against a Corrosion node, deserializing each row into `T`.
     /// Optionally accepts a timeout for the request.
     ///
     /// Calls the `/v1/queries` endpoint (<https://superfly.github.io/corrosion/api/queries.html>).

--- a/crates/corro-client/src/sub.rs
+++ b/crates/corro-client/src/sub.rs
@@ -2,7 +2,7 @@
 //!
 //! Each long-running endpoint exposes a dedicated [`Stream`] implementation:
 //!
-//! * [`QueryStream`] — non-resumable one-shot query results
+//! * [`QueryStream`] — one-shot query results
 //!   (`POST /v1/queries`).
 //! * [`SubscriptionStream`] — resumable live subscription
 //!   (`POST /v1/subscriptions`); transparently reconnects with the last
@@ -358,7 +358,7 @@ where
 /// Stream returned by [`crate::CorrosionApiClient::updates_typed`].
 ///
 /// Yields a [`TypedNotifyEvent`] for every row inserted, updated or deleted
-/// in the watched table after the subscription was registered.
+/// in the watched table after the update was registered.
 pub struct UpdatesStream<T> {
     id: Uuid,
     stream: FramedBody,
@@ -425,11 +425,9 @@ where
     }
 }
 
-/// Stream returned by [`crate::CorrosionApiClient::query_typed`].
+/// Stream returned by [`crate::CorrosionApiClient::query_typed`] for a single query.
 ///
-/// Yields a [`TypedQueryEvent`] for the column header, each row of the
-/// result set, and a final [`TypedQueryEvent::EndOfQuery`]. The stream
-/// terminates after the EOQ frame; queries are not resumable.
+/// Yields a [`TypedQueryEvent`] with columns, each row of the result set, and a final [`TypedQueryEvent::EndOfQuery`].
 pub struct QueryStream<T> {
     stream: FramedBody,
     _deser: std::marker::PhantomData<T>,
@@ -517,7 +515,6 @@ impl Default for LinesBytesCodec {
     /// of a buffered line. See the documentation for [`new_with_max_length`]
     /// for information on why this could be a potential security risk.
     ///
-    /// [`new_with_max_length`]: crate::codec::LinesBytesCodec::default_with_max_length()
     fn default() -> Self {
         LinesBytesCodec {
             next_index: 0,

--- a/crates/corro-client/src/sub.rs
+++ b/crates/corro-client/src/sub.rs
@@ -1,3 +1,18 @@
+//! Streaming response types for the Corrosion HTTP API.
+//!
+//! Each long-running endpoint exposes a dedicated [`Stream`] implementation:
+//!
+//! * [`QueryStream`] — non-resumable one-shot query results
+//!   (`POST /v1/queries`).
+//! * [`SubscriptionStream`] — resumable live subscription
+//!   (`POST /v1/subscriptions`); transparently reconnects with the last
+//!   observed [`ChangeId`] on transient I/O errors.
+//! * [`UpdatesStream`] — table-level update feed (`POST /v1/updates/{table}`).
+//!
+//! All three decode JSON-lines responses through the [`LinesBytesCodec`]
+//! defined here, which is a port of `tokio-util`'s `LinesCodec` adapted to
+//! emit [`bytes::BytesMut`] frames.
+
 use std::{
     error::Error,
     io,
@@ -21,6 +36,9 @@ use tracing::error;
 use uuid::Uuid;
 
 pin_project! {
+    /// Adapter that exposes a [`reqwest::Body`] as a [`Stream`] of
+    /// [`io::Result<Bytes>`], mapping framing errors into [`io::Error`] so
+    /// the underlying [`StreamReader`] can consume them.
     pub struct IoBodyStream {
         #[pin]
         body: reqwest::Body
@@ -59,6 +77,16 @@ type FramedBody = FramedRead<IoBodyStreamReader, LinesBytesCodec>;
 type ResponseFuture =
     Box<dyn Future<Output = Result<reqwest::Response, reqwest::Error>> + Unpin + Send + Sync>;
 
+/// Live subscription stream returned by
+/// [`crate::CorrosionApiClient::subscribe_typed`].
+///
+/// Yields [`TypedQueryEvent<T>`] frames produced by the agent. Once the
+/// initial result set is fully consumed (after the first
+/// [`TypedQueryEvent::EndOfQuery`]) the stream automatically reconnects
+/// when the underlying HTTP body terminates, using the last observed
+/// [`ChangeId`] to resume without gaps. Reconnects use a fixed-size
+/// linear backoff and give up after 10 consecutive failures with
+/// [`SubscriptionError::MaxRetryAttempts`].
 pub struct SubscriptionStream<T> {
     id: Uuid,
     hash: Option<String>,
@@ -73,20 +101,30 @@ pub struct SubscriptionStream<T> {
     _deser: std::marker::PhantomData<T>,
 }
 
+/// Errors yielded by [`SubscriptionStream`].
 #[derive(Debug, thiserror::Error)]
 pub enum SubscriptionError {
+    /// Underlying I/O error on the HTTP body.
     #[error(transparent)]
     Io(#[from] io::Error),
+    /// Generic HTTP error encountered while reconnecting.
     #[error(transparent)]
     Http(#[from] http::Error),
+    /// A frame could not be decoded as a [`TypedQueryEvent`].
     #[error(transparent)]
     Deserialize(#[from] serde_json::Error),
+    /// The agent skipped a [`ChangeId`], indicating the local view is no
+    /// longer consistent with the server.
     #[error("missed a change (expected: {expected}, got: {got}), inconsistent state")]
     MissedChange { expected: ChangeId, got: ChangeId },
+    /// A single JSON line exceeded the codec's maximum length.
     #[error("max line length exceeded")]
     MaxLineLengthExceeded,
+    /// The connection terminated before the initial query produced an
+    /// [`TypedQueryEvent::EndOfQuery`].
     #[error("initial query never finished")]
     UnfinishedQuery,
+    /// Error when maximum number of consecutive reconnect is exceeded.
     #[error("max retry attempts exceeded")]
     MaxRetryAttempts,
 }
@@ -121,14 +159,22 @@ where
         }
     }
 
+    /// Server-assigned subscription identifier.
+    ///
+    /// Persist this id (along with the [`ChangeId`] from
+    /// [`TypedQueryEvent::Change`]) to resume the subscription later via
+    /// [`crate::CorrosionApiClient::subscription_typed`].
     pub fn id(&self) -> Uuid {
         self.id
     }
 
+    /// Hash advertised by the server for this subscription's query.
+    ///
     pub fn hash(&self) -> Option<&str> {
         self.hash.as_deref()
     }
 
+    /// API address the subscription was opened against.
     pub fn api_addr(&self) -> SocketAddr {
         self.api_addr
     }
@@ -309,18 +355,26 @@ where
     }
 }
 
+/// Stream returned by [`crate::CorrosionApiClient::updates_typed`].
+///
+/// Yields a [`TypedNotifyEvent`] for every row inserted, updated or deleted
+/// in the watched table after the subscription was registered.
 pub struct UpdatesStream<T> {
     id: Uuid,
     stream: FramedBody,
     _deser: std::marker::PhantomData<T>,
 }
 
+/// Errors yielded by [`UpdatesStream`].
 #[derive(Debug, thiserror::Error)]
 pub enum UpdatesError {
+    /// Underlying I/O error on the HTTP body.
     #[error(transparent)]
     Io(#[from] io::Error),
+    /// A frame could not be decoded as a [`TypedNotifyEvent`].
     #[error(transparent)]
     Deserialize(#[from] serde_json::Error),
+    /// A single JSON line exceeded the codec's maximum length.
     #[error("max line length exceeded")]
     MaxLineLengthExceeded,
 }
@@ -329,6 +383,7 @@ impl<T> UpdatesStream<T>
 where
     T: DeserializeOwned + Unpin,
 {
+    /// Build an `UpdatesStream` from a freshly opened HTTP response.
     pub fn new(id: Uuid, body: reqwest::Body) -> Self {
         Self {
             id,
@@ -340,6 +395,7 @@ where
         }
     }
 
+    /// Server-assigned subscription identifier for this stream.
     pub fn id(&self) -> Uuid {
         self.id
     }
@@ -369,17 +425,26 @@ where
     }
 }
 
+/// Stream returned by [`crate::CorrosionApiClient::query_typed`].
+///
+/// Yields a [`TypedQueryEvent`] for the column header, each row of the
+/// result set, and a final [`TypedQueryEvent::EndOfQuery`]. The stream
+/// terminates after the EOQ frame; queries are not resumable.
 pub struct QueryStream<T> {
     stream: FramedBody,
     _deser: std::marker::PhantomData<T>,
 }
 
+/// Errors yielded by [`QueryStream`].
 #[derive(Debug, thiserror::Error)]
 pub enum QueryError {
+    /// Underlying I/O error on the HTTP body.
     #[error(transparent)]
     Io(#[from] io::Error),
+    /// A frame could not be decoded as a [`TypedQueryEvent`].
     #[error(transparent)]
     Deserialize(#[from] serde_json::Error),
+    /// A single JSON line exceeded the codec's maximum length.
     #[error("max line length exceeded")]
     MaxLineLengthExceeded,
 }
@@ -388,6 +453,7 @@ impl<T> QueryStream<T>
 where
     T: DeserializeOwned + Unpin,
 {
+    /// Build a `QueryStream` from a freshly opened HTTP response.
     pub fn new(body: reqwest::Body) -> Self {
         Self {
             stream: FramedRead::new(
@@ -422,6 +488,8 @@ where
     }
 }
 
+/// `LinesBytesCodec` used to to split up bytes into lines.
+/// It uses the `\n` character as the line delimiter.
 pub struct LinesBytesCodec {
     // Stored index of the next index to examine for a `\n` character.
     // This is used to optimize searching.

--- a/crates/corro-types/src/metrics_tracker.rs
+++ b/crates/corro-types/src/metrics_tracker.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_BUCKETS: &[f64] = &[
 ];
 
 /// A simple bucket histogram modeled after Prometheus's classic histogram.
-/// See: https://github.com/prometheus/prometheus/blob/main/promql/quantile.go
+/// See: <https://github.com/prometheus/prometheus/blob/7200c43796813095ac3b3afa10202b05ea49d80b/promql/quantile.go>
 pub struct BucketHistogram {
     /// Sorted upper bounds, not including +Inf.
     upper_bounds: Vec<f64>,


### PR DESCRIPTION
This pull request updates the documentation for public crates: `corro-api-types` , `corro-client` and `consul-client`.