### PR TITLE
cli: fix authz for corrosion query/exec commands to pass the API token if configured

### DIFF
--- a/crates/corro-client/src/lib.rs
+++ b/crates/corro-client/src/lib.rs
@@ -48,6 +48,33 @@ impl CorrosionApiClient {
         })
     }
 
+    /// Build a client that sets `Authorization: Bearer <auth_token>` on every request when
+    /// `auth_token` is set. Passing `None` is equivalent to [`Self::new`].
+    pub fn with_auth_token(
+        api_addr: SocketAddr,
+        auth_token: Option<String>,
+    ) -> Result<Self, Error> {
+        let mut builder = reqwest::ClientBuilder::new()
+            .http2_prior_knowledge()
+            .connect_timeout(HTTP2_CONNECT_TIMEOUT)
+            .http2_keep_alive_interval(Some(HTTP2_KEEP_ALIVE_INTERVAL))
+            .http2_keep_alive_timeout(HTTP2_KEEP_ALIVE_INTERVAL / 2);
+
+        if let Some(token) = auth_token {
+            let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|_| Error::InvalidAuthToken)?;
+            value.set_sensitive(true);
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(reqwest::header::AUTHORIZATION, value);
+            builder = builder.default_headers(headers);
+        }
+
+        Ok(Self {
+            api_addr,
+            api_client: builder.build()?,
+        })
+    }
+
     /// Execute a single query against a Corrosion node, deserializing each row into `T`.
     /// Optionally accepts a timeout for the request.
     ///
@@ -673,6 +700,9 @@ pub enum Error {
 
     #[error("could not retrieve subscription id from headers")]
     ExpectedQueryId,
+
+    #[error("auth token contains characters that are not valid in an HTTP header value")]
+    InvalidAuthToken,
 }
 
 #[cfg(test)]

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -19,7 +19,7 @@ use corro_types::{
     actor::{ActorId, ClusterId},
     api::{ExecResult, QueryEvent, Statement},
     base::CrsqlDbVersion,
-    config::{default_admin_path, Config, ConfigError, LogFormat, OtelConfig},
+    config::{default_admin_path, AuthzConfig, Config, ConfigError, LogFormat, OtelConfig},
     sqlite::CrConn,
 };
 use futures::StreamExt;
@@ -636,7 +636,15 @@ impl Cli {
     fn api_client(&self) -> Result<CorrosionApiClient, ConfigError> {
         API_CLIENT
             .get_or_try_init(|| {
-                CorrosionApiClient::new(self.api_addr()?)
+                // Best-effort read of the bearer token from config. If `--api-addr`
+                // is provided without a usable config file, fall through to an
+                // unauthenticated client rather than failing here.
+                let auth_token = self.config().ok().and_then(|c| {
+                    c.api.authorization.map(|authz| match authz {
+                        AuthzConfig::BearerToken(token) => token,
+                    })
+                });
+                CorrosionApiClient::with_auth_token(self.api_addr()?, auth_token)
                     .map_err(|err| config::ConfigError::Foreign(Box::new(err)).into())
             })
             .cloned()


### PR DESCRIPTION
Add support for authz in `CorrosionApiClient` so that `corrosion query/exec` CLI commands send the `Authorization` header to the Corrosion API when the API authz is enabled in the config (`api.authz.bearer-token`)

Fixes #487