### PR TITLE
Update uhlc, remove heavy features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,47 +1462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
-dependencies = [
- "defmt 1.0.1",
-]
-
-[[package]]
-name = "defmt"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
-dependencies = [
- "defmt-parser",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,28 +3791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4603,7 +4540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4936,9 +4873,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -5834,17 +5771,15 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uhlc"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b6df3f3e948b40e20c38a6d1fd6d8f91b3573922fc164e068ad3331560487e"
+checksum = "55bb25449f66ea76693b51f631fdd190821683c65e65e68d990b36c2d1ae9dd2"
 dependencies = [
- "defmt 0.3.100",
  "humantime",
  "lazy_static",
  "log",
  "rand 0.8.5",
- "serde",
- "spin 0.9.8",
+ "spin 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ tracing-opentelemetry = { version = "0.31.0", default-features = false, features
 tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 tracing-test = "0.2"
 thread_local = "1.1.9"
-uhlc = { version = "0.7", features = ["defmt"] }
+uhlc = { version = "0.9", default-features = false, features = ["std"] }
 uuid = { version = "1.3.1", features = ["v4", "serde"] }
 webpki = { version = "0.22.0", default-features = false, features = ["std"] }
 
@@ -123,4 +123,3 @@ codegen-units = 16
 opt-level = 2
 
 [workspace.lints.clippy]
-

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -303,6 +303,7 @@ impl Agent {
             .map_err(|e| format!("could not convert ActorId to uhlc ID: {e}"))?;
         self.clock()
             .update_with_timestamp(&uhlc::Timestamp::new(ts.0, id))
+            .map_err(|e| e.to_string())
     }
 }
 

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -440,8 +440,7 @@ pub enum TimestampParseError {
     Parse(ParseIntError),
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Eq, PartialOrd, Ord)]
-#[serde(transparent)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialOrd, Ord)]
 pub struct Timestamp(pub NTP64);
 
 impl Timestamp {
@@ -460,6 +459,24 @@ impl Timestamp {
 
     pub fn is_zero(&self) -> bool {
         self.0 .0 == 0
+    }
+}
+
+impl Serialize for Timestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.0 .0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self(NTP64(u64::deserialize(deserializer)?)))
     }
 }
 


### PR DESCRIPTION
The 0.7 version of uhlc was pulling in proc-macro-error2 which when compiled with rustc 1.97 issued a warning about containing code that will fail to compile in future versions, but then looking at defmt itself it made no sense to me why this feature was enabled in the first place as it's intended for `no_std` environments, removing the feature entirely removes several crates from the lockfile and doesn't cause any compilation or test failures. The only actual change introduced by the version bump is that `update_with_timestamp` returns a non-String error variant, but which implements Display.