### PR TITLE
Allow zstd compression with custom dictionary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "tripwire",
  "uhlc",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -1227,6 +1228,7 @@ dependencies = [
  "shell-words",
  "shellwords",
  "spawn",
+ "speedy",
  "sqlite3-restore",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/corro-agent/Cargo.toml
+++ b/crates/corro-agent/Cargo.toml
@@ -70,6 +70,7 @@ uuid = { workspace = true }
 corro-pg = { path = "../corro-pg" }
 indexmap = { workspace = true }
 governor.workspace = true
+zstd = { workspace = true }
 
 [dev-dependencies]
 corro-tests = { path = "../corro-tests" }

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -138,6 +138,7 @@ pub fn spawn_incoming_connection_handlers(
             &conn,
             agent.cluster_id(),
             agent.tx_changes().clone(),
+            agent.change_dict(),
         );
         bi::spawn_bipayload_handler(&agent, &bookie, &tripwire, &conn);
     });

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -5,7 +5,12 @@ use arc_swap::ArcSwap;
 use camino::Utf8PathBuf;
 use parking_lot::RwLock;
 use rusqlite::{Connection, OptionalExtension};
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    io::{self, Read, Seek, SeekFrom},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::{
     net::TcpListener,
     sync::{
@@ -15,8 +20,9 @@ use tokio::{
     time::Instant,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use tripwire::Tripwire;
+use zstd;
 
 // Internals
 use crate::{
@@ -35,6 +41,7 @@ use corro_types::{
     base::{CrsqlDbVersion, CrsqlDbVersionRange},
     broadcast::{BroadcastInput, BroadcastV1, ChangeSource, ChangeV1, FocaInput},
     channel::{bounded, CorroReceiver},
+    compress::ZstdDicts,
     config::Config,
     members::Members,
     metrics_tracker::MetricsTracker,
@@ -170,6 +177,50 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
 
     let metrics_tracker = MetricsTracker::new(Duration::from_secs(120), 5)?;
 
+    let compression_config = conf.gossip.compression_config();
+    let change_dict = match &compression_config.dict_path {
+        Some(path) => {
+            let bytes = std::fs::read(path)
+                .map_err(|e| eyre::eyre!("could not read compression dict at {path}: {e}"))?;
+
+            // also pick up any other trained dictionaries in the same directory
+            let mut extra_dicts = Vec::new();
+            if let Some(dir) = path.parent().filter(|dir| !dir.as_str().is_empty()) {
+                let entries = std::fs::read_dir(dir)
+                    .map_err(|e| eyre::eyre!("could not read compression dict dir {dir}: {e}"))?;
+                for entry in entries {
+                    let entry = entry?;
+                    if !entry.file_type()?.is_file() || entry.path() == path.as_std_path() {
+                        continue;
+                    }
+                    let entry_path = entry.path();
+
+                    let mut file = match std::fs::File::open(&entry_path) {
+                        Ok(file) => file,
+                        Err(e) => {
+                            warn!("could not open candidate compression dict {entry_path:?}: {e}");
+                            continue;
+                        }
+                    };
+
+                    match load_dictionary(&mut file) {
+                        Ok(Some(b)) => extra_dicts.push(b),
+                        _ => {
+                            warn!("could not read candidate compression dict {entry_path:?}");
+                        }
+                    }
+                }
+            }
+
+            Some(Arc::new(ZstdDicts::new(
+                &bytes,
+                compression_config.level,
+                extra_dicts,
+            )))
+        }
+        None => None,
+    };
+
     let opts = AgentOptions {
         gossip_server_endpoint,
         transport: transport.clone(),
@@ -202,6 +253,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
         tx_clear_buf,
         tx_changes,
         tx_foca,
+        change_dict,
         write_sema,
         schema: RwLock::new(schema),
         cluster_id,
@@ -274,4 +326,17 @@ async fn setup_spawn_subscriptions(
     }
 
     Ok(Arc::new(TokioRwLock::new(subs_bcast_cache)))
+}
+
+fn load_dictionary(file: &mut std::fs::File) -> io::Result<Option<Vec<u8>>> {
+    let mut prefix = [0u8; 4];
+    let peeked = file.read(&mut prefix)?;
+    let is_dict = peeked == 4 && u32::from_le_bytes(prefix) == zstd::zstd_safe::MAGIC_DICTIONARY;
+    if !is_dict {
+        return Ok(None);
+    }
+    file.seek(SeekFrom::Start(0))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(Some(bytes))
 }

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -182,6 +182,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
         Some(path) => {
             let bytes = std::fs::read(path)
                 .map_err(|e| eyre::eyre!("could not read compression dict at {path}: {e}"))?;
+            info!("using compression dictionary at {path} for encoding");
 
             // also pick up any other trained dictionaries in the same directory
             let mut extra_dicts = Vec::new();
@@ -204,7 +205,10 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
                     };
 
                     match load_dictionary(&mut file) {
-                        Ok(Some(b)) => extra_dicts.push(b),
+                        Ok(Some(b)) => {
+                            info!("loading compression dictionary at {entry_path:?} for decoding");
+                            extra_dicts.push(b);
+                        }
                         _ => {
                             warn!("could not read candidate compression dict {entry_path:?}");
                         }

--- a/crates/corro-agent/src/agent/uni.rs
+++ b/crates/corro-agent/src/agent/uni.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use corro_types::{
     actor::ClusterId,
     broadcast::{BroadcastV1, ChangeSource, ChangeV1, UniPayload, UniPayloadV1},
     channel::CorroSender,
+    compress::ZstdDicts,
 };
 use metrics::counter;
 use speedy::Readable;
@@ -17,6 +20,7 @@ pub fn spawn_unipayload_handler(
     conn: &quinn::Connection,
     cluster_id: ClusterId,
     tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
+    change_dict: Option<Arc<ZstdDicts>>,
 ) {
     tokio::spawn({
         let conn = conn.clone();
@@ -46,6 +50,7 @@ pub fn spawn_unipayload_handler(
 
                 tokio::spawn({
                     let tx_changes = tx_changes.clone();
+                    let change_dict = change_dict.clone();
                     async move {
                         let mut framed = FramedRead::new(
                             rx,
@@ -73,7 +78,8 @@ pub fn spawn_unipayload_handler(
                                                         continue;
                                                     }
                                                     let compressed = bcast.is_compressed();
-                                                    match bcast.into_change() {
+                                                    match bcast.into_change(change_dict.as_deref())
+                                                    {
                                                         Ok(change) => {
                                                             changes.push((
                                                                 change,

--- a/crates/corro-agent/src/api/peer/mod.rs
+++ b/crates/corro-agent/src/api/peer/mod.rs
@@ -1050,7 +1050,7 @@ pub async fn parallel_sync(
                                 trace_ctx,
                             },
                             cluster_id: agent.cluster_id(),
-                            supports_compression: agent.config().gossip.compression,
+                            supports_compression: agent.config().gossip.compression_config().enabled,
                         },
                         &mut tx,
                     ).instrument(info_span!("write_sync_start"))
@@ -1436,8 +1436,9 @@ pub async fn serve_sync(
     mut write: SendStream,
 ) -> Result<usize, SyncError> {
     // only compress if the peer can decode it AND we're locally configured to
-    let supports_compression = wants_compression && agent.config().gossip.compression;
-    let compression_level = agent.config().gossip.compression_level;
+    let compression_config = agent.config().gossip.compression_config();
+    let supports_compression = wants_compression && compression_config.enabled;
+    let compression_level = compression_config.level;
 
     let context =
         opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&trace_ctx));
@@ -1718,7 +1719,9 @@ mod tests {
     use corro_types::{
         api::{ColumnName, TableName},
         broadcast::ChangesetPerTable,
-        config::{Config, TlsClientConfig, TlsConfig, DEFAULT_GOSSIP_CLIENT_ADDR},
+        config::{
+            CompressionConfig, Config, TlsClientConfig, TlsConfig, DEFAULT_GOSSIP_CLIENT_ADDR,
+        },
         pubsub::pack_columns,
         tls::{generate_ca, generate_client_cert, generate_server_cert},
     };
@@ -2464,8 +2467,11 @@ mod tests {
             max_mtu: None,
             disable_gso: false,
             member_id: None,
-            compression: false,
-            compression_level: 3,
+            compression: Some(CompressionConfig {
+                enabled: false,
+                level: 3,
+                dict_path: None,
+            }),
         };
 
         let server = gossip_server_endpoint(&gossip_config).await?;

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -543,9 +543,14 @@ async fn handle_broadcasts(
                 trace!("adding broadcast: {bcast:?}, local? {is_local}");
 
                 // compress payload if needed
-                let bcast = if agent.config().gossip.compression && !bcast.is_compressed() {
-                    let level = agent.config().gossip.compression_level;
-                    match tokio::task::spawn_blocking(move || bcast.compress_for_wire(level)).await
+                let compression_config = agent.config().gossip.compression_config();
+                let bcast = if compression_config.enabled && !bcast.is_compressed() {
+                    let level = compression_config.level;
+                    let dict = agent.change_dict();
+                    match tokio::task::spawn_blocking(move || {
+                        bcast.compress_for_wire(level, dict.as_deref())
+                    })
+                    .await
                     {
                         Ok(bcast) => bcast,
                         Err(e) => {
@@ -1271,7 +1276,13 @@ mod tests {
             let conn = conn.await.unwrap();
 
             let (tx_changes, mut rx_changes) = bounded(100, "changes");
-            spawn_unipayload_handler(&tripwire, &conn, ta1.agent.cluster_id(), tx_changes);
+            spawn_unipayload_handler(
+                &tripwire,
+                &conn,
+                ta1.agent.cluster_id(),
+                tx_changes,
+                ta1.agent.change_dict(),
+            );
 
             // we should receive five items starting from the biggest version
             for i in (0..5).rev() {

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -35,6 +35,7 @@ use crate::{
     base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq},
     broadcast::{BroadcastInput, BroadcastV1, ChangeSource, ChangeV1, FocaInput, Timestamp},
     channel::{bounded, CorroSender},
+    compress::ZstdDicts,
     config::Config,
     metrics_tracker::MetricsTracker,
     pubsub::SubsManager,
@@ -72,6 +73,9 @@ pub struct AgentConfig {
     pub tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
     pub tx_foca: CorroSender<FocaInput>,
 
+    /// Trained zstd dictionary for broadcast compression, if configured.
+    pub change_dict: Option<Arc<ZstdDicts>>,
+
     pub write_sema: Arc<Semaphore>,
 
     pub schema: RwLock<Schema>,
@@ -106,6 +110,7 @@ pub struct AgentInner {
     tx_clear_buf: CorroSender<(ActorId, CrsqlDbVersionRange)>,
     tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
     tx_foca: CorroSender<FocaInput>,
+    change_dict: Option<Arc<ZstdDicts>>,
     write_sema: Arc<Semaphore>,
     schema: RwLock<Schema>,
     cluster_id: ArcSwap<ClusterId>,
@@ -140,6 +145,7 @@ impl Agent {
             tx_clear_buf: config.tx_clear_buf,
             tx_changes: config.tx_changes,
             tx_foca: config.tx_foca,
+            change_dict: config.change_dict,
             write_sema: config.write_sema,
             schema: config.schema,
             cluster_id: ArcSwap::from_pointee(config.cluster_id),
@@ -210,6 +216,10 @@ impl Agent {
 
     pub fn tx_foca(&self) -> &CorroSender<FocaInput> {
         &self.0.tx_foca
+    }
+
+    pub fn change_dict(&self) -> Option<Arc<ZstdDicts>> {
+        self.0.change_dict.clone()
     }
 
     pub fn write_sema(&self) -> &Arc<Semaphore> {

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -4,16 +4,19 @@ use std::{
     fmt, io,
     num::{NonZeroU32, ParseIntError},
     ops::Deref,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
+use crate::compress::{
+    decompress_change, try_compress_change_for_wire, CompressError, WireCompression, ZstdDicts,
+};
 use antithesis_sdk::assert_sometimes;
 use bytes::{Bytes, BytesMut};
 use corro_api_types::{ColumnName, SqliteValue, TableName};
 use corro_base_types::{CrsqlDbVersionRange, CrsqlSeqRange};
 use foca::{Identity, Member, Notification, Runtime, Timer};
 use indexmap::{map::Entry, IndexMap};
-use metrics::{counter, histogram};
+use metrics::counter;
 use rusqlite::{
     types::{FromSql, FromSqlError},
     ToSql,
@@ -96,68 +99,6 @@ pub enum AuthzV1 {
     Token(String),
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum CompressError {
-    #[error(transparent)]
-    Speedy(#[from] speedy::Error),
-    #[error(transparent)]
-    Io(#[from] io::Error),
-}
-
-pub fn compress_change(change: &ChangeV1, level: i32) -> Result<Vec<u8>, CompressError> {
-    let encoded = change.write_to_vec()?;
-    Ok(zstd::stream::encode_all(encoded.as_slice(), level)?)
-}
-
-pub fn decompress_change(data: &[u8]) -> Result<ChangeV1, CompressError> {
-    let start = Instant::now();
-    let decompressed = zstd::stream::decode_all(data)?;
-    histogram!("corro.decompression.time.seconds").record(start.elapsed());
-    if decompressed.len() > data.len() {
-        counter!("corro.decompression.bytes.extra")
-            .increment((decompressed.len() - data.len()) as u64);
-    }
-    Ok(ChangeV1::read_from_buffer(&decompressed)?)
-}
-
-/// Result of attempting to compress a change for the wire.
-pub enum WireCompression {
-    /// Payload shrank; send the compressed bytes.
-    Compressed(Vec<u8>),
-    /// Compression didn't help; send the original change.
-    Uncompressed,
-}
-
-/// Try to compress a `ChangeV1` for the wire. Records compression metrics under
-/// `traffic` (`"broadcast"` or `"sync"`).
-pub fn try_compress_change_for_wire(
-    change: &ChangeV1,
-    traffic: &'static str,
-    level: i32,
-) -> Result<WireCompression, CompressError> {
-    let raw_len = change.write_to_vec()?.len();
-
-    let start = Instant::now();
-    counter!("corro.compression.attempts.total", "traffic" => traffic).increment(1);
-    counter!("corro.compression.bytes.raw.total", "traffic" => traffic).increment(raw_len as u64);
-
-    match compress_change(change, level)? {
-        compressed if compressed.len() < raw_len => {
-            let saved_bytes = raw_len - compressed.len();
-
-            histogram!("corro.compression.time.seconds").record(start.elapsed());
-            counter!("corro.compression.used.total", "traffic" => traffic).increment(1);
-            counter!("corro.compression.bytes.saved", "traffic" => traffic)
-                .increment(saved_bytes as u64);
-            Ok(WireCompression::Compressed(compressed))
-        }
-        _ => {
-            counter!("corro.compression.useless", "traffic" => traffic).increment(raw_len as u64);
-            Ok(WireCompression::Uncompressed)
-        }
-    }
-}
-
 #[derive(Clone, Debug, Readable, Writable)]
 pub enum BroadcastV1 {
     Change(ChangeV1),
@@ -173,12 +114,12 @@ impl BroadcastV1 {
     /// Try to compress the inner `ChangeV1` for the wire. Falls back to the
     /// original, uncompressed variant if compression fails or doesn't
     /// actually shrink the payload.
-    pub fn compress_for_wire(self, level: i32) -> Self {
+    pub fn compress_for_wire(self, level: i32, dicts: Option<&ZstdDicts>) -> Self {
         let BroadcastV1::Change(change) = self else {
             return self;
         };
 
-        match try_compress_change_for_wire(&change, "broadcast", level) {
+        match try_compress_change_for_wire(&change, "broadcast", level, dicts) {
             Ok(WireCompression::Compressed(compressed)) => {
                 BroadcastV1::CompressedChange(compressed)
             }
@@ -194,17 +135,12 @@ impl BroadcastV1 {
     /// Decode the inner `ChangeV1`, borrowing `self` so the original wire
     /// form (compressed or not) can still be reused verbatim -- e.g. to
     /// rebroadcast it to other peers without re-deciding/re-compressing.
-    pub fn into_change(&self) -> Result<ChangeV1, BroadcastDecodeError> {
+    pub fn into_change(&self, dicts: Option<&ZstdDicts>) -> Result<ChangeV1, BroadcastDecodeError> {
         match self {
             BroadcastV1::Change(change) => Ok(change.clone()),
-            BroadcastV1::CompressedChange(data) => match decompress_change(data) {
-                Ok(change) => Ok(change),
-                Err(e) => {
-                    counter!("corro.decompression.errors.total", "traffic" => "broadcast")
-                        .increment(1);
-                    Err(e.into())
-                }
-            },
+            BroadcastV1::CompressedChange(data) => {
+                decompress_change(data, "broadcast", dicts).map_err(Into::into)
+            }
         }
     }
 }
@@ -902,7 +838,7 @@ mod tests {
     fn test_compress_change_compresses_and_roundtrips() {
         let change = change_with_rows(200);
         let raw_len = change.write_to_vec().unwrap().len();
-        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3);
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, None);
 
         let BroadcastV1::CompressedChange(compressed) = bcast else {
             panic!("expected a large, repetitive change to compress");
@@ -920,8 +856,84 @@ mod tests {
         );
 
         let decoded = BroadcastV1::CompressedChange(compressed)
-            .into_change()
+            .into_change(None)
             .unwrap();
         assert_eq!(decoded, change);
+    }
+
+    fn trained_dict_bytes() -> Vec<u8> {
+        let samples: Vec<Vec<u8>> = (1..200)
+            .map(|n| change_with_rows(n).write_to_vec().unwrap())
+            .collect();
+        zstd::dict::from_samples(&samples, 16 * 1024).unwrap()
+    }
+
+    #[test]
+    fn test_compress_change_with_dict_roundtrips() {
+        let change = change_with_rows(50);
+        let dicts = ZstdDicts::new(&trained_dict_bytes(), 3, vec![]);
+
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, Some(&dicts));
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected change to compress with a dict");
+        };
+
+        let decoded = BroadcastV1::CompressedChange(compressed)
+            .into_change(Some(&dicts))
+            .unwrap();
+        assert_eq!(decoded, change);
+    }
+
+    #[test]
+    fn test_decode_with_older_dict_via_directory_scan() {
+        // Simulate a rotation: encode with the "old" dict, but the decoder
+        // was configured with a "new" primary dict and only knows the old
+        // one via its extra (directory-scanned) dictionaries.
+        let old_dict_bytes = trained_dict_bytes();
+        let new_dict_bytes = {
+            let samples: Vec<Vec<u8>> = (200..400)
+                .map(|n| change_with_rows(n).write_to_vec().unwrap())
+                .collect();
+            zstd::dict::from_samples(&samples, 16 * 1024).unwrap()
+        };
+
+        let encoder_dicts = ZstdDicts::new(&old_dict_bytes, 3, vec![]);
+        let decoder_dicts = ZstdDicts::new(&new_dict_bytes, 3, vec![old_dict_bytes]);
+
+        let change = change_with_rows(50);
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, Some(&encoder_dicts));
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected change to compress with a dict");
+        };
+
+        let decoded = BroadcastV1::CompressedChange(compressed)
+            .into_change(Some(&decoder_dicts))
+            .unwrap();
+        assert_eq!(decoded, change);
+    }
+
+    #[test]
+    fn test_decode_fails_for_unknown_dict_id() {
+        let old_dict_bytes = trained_dict_bytes();
+        let encoder_dicts = ZstdDicts::new(&old_dict_bytes, 3, vec![]);
+        // decoder doesn't know about `old_dict_bytes` at all
+        let new_dict_bytes = {
+            let samples: Vec<Vec<u8>> = (200..400)
+                .map(|n| change_with_rows(n).write_to_vec().unwrap())
+                .collect();
+            zstd::dict::from_samples(&samples, 16 * 1024).unwrap()
+        };
+        let decoder_dicts = ZstdDicts::new(&new_dict_bytes, 3, vec![]);
+
+        let change = change_with_rows(50);
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, Some(&encoder_dicts));
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected change to compress with a dict");
+        };
+
+        let err = BroadcastV1::CompressedChange(compressed)
+            .into_change(Some(&decoder_dicts))
+            .unwrap_err();
+        assert!(matches!(err, BroadcastDecodeError::Compress(_)));
     }
 }

--- a/crates/corro-types/src/compress.rs
+++ b/crates/corro-types/src/compress.rs
@@ -1,0 +1,362 @@
+//! zstd compression for broadcast (and, without dictionaries, sync) wire
+//! payloads. See `ZstdDicts` for how dictionary-aware compression works.
+
+use std::{
+    collections::HashMap,
+    io::{self, Read, Write},
+    num::NonZeroU32,
+    time::Instant,
+};
+
+use metrics::{counter, histogram};
+use speedy::{Readable, Writable};
+use tracing::warn;
+
+use crate::broadcast::ChangeV1;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CompressError {
+    #[error(transparent)]
+    Speedy(#[from] speedy::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// Cheaply checks whether `prefix` (a dictionary candidate's leading bytes)
+/// is zstd's dictionary magic number, i.e. looks like an actual trained
+/// dictionary rather than some unrelated file. Meant to be checked against
+/// just the first few bytes of a candidate file, before reading the whole
+/// thing -- not a substitute for the dictionary-id check in
+/// `ZstdDicts::new`, since a conformant dictionary can still have no id.
+pub fn looks_like_zstd_dict(prefix: &[u8]) -> bool {
+    prefix
+        .get(..4)
+        .map(|prefix| {
+            u32::from_le_bytes(prefix.try_into().unwrap()) == zstd::zstd_safe::MAGIC_DICTIONARY
+        })
+        .unwrap_or(false)
+}
+
+/// Trained zstd dictionaries for broadcast compression. `encoder` is the
+/// single, explicitly configured dictionary used to compress outgoing
+/// broadcasts. `decoders` indexes every known dictionary (the encoder one,
+/// plus any extra ones loaded from a scanned directory) by its embedded
+/// zstd dictionary ID, so we can keep decoding broadcasts from peers still
+/// on an older (or newer) dictionary.
+pub struct ZstdDicts {
+    encoder: zstd::dict::EncoderDictionary<'static>,
+    decoders: HashMap<NonZeroU32, zstd::dict::DecoderDictionary<'static>>,
+}
+
+impl ZstdDicts {
+    /// `encoder_bytes` is used both to compress outgoing broadcasts and to
+    /// decode frames that reference its ID. `extra_decoder_bytes` are
+    /// additional dictionaries usable only for decoding.
+    pub fn new(encoder_bytes: &[u8], level: i32, extra_decoder_bytes: Vec<Vec<u8>>) -> Self {
+        let mut decoders = HashMap::new();
+
+        match zstd::zstd_safe::get_dict_id_from_dict(encoder_bytes) {
+            Some(id) => {
+                decoders.insert(id, zstd::dict::DecoderDictionary::copy(encoder_bytes));
+            }
+            None => {
+                warn!(
+                    "configured compression dict has no embedded dictionary id \
+                     (was it trained with `zstd --train`?); broadcasts \
+                     compressed with it can't be decoded by dictionary-aware \
+                     nodes, including this one"
+                );
+            }
+        }
+
+        for bytes in extra_decoder_bytes {
+            match zstd::zstd_safe::get_dict_id_from_dict(&bytes) {
+                Some(id) => {
+                    decoders
+                        .entry(id)
+                        .or_insert_with(|| zstd::dict::DecoderDictionary::copy(&bytes));
+                }
+                None => {
+                    warn!("skipping candidate compression dict with no embedded dictionary id");
+                }
+            }
+        }
+
+        Self {
+            encoder: zstd::dict::EncoderDictionary::copy(encoder_bytes, level),
+            decoders,
+        }
+    }
+}
+
+fn encode_all_with_dict(data: &[u8], level: i32, dicts: Option<&ZstdDicts>) -> io::Result<Vec<u8>> {
+    match dicts {
+        Some(dicts) => {
+            let mut buf = Vec::new();
+            let mut encoder =
+                zstd::stream::write::Encoder::with_prepared_dictionary(&mut buf, &dicts.encoder)?;
+            encoder.write_all(data)?;
+            encoder.finish()?;
+            Ok(buf)
+        }
+        None => zstd::stream::encode_all(data, level),
+    }
+}
+
+/// Decodes `data`, using whichever known dictionary (peeked from compressed bytes) its embedded
+/// dictionary ID points to.
+fn decode_all_with_dict(data: &[u8], dicts: Option<&ZstdDicts>) -> io::Result<Vec<u8>> {
+    let Some(dicts) = dicts else {
+        return zstd::stream::decode_all(data);
+    };
+    match zstd::zstd_safe::get_dict_id_from_frame(data) {
+        None => zstd::stream::decode_all(data),
+        Some(id) => match dicts.decoders.get(&id) {
+            Some(decoder) => {
+                let mut decoder_reader =
+                    zstd::stream::read::Decoder::with_prepared_dictionary(data, decoder)?;
+                let mut buf = Vec::new();
+                decoder_reader.read_to_end(&mut buf)?;
+                Ok(buf)
+            }
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("no known compression dict for id {id}"),
+            )),
+        },
+    }
+}
+
+pub fn compress_change(
+    change: &ChangeV1,
+    level: i32,
+    dicts: Option<&ZstdDicts>,
+) -> Result<Vec<u8>, CompressError> {
+    let encoded = change.write_to_vec()?;
+    Ok(encode_all_with_dict(&encoded, level, dicts)?)
+}
+
+pub fn decompress_change(
+    data: &[u8],
+    traffic: &'static str,
+    dicts: Option<&ZstdDicts>,
+) -> Result<ChangeV1, CompressError> {
+    let start = Instant::now();
+    let decompressed = match decode_all_with_dict(data, dicts) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            counter!("corro.decompression.errors.total", "traffic" => traffic).increment(1);
+            return Err(e.into());
+        }
+    };
+    histogram!("corro.decompression.time.seconds").record(start.elapsed());
+    if decompressed.len() > data.len() {
+        counter!("corro.decompression.bytes.extra")
+            .increment((decompressed.len() - data.len()) as u64);
+    }
+    match ChangeV1::read_from_buffer(&decompressed) {
+        Ok(change) => Ok(change),
+        Err(e) => {
+            counter!("corro.decompression.errors.total", "traffic" => traffic).increment(1);
+            Err(e.into())
+        }
+    }
+}
+
+/// Result of attempting to compress a change for the wire.
+pub enum WireCompression {
+    /// Payload shrank; send the compressed bytes.
+    Compressed(Vec<u8>),
+    /// Compression didn't help; send the original change.
+    Uncompressed,
+}
+
+/// Try to compress a `ChangeV1` for the wire. Records compression metrics under
+/// `traffic` (`"broadcast"` or `"sync"`).
+pub fn try_compress_change_for_wire(
+    change: &ChangeV1,
+    traffic: &'static str,
+    level: i32,
+    dicts: Option<&ZstdDicts>,
+) -> Result<WireCompression, CompressError> {
+    let raw_len = change.write_to_vec()?.len();
+
+    let start = Instant::now();
+    counter!("corro.compression.attempts.total", "traffic" => traffic).increment(1);
+    counter!("corro.compression.bytes.raw.total", "traffic" => traffic).increment(raw_len as u64);
+
+    match compress_change(change, level, dicts)? {
+        compressed if compressed.len() < raw_len => {
+            let saved_bytes = raw_len - compressed.len();
+
+            histogram!("corro.compression.time.seconds").record(start.elapsed());
+            counter!("corro.compression.used.total", "traffic" => traffic).increment(1);
+            counter!("corro.compression.bytes.saved", "traffic" => traffic)
+                .increment(saved_bytes as u64);
+            Ok(WireCompression::Compressed(compressed))
+        }
+        _ => {
+            counter!("corro.compression.useless", "traffic" => traffic).increment(raw_len as u64);
+            Ok(WireCompression::Uncompressed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        actor::ActorId,
+        base::{CrsqlDbVersion, CrsqlSeq},
+        broadcast::{BroadcastDecodeError, BroadcastV1, Changeset, Timestamp},
+        change::Change,
+    };
+    use corro_api_types::SqliteValue;
+    use corro_base_types::CrsqlSeqRange;
+
+    fn change_with_rows(n: usize) -> ChangeV1 {
+        let actor_id = ActorId(Uuid::new_v4());
+        let changes = (0..n)
+            .map(|i| Change {
+                table: "test_table".into(),
+                pk: format!("pk-{i}").into_bytes(),
+                cid: "some_column".into(),
+                val: SqliteValue::Text("a fairly repetitive value".into()),
+                col_version: 1,
+                db_version: CrsqlDbVersion(1),
+                seq: CrsqlSeq(i as u64),
+                site_id: actor_id.to_bytes(),
+                cl: 1,
+            })
+            .collect::<Vec<_>>();
+
+        ChangeV1 {
+            actor_id,
+            changeset: Changeset::Full {
+                version: CrsqlDbVersion(1),
+                changes,
+                seqs: CrsqlSeqRange::new(CrsqlSeq(0), CrsqlSeq(n.max(1) as u64 - 1)),
+                last_seq: CrsqlSeq(n.max(1) as u64 - 1),
+                ts: Timestamp::zero(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_looks_like_zstd_dict() {
+        let samples: Vec<Vec<u8>> = (1..200)
+            .map(|n| change_with_rows(n).write_to_vec().unwrap())
+            .collect();
+        let trained = zstd::dict::from_samples(&samples, 16 * 1024).unwrap();
+
+        assert!(looks_like_zstd_dict(&trained));
+        assert!(!looks_like_zstd_dict(b"not a dictionary"));
+        assert!(!looks_like_zstd_dict(b""));
+        assert!(!looks_like_zstd_dict(&[0u8; 3]));
+    }
+
+    #[test]
+    fn test_compress_change_compresses_and_roundtrips() {
+        let change = change_with_rows(200);
+        let raw_len = change.write_to_vec().unwrap().len();
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, None);
+
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected a large, repetitive change to compress");
+        };
+        let compressed_len = compressed.len();
+
+        assert!(
+            compressed_len < raw_len,
+            "compressed size ({compressed_len}) should be smaller than raw ({raw_len})"
+        );
+
+        let ratio = (1.0 - compressed_len as f64 / raw_len as f64) * 100.0;
+        eprintln!(
+            "broadcast change compression: raw={raw_len}B compressed={compressed_len}B ratio={ratio:.1}%"
+        );
+
+        let decoded = BroadcastV1::CompressedChange(compressed)
+            .into_change(None)
+            .unwrap();
+        assert_eq!(decoded, change);
+    }
+
+    fn trained_dict_bytes() -> Vec<u8> {
+        let samples: Vec<Vec<u8>> = (1..200)
+            .map(|n| change_with_rows(n).write_to_vec().unwrap())
+            .collect();
+        zstd::dict::from_samples(&samples, 16 * 1024).unwrap()
+    }
+
+    #[test]
+    fn test_compress_change_with_dict_roundtrips() {
+        let change = change_with_rows(50);
+        let dicts = ZstdDicts::new(&trained_dict_bytes(), 3, vec![]);
+
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, Some(&dicts));
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected change to compress with a dict");
+        };
+
+        let decoded = BroadcastV1::CompressedChange(compressed)
+            .into_change(Some(&dicts))
+            .unwrap();
+        assert_eq!(decoded, change);
+    }
+
+    #[test]
+    fn test_decode_with_older_dict_via_directory_scan() {
+        // Simulate a rotation: encode with the "old" dict, but the decoder
+        // was configured with a "new" primary dict and only knows the old
+        // one via its extra (directory-scanned) dictionaries.
+        let old_dict_bytes = trained_dict_bytes();
+        let new_dict_bytes = {
+            let samples: Vec<Vec<u8>> = (200..400)
+                .map(|n| change_with_rows(n).write_to_vec().unwrap())
+                .collect();
+            zstd::dict::from_samples(&samples, 16 * 1024).unwrap()
+        };
+
+        let encoder_dicts = ZstdDicts::new(&old_dict_bytes, 3, vec![]);
+        let decoder_dicts = ZstdDicts::new(&new_dict_bytes, 3, vec![old_dict_bytes]);
+
+        let change = change_with_rows(50);
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, Some(&encoder_dicts));
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected change to compress with a dict");
+        };
+
+        let decoded = BroadcastV1::CompressedChange(compressed)
+            .into_change(Some(&decoder_dicts))
+            .unwrap();
+        assert_eq!(decoded, change);
+    }
+
+    #[test]
+    fn test_decode_fails_for_unknown_dict_id() {
+        let old_dict_bytes = trained_dict_bytes();
+        let encoder_dicts = ZstdDicts::new(&old_dict_bytes, 3, vec![]);
+        // decoder doesn't know about `old_dict_bytes` at all
+        let new_dict_bytes = {
+            let samples: Vec<Vec<u8>> = (200..400)
+                .map(|n| change_with_rows(n).write_to_vec().unwrap())
+                .collect();
+            zstd::dict::from_samples(&samples, 16 * 1024).unwrap()
+        };
+        let decoder_dicts = ZstdDicts::new(&new_dict_bytes, 3, vec![]);
+
+        let change = change_with_rows(50);
+        let bcast = BroadcastV1::Change(change.clone()).compress_for_wire(3, Some(&encoder_dicts));
+        let BroadcastV1::CompressedChange(compressed) = bcast else {
+            panic!("expected change to compress with a dict");
+        };
+
+        let err = BroadcastV1::CompressedChange(compressed)
+            .into_change(Some(&decoder_dicts))
+            .unwrap_err();
+        assert!(matches!(err, BroadcastDecodeError::Compress(_)));
+    }
+}

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -232,16 +232,46 @@ pub struct GossipConfig {
     pub disable_gso: bool,
     #[serde(default)]
     pub member_id: Option<MemberId>,
+    #[serde(default)]
+    pub compression: Option<CompressionConfig>,
+}
+
+impl GossipConfig {
+    pub fn compression_config(&self) -> CompressionConfig {
+        self.compression.clone().unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressionConfig {
     /// Whether to zstd-compress broadcast and sync changeset payloads.
     /// Safe to flip cluster-wide at any time: uncompressed and compressed
-    /// nodes interoperate (broadcast drops what it can't decode and heals
-    /// via sync; sync negotiates per-peer via a capability flag).
+    /// nodes interoperate
     #[serde(default)]
-    pub compression: bool,
+    pub enabled: bool,
     /// zstd compression level for wire payloads (1–22). Ignored when
-    /// `compression` is false.
+    /// `enabled` is false.
     #[serde(default = "default_compression_level")]
-    pub compression_level: i32,
+    pub level: i32,
+    /// Path to a trained zstd dictionary (e.g. produced by `corrosion db
+    /// train-dict`), used to compress outgoing broadcasts. Its containing
+    /// directory is also scanned at startup for other trained dictionaries
+    /// (e.g. previous versions of it), which are loaded and indexed by
+    /// their embedded zstd dictionary id purely for decoding -- so
+    /// broadcasts from peers that haven't rotated to the current dictionary
+    /// yet can still be decoded.
+    #[serde(default)]
+    pub dict_path: Option<Utf8PathBuf>,
+}
+
+impl Default for CompressionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            level: default_compression_level(),
+            dict_path: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -410,9 +440,10 @@ impl Config {
                 return Err(ConfigError::InvalidMaxMtu { value: mtu });
             }
         }
-        if !(1..=22).contains(&self.gossip.compression_level) {
+        let compression_level = self.gossip.compression_config().level;
+        if !(1..=22).contains(&compression_level) {
             return Err(ConfigError::InvalidCompressionLevel {
-                value: self.gossip.compression_level,
+                value: compression_level,
             });
         }
         Ok(())
@@ -578,10 +609,13 @@ impl ConfigBuilder {
                 max_mtu: self.max_mtu,
                 disable_gso: self.disable_gso,
                 member_id: self.member_id,
-                compression: self.compression.unwrap_or_default(),
-                compression_level: self
-                    .compression_level
-                    .unwrap_or_else(default_compression_level),
+                compression: Some(CompressionConfig {
+                    enabled: self.compression.unwrap_or_default(),
+                    level: self
+                        .compression_level
+                        .unwrap_or_else(default_compression_level),
+                    dict_path: None,
+                }),
             },
             perf: self.perf.unwrap_or_default(),
             admin: AdminConfig {

--- a/crates/corro-types/src/lib.rs
+++ b/crates/corro-types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bookie;
 pub mod broadcast;
 pub mod change;
 pub mod channel;
+pub mod compress;
 pub mod config;
 pub mod gauge;
 pub mod members;

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -13,10 +13,8 @@ use crate::{
     actor::ActorId,
     agent::Bookie,
     base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq, CrsqlSeqRange},
-    broadcast::{
-        decompress_change, try_compress_change_for_wire, ChangeV1, CompressError, Timestamp,
-        WireCompression,
-    },
+    broadcast::{ChangeV1, Timestamp},
+    compress::{decompress_change, try_compress_change_for_wire, CompressError, WireCompression},
 };
 
 #[derive(Debug, Clone, PartialEq, Readable, Writable)]
@@ -364,16 +362,9 @@ impl SyncMessage {
     pub fn from_buf(buf: &mut BytesMut) -> Result<Self, SyncMessageDecodeError> {
         let msg = Self::from_slice(buf)?;
         Ok(match msg {
-            SyncMessage::V1(SyncMessageV1::CompressedChangeset(data)) => {
-                match decompress_change(&data) {
-                    Ok(change) => SyncMessage::V1(SyncMessageV1::Changeset(change)),
-                    Err(e) => {
-                        counter!("corro.decompression.errors.total", "traffic" => "sync")
-                            .increment(1);
-                        return Err(e.into());
-                    }
-                }
-            }
+            SyncMessage::V1(SyncMessageV1::CompressedChangeset(data)) => SyncMessage::V1(
+                SyncMessageV1::Changeset(decompress_change(&data, "sync", None)?),
+            ),
             other => other,
         })
     }
@@ -387,7 +378,7 @@ impl SyncMessage {
             return self;
         };
 
-        match try_compress_change_for_wire(&change, "sync", level) {
+        match try_compress_change_for_wire(&change, "sync", level, None) {
             Ok(WireCompression::Compressed(compressed)) => {
                 SyncMessage::V1(SyncMessageV1::CompressedChangeset(compressed))
             }

--- a/crates/corrosion/Cargo.toml
+++ b/crates/corrosion/Cargo.toml
@@ -40,6 +40,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shellwords = { version = "1" }
 spawn = { path = "../spawn" }
+speedy = { workspace = true }
 sqlite3-restore = { path = "../sqlite3-restore" }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -18,7 +18,9 @@ use corro_client::CorrosionApiClient;
 use corro_types::{
     actor::{ActorId, ClusterId},
     api::{ExecResult, QueryEvent, Statement},
-    base::CrsqlDbVersion,
+    base::{CrsqlDbVersion, CrsqlSeq},
+    broadcast::{ChangeV1, Changeset, Timestamp},
+    change::{row_to_change, ChunkedChanges, MAX_CHANGES_BYTE_SIZE},
     config::{default_admin_path, AuthzConfig, Config, ConfigError, LogFormat, OtelConfig},
     sqlite::CrConn,
 };
@@ -27,7 +29,8 @@ use once_cell::sync::OnceCell;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk as os;
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use speedy::Writable;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{
     fmt::format::Format, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt,
@@ -562,6 +565,70 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             info!("Exited with code: {:?}", exit.code());
             std::process::exit(exit.code().unwrap_or(1));
         }
+        Command::Db(DbCommand::SampleChanges { out, limit }) => {
+            let db_path = cli.db_path()?;
+            let mut conn = CrConn::init(Connection::open_with_flags(
+                &db_path,
+                OpenFlags::SQLITE_OPEN_READ_ONLY
+                    | OpenFlags::SQLITE_OPEN_NO_MUTEX
+                    | OpenFlags::SQLITE_OPEN_URI,
+            )?)?;
+
+            std::fs::create_dir_all(out)?;
+            let tx = conn.transaction()?;
+
+            let mut version_stmt = tx.prepare(
+                "SELECT DISTINCT site_id, db_version
+                    FROM crsql_changes
+                    ORDER BY ts DESC
+                    LIMIT ?",
+            )?;
+
+            let versions: Vec<(ActorId, CrsqlDbVersion)> = version_stmt
+                .query_map([*limit], |row| Ok((row.get(0)?, row.get(1)?)))?
+                .collect::<Result<_, _>>()?;
+
+            let mut written = 0usize;
+            for (actor_id, version) in versions {
+                let (last_seq, ts): (CrsqlSeq, Timestamp) = tx.query_row(
+                    "SELECT MAX(seq), MAX(ts)
+                         FROM crsql_changes
+                         WHERE site_id = ? AND db_version = ?",
+                    (actor_id, version),
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+
+                let mut change_stmt = tx.prepare(
+                    r#"SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl
+                           FROM crsql_changes
+                           WHERE site_id = ? AND db_version = ?
+                           ORDER BY seq ASC"#,
+                )?;
+                let rows = change_stmt.query_map((actor_id, version), row_to_change)?;
+                let chunked =
+                    ChunkedChanges::new(rows, CrsqlSeq(0), last_seq, MAX_CHANGES_BYTE_SIZE);
+
+                for (i, chunk) in chunked.enumerate() {
+                    let (changes, seqs) = chunk?;
+                    let change = ChangeV1 {
+                        actor_id,
+                        changeset: Changeset::FullV2 {
+                            actor_id,
+                            version,
+                            changes,
+                            seqs,
+                            last_seq,
+                            ts,
+                        },
+                    };
+                    let encoded = change.write_to_vec()?;
+                    std::fs::write(out.join(format!("{actor_id}_{version}_{i}.bin")), &encoded)?;
+                    written += 1;
+                }
+            }
+
+            info!("wrote {written} change samples to {out}");
+        }
         Command::Subs(SubsCommand::Info { hash, id }) => {
             let mut conn = AdminConn::connect(cli.admin_path()).await?;
             conn.send_command(corro_admin::Command::Subs(corro_admin::SubsCommand::Info {
@@ -850,6 +917,17 @@ enum TlsClientCommand {
 enum DbCommand {
     /// Acquires the lock on the DB
     Lock { cmd: String },
+    /// Write recent changes to disk as speedy-encoded `ChangeV1` samples,
+    /// one file per change chunk (as produced by ChunkedChanges), for training a zstd compression
+    /// dictionary with `db train-dict`
+    SampleChanges {
+        /// Directory to write samples into
+        #[arg(long)]
+        out: Utf8PathBuf,
+        /// How many of the most recent db_versions to sample
+        #[arg(long, default_value = "5000")]
+        limit: u32,
+    },
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
This pull request;
-  adds the option of specifying a custom dictionary for  compressing / decompressing changes. This could improve compression ratio and speed up compression times. 
- adds command to write recently inserted changes from database to disk in speedy encoded format. The directory can then be passed to `zstd --train` to generate the custom dictionary.

