### PR TITLE
Distinguish metadata and data ops when inserting foreign changes

### DIFF
--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, Ordering},
     time::{Duration, Instant},
 };
 
@@ -33,6 +34,14 @@ pub static IN_FLIGHT_QUERIES: ThreadLocal<Mutex<InFlightQueries>> = ThreadLocal:
 // Aggregate stats for subscription matcher connections (no per-query breakdown)
 static SUBS_QUERY_STATS: ThreadLocal<Mutex<(u64, u128)>> = ThreadLocal::new(); // (count, nanos)
 
+// Flags for tracking crsql_changes application scope (RW connection only)
+static IN_CHANGES_SCOPE: AtomicBool = AtomicBool::new(false);
+static IN_DATA_MODE: AtomicBool = AtomicBool::new(false);
+
+// Per-thread stats for data vs metadata during crsql_changes application
+static CHANGES_DATA_STATS: ThreadLocal<Mutex<(u64, u128)>> = ThreadLocal::new(); // (count, nanos)
+static CHANGES_META_STATS: ThreadLocal<Mutex<(u64, u128)>> = ThreadLocal::new();
+
 pub async fn query_metrics_loop(mut tripwire: Tripwire) {
     let mut interval = tokio::time::interval(Duration::from_secs(10));
     let mut prev_tick = interval.tick().await;
@@ -43,6 +52,7 @@ pub async fn query_metrics_loop(mut tripwire: Tripwire) {
             prev_tick = t;
             handle_query_metrics(elapsed);
             handle_subs_query_metrics();
+            handle_changes_metrics();
             },
             _ = &mut tripwire => break,
         }
@@ -126,6 +136,25 @@ fn tracing_callback_rw(ev: rusqlite::trace::TraceEvent) {
     handle_sql_tracing_event(ev, false);
 }
 
+fn is_crsql_changes_insert(sql: &str) -> bool {
+    let lower = sql.to_lowercase();
+    lower.contains("insert") && lower.contains("crsql_changes")
+}
+
+/// Returns `Some(true)` for `crsql_internal_sync_bit(1)`,
+/// `Some(false)` for `crsql_internal_sync_bit(0)`,
+/// `None` if not a sync_bit call.
+fn sync_bit_value(sql: &str) -> Option<bool> {
+    let lower = sql.to_lowercase();
+    if lower.contains("crsql_internal_sync_bit(1)") {
+        Some(true)
+    } else if lower.contains("crsql_internal_sync_bit(0)") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
 fn handle_sql_tracing_event(ev: rusqlite::trace::TraceEvent, readonly: bool) {
     match ev {
         rusqlite::trace::TraceEvent::Profile(stmt_ref, duration) => {
@@ -142,6 +171,34 @@ fn handle_sql_tracing_event(ev: rusqlite::trace::TraceEvent, readonly: bool) {
             entry.1 += dur;
             drop(stats); // Release lock quickly
 
+            // Classify data vs metadata during crsql_changes application (RW only)
+            if !readonly {
+                if is_crsql_changes_insert(&sql) {
+                    // Outer INSERT statement completes - reset scope.
+                    // Skip counting this statement: its duration includes all substatements.
+                    IN_CHANGES_SCOPE.store(false, Ordering::Relaxed);
+                    IN_DATA_MODE.store(false, Ordering::Relaxed);
+                } else if IN_CHANGES_SCOPE.load(Ordering::Relaxed) {
+                    if sync_bit_value(&sql).is_some() {
+                        // sync_bit calls are always metadata
+                        let meta = CHANGES_META_STATS.get_or_default();
+                        let mut m = meta.lock();
+                        m.0 += 1;
+                        m.1 += dur;
+                    } else if IN_DATA_MODE.load(Ordering::Relaxed) {
+                        let data = CHANGES_DATA_STATS.get_or_default();
+                        let mut d = data.lock();
+                        d.0 += 1;
+                        d.1 += dur;
+                    } else {
+                        let meta = CHANGES_META_STATS.get_or_default();
+                        let mut m = meta.lock();
+                        m.0 += 1;
+                        m.1 += dur;
+                    }
+                }
+            }
+
             let queries_mu = IN_FLIGHT_QUERIES.get_or_default();
             let mut inflight_queries = queries_mu.lock();
             inflight_queries.remove(&sql);
@@ -156,6 +213,20 @@ fn handle_sql_tracing_event(ev: rusqlite::trace::TraceEvent, readonly: bool) {
             }
         }
         rusqlite::trace::TraceEvent::Stmt(_, sql) => {
+            // Track crsql_changes scope and sync_bit mode (RW only)
+            if !readonly {
+                if is_crsql_changes_insert(sql) {
+                    IN_CHANGES_SCOPE.store(true, Ordering::Relaxed);
+                    IN_DATA_MODE.store(false, Ordering::Relaxed);
+                } else if let Some(val) = IN_CHANGES_SCOPE
+                    .load(Ordering::Relaxed)
+                    .then(|| sync_bit_value(sql))
+                    .flatten()
+                {
+                    IN_DATA_MODE.store(val, Ordering::Relaxed);
+                }
+            }
+
             // skip trigger for subprograms.
             if sql.starts_with("--") {
                 return;
@@ -239,6 +310,33 @@ fn handle_subs_query_metrics() {
     let total_ms = (total_nanos / 1_000_000) as u64;
     counter!("corro.subs.db.query.ms").increment(total_ms);
     counter!("corro.subs.db.query.count").increment(total_count);
+}
+
+fn handle_changes_metrics() {
+    let mut data_count = 0u64;
+    let mut data_nanos = 0u128;
+    for stats_mutex in CHANGES_DATA_STATS.iter() {
+        let mut stats = stats_mutex.lock();
+        data_count += stats.0;
+        data_nanos += stats.1;
+        *stats = (0, 0);
+    }
+
+    let mut meta_count = 0u64;
+    let mut meta_nanos = 0u128;
+    for stats_mutex in CHANGES_META_STATS.iter() {
+        let mut stats = stats_mutex.lock();
+        meta_count += stats.0;
+        meta_nanos += stats.1;
+        *stats = (0, 0);
+    }
+
+    let data_ms = (data_nanos / 1_000_000) as u64;
+    let meta_ms = (meta_nanos / 1_000_000) as u64;
+    counter!("corro.db.crsql_changes.data.ms").increment(data_ms);
+    counter!("corro.db.crsql_changes.data.count").increment(data_count);
+    counter!("corro.db.crsql_changes.metadata.ms").increment(meta_ms);
+    counter!("corro.db.crsql_changes.metadata.count").increment(meta_count);
 }
 
 const CRSQL_EXT_GENERIC_NAME: &str = "crsqlite";


### PR DESCRIPTION
Breaks down query metrics for 'INSERT INTO crsql_changes ...` into 2 parts:

- `corro.db.crsql_changes.data.ms` - how much time did we spent mutating the real data
- `corro.db.crsql_changes.data.count` - how many statements did mutate the real data
- `corro.db.crsql_changes.metadata.ms` - how much time did we spent mutating/accessing the crsqlite metadata
- `corro.db.crsql_changes.metadata.count` - how many statements did mutate or access the crsqlite metadata the real data

The detection works by detecting when crsqlite suppresses it's triggers for propagating local writes, meaning crsqlite is about to write to the underlaying base tables.