### PR TITLE
Fix Postgres transaction error handling

### DIFF
--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -357,6 +357,7 @@ enum TxState {
     Started {
         kind: OpenTxKind,
         permits: Option<(OwnedSemaphorePermit, BookieWriteGuard)>,
+        failed: bool,
     },
     #[default]
     Ended,
@@ -367,12 +368,14 @@ impl TxState {
         Self::Started {
             kind: OpenTxKind::Implicit,
             permits: None,
+            failed: false,
         }
     }
     fn explicit() -> Self {
         Self::Started {
             kind: OpenTxKind::Explicit,
             permits: None,
+            failed: false,
         }
     }
 
@@ -417,6 +420,28 @@ impl TxState {
     }
     fn is_ended(&self) -> bool {
         matches!(self, TxState::Ended)
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(
+            self,
+            TxState::Started {
+                kind: OpenTxKind::Explicit,
+                failed: true,
+                ..
+            }
+        )
+    }
+
+    fn fail_explicit(&mut self) {
+        if let TxState::Started {
+            kind: OpenTxKind::Explicit,
+            failed,
+            ..
+        } = self
+        {
+            *failed = true;
+        }
     }
 
     fn start_implicit(&mut self) {
@@ -1820,11 +1845,7 @@ pub async fn start(
                                                 )
                                                     .into(),
                                             )?;
-                                            send_ready(
-                                                &mut session,
-                                                discard_until_sync,
-                                                &back_tx,
-                                            )?;
+                                            send_ready(&mut session, true, &back_tx)?;
                                             continue;
                                         }
                                     };
@@ -1856,11 +1877,7 @@ pub async fn start(
                                                 message: e.try_into()?,
                                                 flush: true,
                                             })?;
-                                            send_ready(
-                                                &mut session,
-                                                discard_until_sync,
-                                                &back_tx,
-                                            )?;
+                                            send_ready(&mut session, true, &back_tx)?;
                                             continue 'outer;
                                         }
                                     }
@@ -2174,6 +2191,8 @@ impl<'conn> Session<'conn> {
         back_tx: &Sender<BackendResponse>,
         send_row_desc: bool,
     ) -> Result<(), QueryError> {
+        self.validate_transaction_command(cmd)?;
+
         if cmd.is_show() {
             back_tx
                 .blocking_send(
@@ -2342,6 +2361,8 @@ impl<'conn> Session<'conn> {
         max_rows: usize,
         back_tx: &Sender<BackendResponse>,
     ) -> Result<(), QueryError> {
+        self.validate_transaction_command(cmd)?;
+
         // TODO: maybe we don't need to recompute this...
         let fields = field_types(prepped, cmd, FieldFormats::Each(result_formats))?;
 
@@ -2381,6 +2402,9 @@ impl<'conn> Session<'conn> {
             } else {
                 self.commit_db()?;
             }
+        } else if cmd.is_rollback() {
+            let _permits = self.tx_state.end();
+            self.conn.execute_batch("ROLLBACK")?;
         } else if cmd.is_begin() {
             // do nothing
             debug!("cmd is BEGIN");
@@ -2579,6 +2603,18 @@ impl<'conn> Session<'conn> {
         Ok(())
     }
 
+    fn validate_transaction_command(&self, cmd: &ParsedCmd) -> Result<(), QueryError> {
+        if self.tx_state.is_failed() && !cmd.is_rollback() {
+            return Err(QueryError::InFailedTransaction);
+        }
+
+        if self.tx_state.is_explicit() && cmd.is_begin() {
+            return Err(QueryError::ActiveTransaction);
+        }
+
+        Ok(())
+    }
+
     fn commit_db(&self) -> Result<(), ChangeError> {
         let actor_id = self.agent.actor_id();
         self.conn
@@ -2655,6 +2691,10 @@ fn send_ready(
     discard_until_sync: bool,
     back_tx: &Sender<BackendResponse>,
 ) -> Result<(), BoxError> {
+    if discard_until_sync {
+        session.tx_state.fail_explicit();
+    }
+
     let ready_status = if session.tx_state.is_implicit() {
         let permits = session.tx_state.end(); // do this first, in case of failure
         if discard_until_sync {
@@ -2673,7 +2713,7 @@ fn send_ready(
 
         TransactionStatus::Idle
     } else if session.tx_state.is_explicit() {
-        if discard_until_sync {
+        if session.tx_state.is_failed() {
             TransactionStatus::Error
         } else {
             TransactionStatus::Transaction
@@ -2711,6 +2751,10 @@ enum QueryError {
     PermitAcquire(#[from] AcquireError),
     #[error(transparent)]
     Change(#[from] ChangeError),
+    #[error("current transaction is aborted, commands ignored until end of transaction block")]
+    InFailedTransaction,
+    #[error("there is already a transaction in progress")]
+    ActiveTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -2750,6 +2794,18 @@ impl TryFrom<QueryError> for PgWireBackendMessage {
             QueryError::Change(e) => {
                 ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string()).into()
             }
+            e @ QueryError::InFailedTransaction => ErrorInfo::new(
+                "ERROR".to_owned(),
+                SqlState::IN_FAILED_SQL_TRANSACTION.code().into(),
+                e.to_string(),
+            )
+            .into(),
+            e @ QueryError::ActiveTransaction => ErrorInfo::new(
+                "ERROR".to_owned(),
+                SqlState::ACTIVE_SQL_TRANSACTION.code().into(),
+                e.to_string(),
+            )
+            .into(),
         }))
     }
 }

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -266,6 +266,48 @@ async fn test_pg() {
     wait_for_all_pending_handles().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_transaction_errors() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+    let (client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(client_conn);
+
+    client.batch_execute("BEGIN").await.unwrap();
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (1)", &[])
+        .await
+        .unwrap();
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (1)", &[])
+        .await
+        .unwrap_err();
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+    client.batch_execute("ROLLBACK").await.unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM kitchensink", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i64>(0), 0);
+
+    client.batch_execute("BEGIN").await.unwrap();
+    let error = client.batch_execute("BEGIN").await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25001");
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+    client.batch_execute("ROLLBACK").await.unwrap();
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
 #[tracing_test::traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pg_readonly() {


### PR DESCRIPTION
Keep explicit Postgres transactions in the failed state after an error so later commands return 25P02 until ROLLBACK. Also reject a nested BEGIN with 25001.

Adds coverage for both cases.

Fixes #502