### PR TITLE
Expose tables through information_schema

### DIFF
--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -80,7 +80,15 @@ use crate::{
     sql_state::SqlState,
     utils::CountedTcpStream,
     vtab::{
-        information_schema_tables::InformationSchemaTablesTable,
+        information_schema_columns::{
+            load_information_schema_columns, InformationSchemaColumnsTable,
+        },
+        information_schema_table_constraints::{
+            load_information_schema_table_constraints, InformationSchemaTableConstraintsTable,
+        },
+        information_schema_tables::{
+            load_information_schema_table_names, InformationSchemaTablesTable,
+        },
         pg_class::PgClassTable,
         pg_database::{PgDatabase, PgDatabaseTable},
         pg_namespace::PgNamespaceTable,
@@ -876,15 +884,12 @@ pub async fn start(
                         )?;
 
                         let dbs = Arc::new(vec![PgDatabase::new("state".into())]);
-                        let table_names = Arc::new(
-                            agent
-                                .schema()
-                                .read()
-                                .tables
-                                .keys()
-                                .cloned()
-                                .collect::<Vec<_>>(),
+                        let table_names = load_information_schema_table_names(&conn)?;
+                        let columns = Arc::new(load_information_schema_columns(&conn, &table_names)?);
+                        let table_constraints = Arc::new(
+                            load_information_schema_table_constraints(columns.as_slice()),
                         );
+                        let table_names = Arc::new(table_names);
 
                         conn.create_module(
                             "pg_database",
@@ -915,6 +920,16 @@ pub async fn start(
                             "tables",
                             eponymous_only_module::<InformationSchemaTablesTable>(),
                             Some(table_names),
+                        )?;
+                        conn.create_module(
+                            "columns",
+                            eponymous_only_module::<InformationSchemaColumnsTable>(),
+                            Some(columns),
+                        )?;
+                        conn.create_module(
+                            "table_constraints",
+                            eponymous_only_module::<InformationSchemaTableConstraintsTable>(),
+                            Some(table_constraints),
                         )?;
 
                         conn.create_scalar_function(

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -80,6 +80,7 @@ use crate::{
     sql_state::SqlState,
     utils::CountedTcpStream,
     vtab::{
+        information_schema_tables::InformationSchemaTablesTable,
         pg_class::PgClassTable,
         pg_database::{PgDatabase, PgDatabaseTable},
         pg_namespace::PgNamespaceTable,
@@ -869,9 +870,21 @@ pub async fn start(
                             int_handle.interrupt();
                         });
 
-                        conn.execute_batch("ATTACH ':memory:' AS pg_catalog;")?;
+                        conn.execute_batch(
+                            "ATTACH ':memory:' AS pg_catalog;
+                             ATTACH ':memory:' AS information_schema;",
+                        )?;
 
                         let dbs = Arc::new(vec![PgDatabase::new("state".into())]);
+                        let table_names = Arc::new(
+                            agent
+                                .schema()
+                                .read()
+                                .tables
+                                .keys()
+                                .cloned()
+                                .collect::<Vec<_>>(),
+                        );
 
                         conn.create_module(
                             "pg_database",
@@ -897,6 +910,11 @@ pub async fn start(
                             "pg_class",
                             eponymous_only_module::<PgClassTable>(),
                             None,
+                        )?;
+                        conn.create_module(
+                            "tables",
+                            eponymous_only_module::<InformationSchemaTablesTable>(),
+                            Some(table_names),
                         )?;
 
                         conn.create_scalar_function(

--- a/crates/corro-pg/src/vtab/information_schema_columns.rs
+++ b/crates/corro-pg/src/vtab/information_schema_columns.rs
@@ -1,0 +1,390 @@
+use std::{marker::PhantomData, os::raw::c_int, sync::Arc};
+
+use rusqlite::vtab::{
+    sqlite3_vtab, sqlite3_vtab_cursor, Filters, IndexInfo, VTab, VTabConnection, VTabCursor,
+};
+
+pub struct InformationSchemaColumn {
+    pub(crate) table_name: String,
+    column_name: String,
+    ordinal_position: i64,
+    column_default: Option<String>,
+    nullable: bool,
+    data_type: String,
+    character_maximum_length: Option<i64>,
+    character_octet_length: Option<i64>,
+    numeric_precision: Option<i64>,
+    numeric_precision_radix: Option<i64>,
+    numeric_scale: Option<i64>,
+    datetime_precision: Option<i64>,
+    udt_name: String,
+    dtd_identifier: String,
+    generated: bool,
+    pub(crate) primary_key_ordinal: Option<i64>,
+}
+
+struct TypeMetadata {
+    data_type: String,
+    character_maximum_length: Option<i64>,
+    character_octet_length: Option<i64>,
+    numeric_precision: Option<i64>,
+    numeric_precision_radix: Option<i64>,
+    numeric_scale: Option<i64>,
+    datetime_precision: Option<i64>,
+    udt_name: String,
+}
+
+impl TypeMetadata {
+    fn new(data_type: &str, udt_name: &str) -> Self {
+        Self {
+            data_type: data_type.into(),
+            character_maximum_length: None,
+            character_octet_length: None,
+            numeric_precision: None,
+            numeric_precision_radix: None,
+            numeric_scale: None,
+            datetime_precision: None,
+            udt_name: udt_name.into(),
+        }
+    }
+}
+
+fn type_modifiers(declared_type: &str) -> (Option<i64>, Option<i64>) {
+    let Some(open) = declared_type.find('(') else {
+        return (None, None);
+    };
+    let Some(close) = declared_type.rfind(')') else {
+        return (None, None);
+    };
+    if close <= open {
+        return (None, None);
+    }
+
+    let mut values = declared_type[open + 1..close]
+        .split(',')
+        .map(str::trim)
+        .map(str::parse::<i64>);
+    (
+        values.next().and_then(Result::ok),
+        values.next().and_then(Result::ok),
+    )
+}
+
+fn postgres_type_metadata(declared_type: &str) -> TypeMetadata {
+    let normalized = declared_type.trim().to_ascii_uppercase();
+    let (first_modifier, second_modifier) = type_modifiers(&normalized);
+
+    if normalized == "JSONB" {
+        TypeMetadata::new("jsonb", "jsonb")
+    } else if normalized == "JSON" {
+        TypeMetadata::new("json", "json")
+    } else if normalized.contains("INT") {
+        let mut metadata = TypeMetadata::new("bigint", "int8");
+        metadata.numeric_precision = Some(64);
+        metadata.numeric_precision_radix = Some(2);
+        metadata.numeric_scale = Some(0);
+        metadata
+    } else if normalized.starts_with("DATETIME") || normalized.starts_with("TIMESTAMP") {
+        let mut metadata = TypeMetadata::new("timestamp without time zone", "timestamp");
+        metadata.datetime_precision = Some(first_modifier.unwrap_or(6));
+        metadata
+    } else if normalized.starts_with("VARCHAR")
+        || normalized.starts_with("CHARACTER VARYING")
+        || normalized.starts_with("CHAR VARYING")
+    {
+        let mut metadata = TypeMetadata::new("character varying", "varchar");
+        metadata.character_maximum_length = first_modifier;
+        metadata.character_octet_length = first_modifier.and_then(|length| length.checked_mul(4));
+        metadata
+    } else if normalized.contains("CLOB") || normalized.contains("TEXT") {
+        TypeMetadata::new("text", "text")
+    } else if normalized.contains("CHAR") {
+        let mut metadata = TypeMetadata::new("character", "bpchar");
+        let length = first_modifier.or(Some(1));
+        metadata.character_maximum_length = length;
+        metadata.character_octet_length = length.and_then(|length| length.checked_mul(4));
+        metadata
+    } else if normalized.is_empty() || normalized.contains("BLOB") || normalized.contains("BINARY")
+    {
+        TypeMetadata::new("bytea", "bytea")
+    } else if normalized.contains("REAL")
+        || normalized.contains("FLOA")
+        || normalized.contains("DOUB")
+    {
+        let mut metadata = TypeMetadata::new("double precision", "float8");
+        metadata.numeric_precision = Some(53);
+        metadata.numeric_precision_radix = Some(2);
+        metadata
+    } else if normalized.starts_with("BOOL") {
+        TypeMetadata::new("boolean", "bool")
+    } else if normalized.starts_with("DECIMAL") || normalized.starts_with("NUMERIC") {
+        let mut metadata = TypeMetadata::new("numeric", "numeric");
+        metadata.numeric_precision = first_modifier;
+        metadata.numeric_precision_radix = Some(10);
+        metadata.numeric_scale = second_modifier;
+        metadata
+    } else if normalized.starts_with("DATE") {
+        TypeMetadata::new("date", "date")
+    } else if normalized.starts_with("TIME") {
+        let mut metadata = TypeMetadata::new("time without time zone", "time");
+        metadata.datetime_precision = Some(first_modifier.unwrap_or(6));
+        metadata
+    } else {
+        let udt_name = normalized
+            .split(|character: char| character == '(' || character.is_ascii_whitespace())
+            .next()
+            .filter(|name| !name.is_empty())
+            .unwrap_or("unknown")
+            .to_ascii_lowercase();
+        TypeMetadata::new("USER-DEFINED", &udt_name)
+    }
+}
+
+pub fn load_information_schema_columns(
+    conn: &rusqlite::Connection,
+    table_names: &[String],
+) -> rusqlite::Result<Vec<InformationSchemaColumn>> {
+    let mut statement = conn.prepare(
+        "SELECT cid, name, type, \"notnull\", dflt_value, pk, hidden
+         FROM pragma_table_xinfo(?1)
+         ORDER BY cid",
+    )?;
+    let mut columns = Vec::new();
+
+    for table_name in table_names {
+        let table_columns = statement
+            .query_map([table_name], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, i64>(6)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        for (cid, column_name, declared_type, not_null, column_default, primary_key, hidden) in
+            table_columns
+        {
+            // Negative column IDs and hidden virtual-table arguments are SQLite implementation
+            // details rather than user-visible table columns. Generated columns use 2 or 3.
+            if cid < 0 || hidden == 1 {
+                continue;
+            }
+
+            let metadata = postgres_type_metadata(declared_type.as_deref().unwrap_or_default());
+            let ordinal_position = cid + 1;
+            columns.push(InformationSchemaColumn {
+                table_name: table_name.clone(),
+                column_name,
+                ordinal_position,
+                column_default,
+                nullable: not_null == 0 && primary_key == 0,
+                data_type: metadata.data_type,
+                character_maximum_length: metadata.character_maximum_length,
+                character_octet_length: metadata.character_octet_length,
+                numeric_precision: metadata.numeric_precision,
+                numeric_precision_radix: metadata.numeric_precision_radix,
+                numeric_scale: metadata.numeric_scale,
+                datetime_precision: metadata.datetime_precision,
+                udt_name: metadata.udt_name,
+                dtd_identifier: ordinal_position.to_string(),
+                generated: matches!(hidden, 2 | 3),
+                primary_key_ordinal: (primary_key > 0).then_some(primary_key),
+            });
+        }
+    }
+
+    Ok(columns)
+}
+
+#[repr(C)]
+pub struct InformationSchemaColumnsTable {
+    /// Base class. Must be first
+    base: sqlite3_vtab,
+    columns: Arc<Vec<InformationSchemaColumn>>,
+}
+
+unsafe impl<'vtab> VTab<'vtab> for InformationSchemaColumnsTable {
+    type Aux = Arc<Vec<InformationSchemaColumn>>;
+    type Cursor = InformationSchemaColumnsCursor<'vtab>;
+
+    fn connect(
+        _: &mut VTabConnection,
+        aux: Option<&Arc<Vec<InformationSchemaColumn>>>,
+        args: &[&[u8]],
+    ) -> rusqlite::Result<(String, InformationSchemaColumnsTable)> {
+        let vtab = InformationSchemaColumnsTable {
+            base: sqlite3_vtab::default(),
+            columns: aux.unwrap().clone(),
+        };
+        let table_name = std::str::from_utf8(args[0]).map_err(rusqlite::Error::Utf8Error)?;
+
+        Ok((
+            format!(
+                "CREATE TABLE {table_name} (
+                    table_catalog            TEXT,
+                    table_schema             TEXT,
+                    table_name               TEXT,
+                    column_name              TEXT,
+                    ordinal_position         INTEGER,
+                    column_default           TEXT,
+                    is_nullable              TEXT,
+                    data_type                TEXT,
+                    character_maximum_length INTEGER,
+                    character_octet_length   INTEGER,
+                    numeric_precision        INTEGER,
+                    numeric_precision_radix  INTEGER,
+                    numeric_scale            INTEGER,
+                    datetime_precision       INTEGER,
+                    interval_type            TEXT,
+                    interval_precision       INTEGER,
+                    character_set_catalog    TEXT,
+                    character_set_schema     TEXT,
+                    character_set_name       TEXT,
+                    collation_catalog        TEXT,
+                    collation_schema         TEXT,
+                    collation_name           TEXT,
+                    domain_catalog           TEXT,
+                    domain_schema            TEXT,
+                    domain_name              TEXT,
+                    udt_catalog              TEXT,
+                    udt_schema               TEXT,
+                    udt_name                 TEXT,
+                    scope_catalog            TEXT,
+                    scope_schema             TEXT,
+                    scope_name               TEXT,
+                    maximum_cardinality      INTEGER,
+                    dtd_identifier           TEXT,
+                    is_self_referencing      TEXT,
+                    is_identity              TEXT,
+                    identity_generation      TEXT,
+                    identity_start           TEXT,
+                    identity_increment       TEXT,
+                    identity_maximum         TEXT,
+                    identity_minimum         TEXT,
+                    identity_cycle           TEXT,
+                    is_generated             TEXT,
+                    generation_expression    TEXT,
+                    is_updatable             TEXT
+                )"
+            ),
+            vtab,
+        ))
+    }
+
+    fn best_index(&self, info: &mut IndexInfo) -> rusqlite::Result<()> {
+        info.set_estimated_cost(1.);
+        Ok(())
+    }
+
+    fn open(&'vtab mut self) -> rusqlite::Result<InformationSchemaColumnsCursor<'vtab>> {
+        Ok(InformationSchemaColumnsCursor {
+            columns: self.columns.as_slice(),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct InformationSchemaColumnsCursor<'vtab> {
+    /// Base class. Must be first
+    base: sqlite3_vtab_cursor,
+    row_id: i64,
+    columns: &'vtab [InformationSchemaColumn],
+    phantom: PhantomData<&'vtab InformationSchemaColumnsTable>,
+}
+
+unsafe impl VTabCursor for InformationSchemaColumnsCursor<'_> {
+    fn filter(
+        &mut self,
+        _idx_num: c_int,
+        _idx_str: Option<&str>,
+        _args: &Filters<'_>,
+    ) -> rusqlite::Result<()> {
+        self.row_id = 0;
+        Ok(())
+    }
+
+    fn next(&mut self) -> rusqlite::Result<()> {
+        self.row_id += 1;
+        Ok(())
+    }
+
+    fn eof(&self) -> bool {
+        self.row_id >= self.columns.len() as i64
+    }
+
+    fn column(&self, ctx: &mut rusqlite::vtab::Context, col: c_int) -> rusqlite::Result<()> {
+        if let Some(column) = self.columns.get(self.row_id as usize) {
+            match col {
+                0 => ctx.set_result(&"state"),
+                1 => ctx.set_result(&"public"),
+                2 => ctx.set_result(&column.table_name),
+                3 => ctx.set_result(&column.column_name),
+                4 => ctx.set_result(&column.ordinal_position),
+                5 => ctx.set_result(&column.column_default),
+                6 => ctx.set_result(&if column.nullable { "YES" } else { "NO" }),
+                7 => ctx.set_result(&column.data_type),
+                8 => ctx.set_result(&column.character_maximum_length),
+                9 => ctx.set_result(&column.character_octet_length),
+                10 => ctx.set_result(&column.numeric_precision),
+                11 => ctx.set_result(&column.numeric_precision_radix),
+                12 => ctx.set_result(&column.numeric_scale),
+                13 => ctx.set_result(&column.datetime_precision),
+                14 => ctx.set_result(&Option::<String>::None),
+                15 => ctx.set_result(&Option::<i64>::None),
+                16..=24 | 28..=30 => ctx.set_result(&Option::<String>::None),
+                25 => ctx.set_result(&"state"),
+                26 => ctx.set_result(&"pg_catalog"),
+                27 => ctx.set_result(&column.udt_name),
+                31 => ctx.set_result(&Option::<i64>::None),
+                32 => ctx.set_result(&column.dtd_identifier),
+                33 | 34 => ctx.set_result(&"NO"),
+                35..=40 => ctx.set_result(&Option::<String>::None),
+                41 => ctx.set_result(&if column.generated { "ALWAYS" } else { "NEVER" }),
+                42 => ctx.set_result(&Option::<String>::None),
+                43 => ctx.set_result(&"YES"),
+                _ => Err(rusqlite::Error::InvalidColumnIndex(col as usize)),
+            }
+        } else {
+            Err(rusqlite::Error::ModuleError(format!(
+                "information schema column out of bound (row id: {})",
+                self.row_id
+            )))
+        }
+    }
+
+    fn rowid(&self) -> rusqlite::Result<i64> {
+        Ok(self.row_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::postgres_type_metadata;
+
+    #[test]
+    fn maps_sqlite_declared_types_to_postgres_catalog_types() {
+        let bigint = postgres_type_metadata("INTEGER");
+        assert_eq!(bigint.data_type, "bigint");
+        assert_eq!(bigint.udt_name, "int8");
+        assert_eq!(bigint.numeric_precision, Some(64));
+
+        let varchar = postgres_type_metadata("VARCHAR(255)");
+        assert_eq!(varchar.data_type, "character varying");
+        assert_eq!(varchar.character_maximum_length, Some(255));
+
+        let timestamp = postgres_type_metadata("DATETIME");
+        assert_eq!(timestamp.data_type, "timestamp without time zone");
+        assert_eq!(timestamp.datetime_precision, Some(6));
+
+        let float = postgres_type_metadata("REAL");
+        assert_eq!(float.data_type, "double precision");
+        assert_eq!(float.udt_name, "float8");
+    }
+}

--- a/crates/corro-pg/src/vtab/information_schema_columns.rs
+++ b/crates/corro-pg/src/vtab/information_schema_columns.rs
@@ -323,7 +323,7 @@ unsafe impl VTabCursor for InformationSchemaColumnsCursor<'_> {
         if let Some(column) = self.columns.get(self.row_id as usize) {
             match col {
                 0 => ctx.set_result(&"state"),
-                1 => ctx.set_result(&"public"),
+                1 => ctx.set_result(&"main"),
                 2 => ctx.set_result(&column.table_name),
                 3 => ctx.set_result(&column.column_name),
                 4 => ctx.set_result(&column.ordinal_position),

--- a/crates/corro-pg/src/vtab/information_schema_table_constraints.rs
+++ b/crates/corro-pg/src/vtab/information_schema_table_constraints.rs
@@ -118,7 +118,7 @@ unsafe impl VTabCursor for InformationSchemaTableConstraintsCursor<'_> {
         if let Some(constraint) = self.constraints.get(self.row_id as usize) {
             match col {
                 0 | 3 => ctx.set_result(&"state"),
-                1 | 4 => ctx.set_result(&"public"),
+                1 | 4 => ctx.set_result(&"main"),
                 2 => ctx.set_result(&constraint.constraint_name),
                 5 => ctx.set_result(&constraint.table_name),
                 6 => ctx.set_result(&"PRIMARY KEY"),

--- a/crates/corro-pg/src/vtab/information_schema_table_constraints.rs
+++ b/crates/corro-pg/src/vtab/information_schema_table_constraints.rs
@@ -1,0 +1,140 @@
+use std::{collections::BTreeSet, marker::PhantomData, os::raw::c_int, sync::Arc};
+
+use rusqlite::vtab::{
+    sqlite3_vtab, sqlite3_vtab_cursor, Filters, IndexInfo, VTab, VTabConnection, VTabCursor,
+};
+
+use super::information_schema_columns::InformationSchemaColumn;
+
+pub struct InformationSchemaTableConstraint {
+    table_name: String,
+    constraint_name: String,
+}
+
+pub fn load_information_schema_table_constraints(
+    columns: &[InformationSchemaColumn],
+) -> Vec<InformationSchemaTableConstraint> {
+    let mut primary_key_tables = BTreeSet::new();
+    for column in columns {
+        if column.primary_key_ordinal.is_some() {
+            primary_key_tables.insert(column.table_name.clone());
+        }
+    }
+
+    primary_key_tables
+        .into_iter()
+        .map(|table_name| InformationSchemaTableConstraint {
+            constraint_name: format!("{table_name}_pkey"),
+            table_name,
+        })
+        .collect()
+}
+
+#[repr(C)]
+pub struct InformationSchemaTableConstraintsTable {
+    /// Base class. Must be first
+    base: sqlite3_vtab,
+    constraints: Arc<Vec<InformationSchemaTableConstraint>>,
+}
+
+unsafe impl<'vtab> VTab<'vtab> for InformationSchemaTableConstraintsTable {
+    type Aux = Arc<Vec<InformationSchemaTableConstraint>>;
+    type Cursor = InformationSchemaTableConstraintsCursor<'vtab>;
+
+    fn connect(
+        _: &mut VTabConnection,
+        aux: Option<&Arc<Vec<InformationSchemaTableConstraint>>>,
+        args: &[&[u8]],
+    ) -> rusqlite::Result<(String, InformationSchemaTableConstraintsTable)> {
+        let vtab = InformationSchemaTableConstraintsTable {
+            base: sqlite3_vtab::default(),
+            constraints: aux.unwrap().clone(),
+        };
+        let table_name = std::str::from_utf8(args[0]).map_err(rusqlite::Error::Utf8Error)?;
+
+        Ok((
+            format!(
+                "CREATE TABLE {table_name} (
+                    constraint_catalog TEXT,
+                    constraint_schema  TEXT,
+                    constraint_name    TEXT,
+                    table_catalog      TEXT,
+                    table_schema       TEXT,
+                    table_name         TEXT,
+                    constraint_type    TEXT,
+                    is_deferrable      TEXT,
+                    initially_deferred TEXT,
+                    enforced           TEXT
+                )"
+            ),
+            vtab,
+        ))
+    }
+
+    fn best_index(&self, info: &mut IndexInfo) -> rusqlite::Result<()> {
+        info.set_estimated_cost(1.);
+        Ok(())
+    }
+
+    fn open(&'vtab mut self) -> rusqlite::Result<InformationSchemaTableConstraintsCursor<'vtab>> {
+        Ok(InformationSchemaTableConstraintsCursor {
+            constraints: self.constraints.as_slice(),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct InformationSchemaTableConstraintsCursor<'vtab> {
+    /// Base class. Must be first
+    base: sqlite3_vtab_cursor,
+    row_id: i64,
+    constraints: &'vtab [InformationSchemaTableConstraint],
+    phantom: PhantomData<&'vtab InformationSchemaTableConstraintsTable>,
+}
+
+unsafe impl VTabCursor for InformationSchemaTableConstraintsCursor<'_> {
+    fn filter(
+        &mut self,
+        _idx_num: c_int,
+        _idx_str: Option<&str>,
+        _args: &Filters<'_>,
+    ) -> rusqlite::Result<()> {
+        self.row_id = 0;
+        Ok(())
+    }
+
+    fn next(&mut self) -> rusqlite::Result<()> {
+        self.row_id += 1;
+        Ok(())
+    }
+
+    fn eof(&self) -> bool {
+        self.row_id >= self.constraints.len() as i64
+    }
+
+    fn column(&self, ctx: &mut rusqlite::vtab::Context, col: c_int) -> rusqlite::Result<()> {
+        if let Some(constraint) = self.constraints.get(self.row_id as usize) {
+            match col {
+                0 | 3 => ctx.set_result(&"state"),
+                1 | 4 => ctx.set_result(&"public"),
+                2 => ctx.set_result(&constraint.constraint_name),
+                5 => ctx.set_result(&constraint.table_name),
+                6 => ctx.set_result(&"PRIMARY KEY"),
+                7 | 8 => ctx.set_result(&"NO"),
+                9 => ctx.set_result(&"YES"),
+                _ => Err(rusqlite::Error::InvalidColumnIndex(col as usize)),
+            }
+        } else {
+            Err(rusqlite::Error::ModuleError(format!(
+                "information schema table constraint out of bound (row id: {})",
+                self.row_id
+            )))
+        }
+    }
+
+    fn rowid(&self) -> rusqlite::Result<i64> {
+        Ok(self.row_id)
+    }
+}

--- a/crates/corro-pg/src/vtab/information_schema_tables.rs
+++ b/crates/corro-pg/src/vtab/information_schema_tables.rs
@@ -103,7 +103,7 @@ unsafe impl VTabCursor for InformationSchemaTablesCursor<'_> {
         if let Some(table_name) = self.table_names.get(self.row_id as usize) {
             match col {
                 0 => ctx.set_result(&"state"),
-                1 => ctx.set_result(&"public"),
+                1 => ctx.set_result(&"main"),
                 2 => ctx.set_result(table_name),
                 3 => ctx.set_result(&"BASE TABLE"),
                 4..=8 | 11 => ctx.set_result(&Option::<String>::None),

--- a/crates/corro-pg/src/vtab/information_schema_tables.rs
+++ b/crates/corro-pg/src/vtab/information_schema_tables.rs
@@ -4,6 +4,14 @@ use rusqlite::vtab::{
     sqlite3_vtab, sqlite3_vtab_cursor, Filters, IndexInfo, VTab, VTabConnection, VTabCursor,
 };
 
+pub fn load_information_schema_table_names(
+    conn: &rusqlite::Connection,
+) -> rusqlite::Result<Vec<String>> {
+    conn.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")?
+        .query_map([], |row| row.get(0))?
+        .collect()
+}
+
 #[repr(C)]
 pub struct InformationSchemaTablesTable {
     /// Base class. Must be first

--- a/crates/corro-pg/src/vtab/information_schema_tables.rs
+++ b/crates/corro-pg/src/vtab/information_schema_tables.rs
@@ -1,0 +1,117 @@
+use std::{marker::PhantomData, os::raw::c_int, sync::Arc};
+
+use rusqlite::vtab::{
+    sqlite3_vtab, sqlite3_vtab_cursor, Filters, IndexInfo, VTab, VTabConnection, VTabCursor,
+};
+
+#[repr(C)]
+pub struct InformationSchemaTablesTable {
+    /// Base class. Must be first
+    base: sqlite3_vtab,
+    table_names: Arc<Vec<String>>,
+}
+
+unsafe impl<'vtab> VTab<'vtab> for InformationSchemaTablesTable {
+    type Aux = Arc<Vec<String>>;
+    type Cursor = InformationSchemaTablesCursor<'vtab>;
+
+    fn connect(
+        _: &mut VTabConnection,
+        aux: Option<&Arc<Vec<String>>>,
+        args: &[&[u8]],
+    ) -> rusqlite::Result<(String, InformationSchemaTablesTable)> {
+        let vtab = InformationSchemaTablesTable {
+            base: sqlite3_vtab::default(),
+            table_names: aux.unwrap().clone(),
+        };
+
+        let table_name = std::str::from_utf8(args[0]).map_err(rusqlite::Error::Utf8Error)?;
+
+        Ok((
+            format!(
+                "CREATE TABLE {table_name} (
+                    table_catalog                TEXT,
+                    table_schema                 TEXT,
+                    table_name                   TEXT,
+                    table_type                   TEXT,
+                    self_referencing_column_name TEXT,
+                    reference_generation         TEXT,
+                    user_defined_type_catalog    TEXT,
+                    user_defined_type_schema     TEXT,
+                    user_defined_type_name       TEXT,
+                    is_insertable_into            TEXT,
+                    is_typed                      TEXT,
+                    commit_action                 TEXT
+                )"
+            ),
+            vtab,
+        ))
+    }
+
+    fn best_index(&self, info: &mut IndexInfo) -> rusqlite::Result<()> {
+        info.set_estimated_cost(1.);
+        Ok(())
+    }
+
+    fn open(&'vtab mut self) -> rusqlite::Result<InformationSchemaTablesCursor<'vtab>> {
+        Ok(InformationSchemaTablesCursor {
+            table_names: self.table_names.as_slice(),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct InformationSchemaTablesCursor<'vtab> {
+    /// Base class. Must be first
+    base: sqlite3_vtab_cursor,
+    row_id: i64,
+    table_names: &'vtab [String],
+    phantom: PhantomData<&'vtab InformationSchemaTablesTable>,
+}
+
+unsafe impl VTabCursor for InformationSchemaTablesCursor<'_> {
+    fn filter(
+        &mut self,
+        _idx_num: c_int,
+        _idx_str: Option<&str>,
+        _args: &Filters<'_>,
+    ) -> rusqlite::Result<()> {
+        self.row_id = 0;
+        Ok(())
+    }
+
+    fn next(&mut self) -> rusqlite::Result<()> {
+        self.row_id += 1;
+        Ok(())
+    }
+
+    fn eof(&self) -> bool {
+        self.row_id >= self.table_names.len() as i64
+    }
+
+    fn column(&self, ctx: &mut rusqlite::vtab::Context, col: c_int) -> rusqlite::Result<()> {
+        if let Some(table_name) = self.table_names.get(self.row_id as usize) {
+            match col {
+                0 => ctx.set_result(&"state"),
+                1 => ctx.set_result(&"public"),
+                2 => ctx.set_result(table_name),
+                3 => ctx.set_result(&"BASE TABLE"),
+                4..=8 | 11 => ctx.set_result(&Option::<String>::None),
+                9 => ctx.set_result(&"YES"),
+                10 => ctx.set_result(&"NO"),
+                _ => Err(rusqlite::Error::InvalidColumnIndex(col as usize)),
+            }
+        } else {
+            Err(rusqlite::Error::ModuleError(format!(
+                "information schema table out of bound (row id: {})",
+                self.row_id
+            )))
+        }
+    }
+
+    fn rowid(&self) -> rusqlite::Result<i64> {
+        Ok(self.row_id)
+    }
+}

--- a/crates/corro-pg/src/vtab/mod.rs
+++ b/crates/corro-pg/src/vtab/mod.rs
@@ -1,3 +1,4 @@
+pub mod information_schema_tables;
 pub mod pg_class;
 pub mod pg_database;
 pub mod pg_namespace;

--- a/crates/corro-pg/src/vtab/mod.rs
+++ b/crates/corro-pg/src/vtab/mod.rs
@@ -1,3 +1,5 @@
+pub mod information_schema_columns;
+pub mod information_schema_table_constraints;
 pub mod information_schema_tables;
 pub mod pg_class;
 pub mod pg_database;

--- a/crates/corro-pg/src/vtab/pg_namespace.rs
+++ b/crates/corro-pg/src/vtab/pg_namespace.rs
@@ -7,7 +7,7 @@ use rusqlite::vtab::{
 const PG_NAMESPACES: &[(i64, &str, i64, &str)] = &[
     (99, "pg_toast", 10, ""),
     (11, "pg_catalog", 10, ""),
-    (2200, "public", 10, ""),
+    (2200, "main", 10, ""),
     (13427, "information_schema", 10, ""),
 ];
 

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -75,6 +75,75 @@ async fn setup_pg_test_server(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_information_schema_tables() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+    let (client, connection) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(connection);
+
+    let rows = client
+        .query(
+            "SELECT table_catalog, table_schema, table_name, table_type, \
+             self_referencing_column_name, reference_generation, \
+             user_defined_type_catalog, user_defined_type_schema, user_defined_type_name, \
+             is_insertable_into, is_typed, commit_action \
+             FROM information_schema.tables \
+             WHERE table_schema = 'public' AND table_type = 'BASE TABLE' \
+             ORDER BY table_name",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let table_names = rows
+        .iter()
+        .map(|row| row.get::<_, String>("table_name"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        table_names,
+        [
+            "kitchensink",
+            "tests",
+            "tests2",
+            "tests3",
+            "testsblob",
+            "testsbool",
+            "wide",
+        ]
+    );
+
+    for row in rows {
+        assert_eq!(row.get::<_, &str>("table_catalog"), "state");
+        assert_eq!(row.get::<_, &str>("table_schema"), "public");
+        assert_eq!(row.get::<_, &str>("table_type"), "BASE TABLE");
+        assert_eq!(row.get::<_, &str>("is_insertable_into"), "YES");
+        assert_eq!(row.get::<_, &str>("is_typed"), "NO");
+        assert_eq!(
+            row.get::<_, Option<&str>>("self_referencing_column_name"),
+            None
+        );
+        assert_eq!(row.get::<_, Option<&str>>("reference_generation"), None);
+        assert_eq!(
+            row.get::<_, Option<&str>>("user_defined_type_catalog"),
+            None
+        );
+        assert_eq!(row.get::<_, Option<&str>>("user_defined_type_schema"), None);
+        assert_eq!(row.get::<_, Option<&str>>("user_defined_type_name"), None);
+        assert_eq!(row.get::<_, Option<&str>>("commit_action"), None);
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
 

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -89,12 +89,28 @@ async fn test_information_schema() {
 
     let rows = client
         .query(
+            "SELECT nspname FROM pg_catalog.pg_namespace \
+             WHERE nspname IN ('main', 'public') \
+             ORDER BY nspname",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.iter()
+            .map(|row| row.get::<_, &str>("nspname"))
+            .collect::<Vec<_>>(),
+        ["main"]
+    );
+
+    let rows = client
+        .query(
             "SELECT table_catalog, table_schema, table_name, table_type, \
              self_referencing_column_name, reference_generation, \
              user_defined_type_catalog, user_defined_type_schema, user_defined_type_name, \
              is_insertable_into, is_typed, commit_action \
              FROM information_schema.tables \
-             WHERE table_schema = 'public' AND table_type = 'BASE TABLE' \
+             WHERE table_schema = 'main' AND table_type = 'BASE TABLE' \
              ORDER BY table_name",
             &[],
         )
@@ -121,7 +137,7 @@ async fn test_information_schema() {
 
     for row in rows {
         assert_eq!(row.get::<_, &str>("table_catalog"), "state");
-        assert_eq!(row.get::<_, &str>("table_schema"), "public");
+        assert_eq!(row.get::<_, &str>("table_schema"), "main");
         assert_eq!(row.get::<_, &str>("table_type"), "BASE TABLE");
         assert_eq!(row.get::<_, &str>("is_insertable_into"), "YES");
         assert_eq!(row.get::<_, &str>("is_typed"), "NO");
@@ -142,7 +158,7 @@ async fn test_information_schema() {
     let rows = client
         .query(
             "SELECT * FROM information_schema.columns \
-             WHERE table_schema = 'public' AND table_name = 'kitchensink' \
+             WHERE table_schema = 'main' AND table_name = 'kitchensink' \
              ORDER BY ordinal_position",
             &[],
         )
@@ -153,7 +169,7 @@ async fn test_information_schema() {
 
     let id = &rows[0];
     assert_eq!(id.get::<_, &str>("table_catalog"), "state");
-    assert_eq!(id.get::<_, &str>("table_schema"), "public");
+    assert_eq!(id.get::<_, &str>("table_schema"), "main");
     assert_eq!(id.get::<_, &str>("table_name"), "kitchensink");
     assert_eq!(id.get::<_, &str>("column_name"), "id");
     assert_eq!(id.get::<_, i64>("ordinal_position"), 1);
@@ -211,7 +227,7 @@ async fn test_information_schema() {
     let rows = client
         .query(
             "SELECT * FROM information_schema.table_constraints \
-             WHERE table_schema = 'public' \
+             WHERE table_schema = 'main' \
              AND table_name IN ('kitchensink', 'wide') \
              ORDER BY table_name",
             &[],
@@ -223,13 +239,13 @@ async fn test_information_schema() {
 
     for (row, table_name) in rows.iter().zip(["kitchensink", "wide"]) {
         assert_eq!(row.get::<_, &str>("constraint_catalog"), "state");
-        assert_eq!(row.get::<_, &str>("constraint_schema"), "public");
+        assert_eq!(row.get::<_, &str>("constraint_schema"), "main");
         assert_eq!(
             row.get::<_, &str>("constraint_name"),
             format!("{table_name}_pkey")
         );
         assert_eq!(row.get::<_, &str>("table_catalog"), "state");
-        assert_eq!(row.get::<_, &str>("table_schema"), "public");
+        assert_eq!(row.get::<_, &str>("table_schema"), "main");
         assert_eq!(row.get::<_, &str>("table_name"), table_name);
         assert_eq!(row.get::<_, &str>("constraint_type"), "PRIMARY KEY");
         assert_eq!(row.get::<_, &str>("is_deferrable"), "NO");

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -75,7 +75,7 @@ async fn setup_pg_test_server(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_information_schema_tables() {
+async fn test_information_schema() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
 
     let (_ta, server) = setup_pg_test_server(tripwire, None).await;
@@ -105,18 +105,19 @@ async fn test_information_schema_tables() {
         .iter()
         .map(|row| row.get::<_, String>("table_name"))
         .collect::<Vec<_>>();
-    assert_eq!(
-        table_names,
-        [
-            "kitchensink",
-            "tests",
-            "tests2",
-            "tests3",
-            "testsblob",
-            "testsbool",
-            "wide",
-        ]
-    );
+    for expected in [
+        "__corro_schema",
+        "kitchensink",
+        "kitchensink__crsql_clock",
+        "kitchensink__crsql_pks",
+        "tests",
+        "wide",
+    ] {
+        assert!(
+            table_names.iter().any(|table_name| table_name == expected),
+            "missing {expected} from information_schema.tables"
+        );
+    }
 
     for row in rows {
         assert_eq!(row.get::<_, &str>("table_catalog"), "state");
@@ -136,6 +137,104 @@ async fn test_information_schema_tables() {
         assert_eq!(row.get::<_, Option<&str>>("user_defined_type_schema"), None);
         assert_eq!(row.get::<_, Option<&str>>("user_defined_type_name"), None);
         assert_eq!(row.get::<_, Option<&str>>("commit_action"), None);
+    }
+
+    let rows = client
+        .query(
+            "SELECT * FROM information_schema.columns \
+             WHERE table_schema = 'public' AND table_name = 'kitchensink' \
+             ORDER BY ordinal_position",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 4);
+    assert_eq!(rows[0].columns().len(), 44);
+
+    let id = &rows[0];
+    assert_eq!(id.get::<_, &str>("table_catalog"), "state");
+    assert_eq!(id.get::<_, &str>("table_schema"), "public");
+    assert_eq!(id.get::<_, &str>("table_name"), "kitchensink");
+    assert_eq!(id.get::<_, &str>("column_name"), "id");
+    assert_eq!(id.get::<_, i64>("ordinal_position"), 1);
+    assert_eq!(id.get::<_, Option<&str>>("column_default"), None);
+    assert_eq!(id.get::<_, &str>("is_nullable"), "NO");
+    assert_eq!(id.get::<_, &str>("data_type"), "bigint");
+    assert_eq!(id.get::<_, Option<i64>>("numeric_precision"), Some(64));
+    assert_eq!(id.get::<_, Option<i64>>("numeric_precision_radix"), Some(2));
+    assert_eq!(id.get::<_, Option<i64>>("numeric_scale"), Some(0));
+    assert_eq!(id.get::<_, &str>("udt_catalog"), "state");
+    assert_eq!(id.get::<_, &str>("udt_schema"), "pg_catalog");
+    assert_eq!(id.get::<_, &str>("udt_name"), "int8");
+    assert_eq!(id.get::<_, &str>("dtd_identifier"), "1");
+    assert_eq!(id.get::<_, &str>("is_identity"), "NO");
+    assert_eq!(id.get::<_, &str>("is_generated"), "NEVER");
+    assert_eq!(id.get::<_, &str>("is_updatable"), "YES");
+
+    let other_ts = &rows[1];
+    assert_eq!(other_ts.get::<_, &str>("column_name"), "other_ts");
+    assert_eq!(other_ts.get::<_, &str>("is_nullable"), "YES");
+    assert_eq!(
+        other_ts.get::<_, &str>("data_type"),
+        "timestamp without time zone"
+    );
+    assert_eq!(other_ts.get::<_, &str>("udt_name"), "timestamp");
+    assert_eq!(
+        other_ts.get::<_, Option<i64>>("datetime_precision"),
+        Some(6)
+    );
+
+    let updated_at = &rows[2];
+    assert_eq!(updated_at.get::<_, &str>("column_name"), "updated_at");
+    assert_eq!(updated_at.get::<_, &str>("is_nullable"), "NO");
+    assert_eq!(
+        updated_at.get::<_, Option<&str>>("column_default"),
+        Some("CURRENT_TIMESTAMP")
+    );
+
+    let trusted = &rows[3];
+    assert_eq!(trusted.get::<_, &str>("column_name"), "trusted");
+    assert_eq!(trusted.get::<_, &str>("data_type"), "boolean");
+    assert_eq!(trusted.get::<_, &str>("udt_name"), "bool");
+
+    let internal_columns = client
+        .query(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_name = 'kitchensink__crsql_pks' \
+             ORDER BY ordinal_position",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(!internal_columns.is_empty());
+
+    let rows = client
+        .query(
+            "SELECT * FROM information_schema.table_constraints \
+             WHERE table_schema = 'public' \
+             AND table_name IN ('kitchensink', 'wide') \
+             ORDER BY table_name",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].columns().len(), 10);
+
+    for (row, table_name) in rows.iter().zip(["kitchensink", "wide"]) {
+        assert_eq!(row.get::<_, &str>("constraint_catalog"), "state");
+        assert_eq!(row.get::<_, &str>("constraint_schema"), "public");
+        assert_eq!(
+            row.get::<_, &str>("constraint_name"),
+            format!("{table_name}_pkey")
+        );
+        assert_eq!(row.get::<_, &str>("table_catalog"), "state");
+        assert_eq!(row.get::<_, &str>("table_schema"), "public");
+        assert_eq!(row.get::<_, &str>("table_name"), table_name);
+        assert_eq!(row.get::<_, &str>("constraint_type"), "PRIMARY KEY");
+        assert_eq!(row.get::<_, &str>("is_deferrable"), "NO");
+        assert_eq!(row.get::<_, &str>("initially_deferred"), "NO");
+        assert_eq!(row.get::<_, &str>("enforced"), "YES");
     }
 
     tripwire_tx.send(()).await.ok();


### PR DESCRIPTION
## Summary

- attach an `information_schema` catalog for PostgreSQL listener sessions
- populate `information_schema.tables` directly from `sqlite_master`, including Corrosion and CR-SQLite internal tables
- expose PostgreSQL 14-compatible `information_schema.columns` metadata and primary-key rows through `information_schema.table_constraints`
- add PostgreSQL-wire integration coverage for user/internal table discovery, column metadata, and single/composite primary keys

Fixes #372

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p corro-pg --all-targets -- -D warnings`
- `cargo nextest run --profile ci -p corro-pg`
- `git diff --check`
