### PR TITLE
Add command to reload zstd dicts

### DIFF
--- a/crates/corro-admin/src/lib.rs
+++ b/crates/corro-admin/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use camino::Utf8PathBuf;
-use corro_agent::agent::util::execute_schema_from_paths;
+use corro_agent::agent::{reload_change_dicts, util::execute_schema_from_paths};
 use corro_types::{
     actor::{ActorId, ClusterId},
     agent::{Agent, BookedVersions, Bookie, WriteConn},
@@ -112,6 +112,7 @@ pub enum Command {
     Subs(SubsCommand),
     Log(LogCommand),
     Reload,
+    ReloadDicts,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -225,6 +226,29 @@ async fn handle_conn(
                     }
                     info_log(&mut stream, "schema reload finished").await;
                     send_success(&mut stream).await;
+                }
+                Command::ReloadDicts => {
+                    info_log(
+                        &mut stream,
+                        "reloading zstd compression dictionaries from configured dict_dir...",
+                    )
+                    .await;
+                    match reload_change_dicts(&agent) {
+                        Ok(decoder_count) => {
+                            info_log(
+                                &mut stream,
+                                format!(
+                                    "compression dictionary reload finished ({decoder_count} decoder dicts)"
+                                ),
+                            )
+                            .await;
+                            send_success(&mut stream).await;
+                        }
+                        Err(e) => {
+                            send_error(&mut stream, e).await;
+                            continue;
+                        }
+                    }
                 }
                 Command::Sync(SyncCommand::Generate) => {
                     info_log(&mut stream, "generating sync...").await;

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -138,7 +138,7 @@ pub fn spawn_incoming_connection_handlers(
             &conn,
             agent.cluster_id(),
             agent.tx_changes().clone(),
-            agent.change_dict(),
+            agent.change_dict_slot(),
         );
         bi::spawn_bipayload_handler(&agent, &bookie, &tripwire, &conn);
     });

--- a/crates/corro-agent/src/agent/mod.rs
+++ b/crates/corro-agent/src/agent/mod.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 // Public exports
 pub use error::{SyncClientError, SyncRecvError};
 pub use run_root::start_with_config;
-pub use setup::{setup, AgentOptions};
+pub use setup::{reload_change_dicts, setup, AgentOptions};
 pub use uni::spawn_unipayload_handler;
 pub use util::process_multiple_changes;
 

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -42,7 +42,7 @@ use corro_types::{
     broadcast::{BroadcastInput, BroadcastV1, ChangeSource, ChangeV1, FocaInput},
     channel::{bounded, CorroReceiver},
     compress::ZstdDicts,
-    config::Config,
+    config::{CompressionConfig, Config},
     members::Members,
     metrics_tracker::MetricsTracker,
     pubsub::{Matcher, SubsManager},
@@ -177,73 +177,7 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
 
     let metrics_tracker = MetricsTracker::new(Duration::from_secs(120), 5)?;
 
-    let compression_config = conf.gossip.compression_config();
-    let change_dict = match &compression_config.dict_dir {
-        Some(dir) => {
-            let encode_name = compression_config.dict_file.as_deref();
-            let mut encoder_bytes: Option<Vec<u8>> = None;
-            let mut decoder_dicts = Vec::new();
-
-            let entries = std::fs::read_dir(dir)
-                .map_err(|e| eyre::eyre!("could not read compression dict dir {dir}: {e}"))?;
-            for entry in entries {
-                let entry = entry?;
-                if !entry.file_type()?.is_file() {
-                    continue;
-                }
-                let entry_path = entry.path();
-                let file_name = entry.file_name();
-                let file_name = file_name.to_string_lossy();
-
-                let mut file = match std::fs::File::open(&entry_path) {
-                    Ok(file) => file,
-                    Err(e) => {
-                        warn!("could not open candidate compression dict {entry_path:?}: {e}");
-                        continue;
-                    }
-                };
-
-                match load_dictionary(&mut file) {
-                    Ok(Some(b)) => {
-                        if encode_name == Some(file_name.as_ref()) {
-                            info!(
-                                path = %entry_path.display(),
-                                dict_id = ?zstd::zstd_safe::get_dict_id_from_dict(&b),
-                                "using compression dictionary for encoding and decoding"
-                            );
-                            encoder_bytes = Some(b.clone());
-                        } else {
-                            info!(
-                                path = %entry_path.display(),
-                                dict_id = ?zstd::zstd_safe::get_dict_id_from_dict(&b),
-                                "using compression dictionary for decoding"
-                            );
-                        }
-                        decoder_dicts.push(b);
-                    }
-                    _ => {
-                        warn!("could not read candidate compression dict {entry_path:?}");
-                    }
-                }
-            }
-
-            if let Some(name) = encode_name {
-                if encoder_bytes.is_none() {
-                    eyre::bail!(
-                        "gossip.compression.dict_file `{name}` not found in {dir} \
-                         or is not a valid zstd dictionary"
-                    );
-                }
-            }
-
-            Some(Arc::new(ZstdDicts::new(
-                encoder_bytes.as_deref(),
-                compression_config.level,
-                decoder_dicts,
-            )))
-        }
-        None => None,
-    };
+    let change_dict = load_change_dicts(&conf.gossip.compression_config())?;
 
     let opts = AgentOptions {
         gossip_server_endpoint,
@@ -290,6 +224,88 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
     });
 
     Ok((agent, opts))
+}
+
+/// Load trained zstd dictionaries from `gossip.compression.dict_dir`.
+///
+/// Every valid dictionary file in the directory is registered for decoding.
+/// When `dict_file` is set, that file is also used as the encoder dictionary.
+pub fn load_change_dicts(
+    compression_config: &CompressionConfig,
+) -> eyre::Result<Option<Arc<ZstdDicts>>> {
+    let Some(dir) = &compression_config.dict_dir else {
+        return Ok(None);
+    };
+
+    let encode_name = compression_config.dict_file.as_deref();
+    let mut encoder_bytes: Option<Vec<u8>> = None;
+    let mut decoder_dicts = Vec::new();
+
+    let entries = std::fs::read_dir(dir)
+        .map_err(|e| eyre::eyre!("could not read compression dict dir {dir}: {e}"))?;
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let entry_path = entry.path();
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        let mut file = match std::fs::File::open(&entry_path) {
+            Ok(file) => file,
+            Err(e) => {
+                warn!("could not open candidate compression dict {entry_path:?}: {e}");
+                continue;
+            }
+        };
+
+        match load_dictionary(&mut file) {
+            Ok(Some(b)) => {
+                if encode_name == Some(file_name.as_ref()) {
+                    info!(
+                        path = %entry_path.display(),
+                        dict_id = ?zstd::zstd_safe::get_dict_id_from_dict(&b),
+                        "using compression dictionary for encoding and decoding"
+                    );
+                    encoder_bytes = Some(b.clone());
+                } else {
+                    info!(
+                        path = %entry_path.display(),
+                        dict_id = ?zstd::zstd_safe::get_dict_id_from_dict(&b),
+                        "using compression dictionary for decoding"
+                    );
+                }
+                decoder_dicts.push(b);
+            }
+            _ => {
+                warn!("could not read candidate compression dict {entry_path:?}");
+            }
+        }
+    }
+
+    if let Some(name) = encode_name {
+        if encoder_bytes.is_none() {
+            eyre::bail!(
+                "gossip.compression.dict_file `{name}` not found in {dir} \
+                 or is not a valid zstd dictionary"
+            );
+        }
+    }
+
+    Ok(Some(Arc::new(ZstdDicts::new(
+        encoder_bytes.as_deref(),
+        compression_config.level,
+        decoder_dicts,
+    ))))
+}
+
+/// Rescan `gossip.compression.dict_dir` and swap the agent's dictionaries.
+pub fn reload_change_dicts(agent: &Agent) -> eyre::Result<usize> {
+    let dicts = load_change_dicts(&agent.config().gossip.compression_config())?;
+    let decoder_count = dicts.as_ref().map(|d| d.decoder_count()).unwrap_or(0);
+    agent.set_change_dict(dicts);
+    Ok(decoder_count)
 }
 
 /// Initialise subscription state and tasks

--- a/crates/corro-agent/src/agent/uni.rs
+++ b/crates/corro-agent/src/agent/uni.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use arc_swap::ArcSwapOption;
 use corro_types::{
     actor::ClusterId,
     broadcast::{BroadcastV1, ChangeSource, ChangeV1, UniPayload, UniPayloadV1},
@@ -20,7 +21,7 @@ pub fn spawn_unipayload_handler(
     conn: &quinn::Connection,
     cluster_id: ClusterId,
     tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
-    change_dict: Option<Arc<ZstdDicts>>,
+    change_dict: Arc<ArcSwapOption<ZstdDicts>>,
 ) {
     tokio::spawn({
         let conn = conn.clone();
@@ -48,9 +49,10 @@ pub fn spawn_unipayload_handler(
                     conn.remote_address()
                 );
 
+                let change_dict = change_dict.load_full();
+
                 tokio::spawn({
                     let tx_changes = tx_changes.clone();
-                    let change_dict = change_dict.clone();
                     async move {
                         let mut framed = FramedRead::new(
                             rx,

--- a/crates/corro-agent/src/broadcast/mod.rs
+++ b/crates/corro-agent/src/broadcast/mod.rs
@@ -1281,7 +1281,7 @@ mod tests {
                 &conn,
                 ta1.agent.cluster_id(),
                 tx_changes,
-                ta1.agent.change_dict(),
+                ta1.agent.change_dict_slot(),
             );
 
             // we should receive five items starting from the biggest version

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use antithesis_sdk::assert_unreachable;
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use camino::Utf8PathBuf;
 use metrics::{gauge, histogram};
 use parking_lot::RwLock;
@@ -110,7 +110,7 @@ pub struct AgentInner {
     tx_clear_buf: CorroSender<(ActorId, CrsqlDbVersionRange)>,
     tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
     tx_foca: CorroSender<FocaInput>,
-    change_dict: Option<Arc<ZstdDicts>>,
+    change_dict: Arc<ArcSwapOption<ZstdDicts>>,
     write_sema: Arc<Semaphore>,
     schema: RwLock<Schema>,
     cluster_id: ArcSwap<ClusterId>,
@@ -145,7 +145,7 @@ impl Agent {
             tx_clear_buf: config.tx_clear_buf,
             tx_changes: config.tx_changes,
             tx_foca: config.tx_foca,
-            change_dict: config.change_dict,
+            change_dict: Arc::new(ArcSwapOption::from(config.change_dict)),
             write_sema: config.write_sema,
             schema: config.schema,
             cluster_id: ArcSwap::from_pointee(config.cluster_id),
@@ -219,7 +219,15 @@ impl Agent {
     }
 
     pub fn change_dict(&self) -> Option<Arc<ZstdDicts>> {
+        self.0.change_dict.load_full()
+    }
+
+    pub fn change_dict_slot(&self) -> Arc<ArcSwapOption<ZstdDicts>> {
         self.0.change_dict.clone()
+    }
+
+    pub fn set_change_dict(&self, dicts: Option<Arc<ZstdDicts>>) {
+        self.0.change_dict.store(dicts);
     }
 
     pub fn write_sema(&self) -> &Arc<Semaphore> {

--- a/crates/corro-types/src/compress.rs
+++ b/crates/corro-types/src/compress.rs
@@ -82,6 +82,10 @@ impl ZstdDicts {
 
         Self { encoder, decoders }
     }
+
+    pub fn decoder_count(&self) -> usize {
+        self.decoders.len()
+    }
 }
 
 fn encode_all_with_dict(data: &[u8], level: i32, dicts: Option<&ZstdDicts>) -> io::Result<Vec<u8>> {

--- a/crates/corro-types/src/config.rs
+++ b/crates/corro-types/src/config.rs
@@ -254,9 +254,10 @@ pub struct CompressionConfig {
     #[serde(default = "default_compression_level")]
     pub level: i32,
     /// Directory of trained zstd dictionaries. Every valid dictionary file in this directory
-    /// is loaded at startup and indexed by its embedded zstd dictionary id for
-    /// decoding, so broadcasts from peers still on an older (or newer)
-    /// encoding dictionary can be understood during a gradual rollout.
+    /// is loaded at startup (and on `corrosion reload-dicts`) and indexed by its
+    /// embedded zstd dictionary id for decoding, so broadcasts from peers still
+    /// on an older (or newer) encoding dictionary can be understood during a
+    /// gradual rollout.
     #[serde(default)]
     pub dict_dir: Option<Utf8PathBuf>,
     /// Filename within `dict_dir` used to compress outgoing broadcasts.

--- a/crates/corrosion/src/command/reload.rs
+++ b/crates/corrosion/src/command/reload.rs
@@ -15,6 +15,16 @@ pub async fn run<P: AsRef<Path>>(admin_path: P) -> eyre::Result<()> {
     Ok(())
 }
 
+pub async fn run_dicts<P: AsRef<Path>>(admin_path: P) -> eyre::Result<()> {
+    let mut conn = AdminConn::connect(admin_path).await?;
+    if let Err(e) = conn.send_command(Command::ReloadDicts).await {
+        error!("Failed to reload compression dictionaries: {e}");
+        return Err(eyre!("Failed to reload compression dictionaries: {e}"));
+    }
+    info!("Successfully reloaded zstd compression dictionaries from configured dict_dir!");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -486,6 +486,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
             }
         }
         Command::Reload => command::reload::run(cli.admin_path()).await?,
+        Command::ReloadDicts => command::reload::run_dicts(cli.admin_path()).await?,
         Command::Sync(SyncCommand::Generate) => {
             let mut conn = AdminConn::connect(cli.admin_path()).await?;
             conn.send_command(corro_admin::Command::Sync(
@@ -804,6 +805,10 @@ enum Command {
 
     /// Reload Corrosion schema
     Reload,
+
+    /// Rescan gossip.compression.dict_dir and reload zstd dictionaries
+    /// without restarting the agent
+    ReloadDicts,
 
     /// Sync-related commands
     #[command(subcommand)]

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -38,6 +38,7 @@
     - [exec](cli/exec.md)
     - [query](cli/query.md)
     - [reload](cli/reload.md)
+    - [reload-dicts](cli/reload-dicts.md)
     - [restore](cli/restore.md)
     - [subs](cli/subs.md)
     - [sync](cli/sync.md)

--- a/doc/cli/README.md
+++ b/doc/cli/README.md
@@ -13,6 +13,7 @@ See the pages for each subcommand:
 - [`corrosion exec`](exec.md)
 - [`corrosion query`](query.md)
 - [`corrosion reload`](reload.md)
+- [`corrosion reload-dicts`](reload-dicts.md)
 - [`corrosion restore`](restore.md)
 - [`corrosion subs`](subs.md)
 - [`corrosion sync`](sync.md)

--- a/doc/cli/reload-dicts.md
+++ b/doc/cli/reload-dicts.md
@@ -1,0 +1,23 @@
+# The `corrosion reload-dicts` command
+
+Rescans `gossip.compression.dict_dir` on the running agent and swaps in the
+dictionaries found there. Use this after dropping a new decoder dictionary into
+the directory so peers using that dictionary id can be understood without
+restarting Corrosion.
+
+```
+$ corrosion reload-dicts --help
+Rescan gossip.compression.dict_dir and reload zstd dictionaries without restarting the agent
+
+Usage: corrosion reload-dicts [OPTIONS]
+
+Options:
+  -c, --config <CONFIG_PATH>     Set the config file path [default: /etc/corrosion/config.toml]
+      --api-addr <API_ADDR>
+      --db-path <DB_PATH>
+      --admin-path <ADMIN_PATH>
+  -h, --help
+```
+
+Keep older dictionary files in `dict_dir` for as long as peers may still encode
+with them — reload replaces the in-memory set with whatever is currently on disk.


### PR DESCRIPTION
This pr adds a command to load new zstd dictionaries in the compression directory into corrosion. This allows us to introduce a new dictionary without a restart