### PR TITLE
return error when reload command fails

### DIFF
--- a/crates/corrosion/src/command/reload.rs
+++ b/crates/corrosion/src/command/reload.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use crate::admin::AdminConn;
 use corro_admin::Command;
-use tracing::info;
+use eyre::eyre;
+use tracing::{error, info};
 
 pub async fn run<P: AsRef<Path>>(admin_path: P) -> eyre::Result<()> {
     let mut conn = AdminConn::connect(admin_path).await?;

--- a/crates/corrosion/src/command/reload.rs
+++ b/crates/corrosion/src/command/reload.rs
@@ -6,7 +6,10 @@ use tracing::info;
 
 pub async fn run<P: AsRef<Path>>(admin_path: P) -> eyre::Result<()> {
     let mut conn = AdminConn::connect(admin_path).await?;
-    conn.send_command(Command::Reload).await?;
+    if let Err(e) = conn.send_command(Command::Reload).await {
+        error!("Failed to reload schema: {e}");
+        return Err(eyre!("Failed to reload schema: {e}"));
+    }
     info!("Successfully reloaded Corrosion's schema from configured paths!");
     Ok(())
 }


### PR DESCRIPTION
`corrosion reload` command can fail silently because we don't propagate error to user