### PR TITLE
Retry buffered partials after schema changes

### DIFF
--- a/crates/corro-agent/src/agent/run_root.rs
+++ b/crates/corro-agent/src/agent/run_root.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use corro_types::{
-    agent::{Agent, Bookie},
+    agent::{Agent, ApplyTrigger, Bookie},
     base::CrsqlSeq,
     channel::bounded,
     config::{Config, PerfConfig},
@@ -169,7 +169,10 @@ async fn run(
                     let tx_apply = agent.tx_apply().clone();
                     let version = *version;
                     tokio::spawn(async move {
-                        if let Err(e) = tx_apply.send((actor_id, version)).await {
+                        if let Err(e) = tx_apply
+                            .send(ApplyTrigger::Version(actor_id, version))
+                            .await
+                        {
                             error!("could not schedule buffered changes application: {e}");
                         }
                     });

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -37,8 +37,8 @@ use crate::{
 };
 use corro_types::{
     actor::ActorId,
-    agent::{migrate, Agent, AgentConfig, BookedVersions, Bookie, SplitPool},
-    base::{CrsqlDbVersion, CrsqlDbVersionRange},
+    agent::{migrate, Agent, AgentConfig, ApplyTrigger, BookedVersions, Bookie, SplitPool},
+    base::CrsqlDbVersionRange,
     broadcast::{BroadcastInput, BroadcastV1, ChangeSource, ChangeV1, FocaInput},
     channel::{bounded, CorroReceiver},
     compress::ZstdDicts,
@@ -57,7 +57,7 @@ pub struct AgentOptions {
     pub transport: Transport,
     pub api_listeners: Vec<TcpListener>,
     pub rx_bcast: CorroReceiver<BroadcastInput>,
-    pub rx_apply: CorroReceiver<(ActorId, CrsqlDbVersion)>,
+    pub rx_apply: CorroReceiver<ApplyTrigger>,
     pub rx_clear_buf: CorroReceiver<(ActorId, CrsqlDbVersionRange)>,
     pub rx_changes: CorroReceiver<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
     pub rx_foca: CorroReceiver<FocaInput>,

--- a/crates/corro-agent/src/agent/tests.rs
+++ b/crates/corro-agent/src/agent/tests.rs
@@ -1665,3 +1665,151 @@ async fn test_apply_buffered_version_in_chunks() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_schema_change_retries_all_fully_buffered_partials() -> eyre::Result<()> {
+    _ = tracing_subscriber::fmt::try_init();
+
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let dir = tempfile::tempdir()?;
+
+    let mut config = Config::builder()
+        .db_path(dir.path().join("corrosion.db").display().to_string())
+        .gossip_addr("127.0.0.1:0".parse()?)
+        .api_addr("127.0.0.1:0".parse()?)
+        .build()?;
+
+    config.perf.partial_retry_backoff = 60 * 60;
+
+    let (agent, opts) = setup(config, tripwire.clone()).await?;
+    let bookie = agent.bookie().clone();
+    let mut rx_apply = opts.rx_apply;
+
+    let actor_a = ActorId(Uuid::new_v4());
+    let actor_b = ActorId(Uuid::new_v4());
+    let version = CrsqlDbVersion(1);
+    let ts = agent.clock().new_timestamp().into();
+
+    let make_part = |actor_id: ActorId, seq: u64, id: i64, text: &str| {
+        (
+            ChangeV1 {
+                actor_id,
+                changeset: Changeset::Full {
+                    version,
+                    changes: vec![Change {
+                        table: TableName("retry_after_schema_change".into()),
+                        pk: pack_columns(&vec![id.into()]).unwrap(),
+                        cid: ColumnName("text".into()),
+                        val: text.to_owned().into(),
+                        col_version: 1,
+                        db_version: version,
+                        seq: CrsqlSeq(seq),
+                        site_id: actor_id.to_bytes(),
+                        cl: 1,
+                    }],
+                    seqs: CrsqlSeqRange::new(CrsqlSeq(seq), CrsqlSeq(seq)),
+                    last_seq: CrsqlSeq(1),
+                    ts,
+                },
+            },
+            ChangeSource::Sync,
+            Instant::now(),
+        )
+    };
+
+    process_multiple_changes(
+        agent.clone(),
+        bookie.clone(),
+        vec![
+            make_part(actor_a, 0, 1, "a-first"),
+            make_part(actor_a, 1, 2, "a-second"),
+            make_part(actor_b, 0, 3, "b-first"),
+            make_part(actor_b, 1, 4, "b-second"),
+        ],
+        Duration::from_secs(60),
+    )
+    .await?;
+
+    for actor_id in [actor_a, actor_b] {
+        let booked = bookie.get(&actor_id).unwrap();
+        let read = booked.read();
+        assert!(read.get_partial(&version).unwrap().is_complete());
+    }
+
+    for _ in 0..2 {
+        let initial_apply = timeout(Duration::from_secs(1), rx_apply.recv()).await?;
+        assert!(initial_apply.is_some());
+    }
+
+    for actor_id in [actor_a, actor_b] {
+        let result = crate::agent::util::process_fully_buffered_changes(
+            &agent,
+            &bookie,
+            actor_id,
+            version,
+            Duration::from_secs(60),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    let apply_loop = tokio::spawn(crate::agent::util::apply_fully_buffered_changes_loop(
+        agent.clone(),
+        bookie.clone(),
+        rx_apply,
+        tripwire.clone(),
+    ));
+
+    tokio::task::yield_now().await;
+
+    execute_schema(
+        &agent,
+        vec![r#"
+            CREATE TABLE retry_after_schema_change (
+                id INTEGER NOT NULL PRIMARY KEY,
+                text TEXT NOT NULL DEFAULT ''
+            ) WITHOUT ROWID;
+            "#
+        .to_owned()],
+    )
+    .await?;
+
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let count: i64 = agent
+                .pool()
+                .read()
+                .await
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM retry_after_schema_change",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+
+            if count == 4 {
+                break;
+            }
+
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("schema change should retry all fully buffered partials");
+
+    for actor_id in [actor_a, actor_b] {
+        let booked = bookie.get(&actor_id).unwrap();
+        let read = booked.read();
+        assert!(read.get_partial(&version).is_none());
+        assert!(read.contains_version(&version));
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    apply_loop.await?;
+    wait_for_all_pending_handles().await;
+
+    Ok(())
+}

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -504,7 +504,7 @@ pub async fn apply_fully_buffered_changes_loop(
                     vec![(actor_id, version)]
                 }
                 Some(ApplyTrigger::SchemaChanged) => {
-                    match find_fully_buffered_partials(&agent).await {
+                    match find_fully_buffered_partials(&agent, None).await {
                         Ok(partials) if partials.is_empty() => continue,
                         Ok(partials) => {
                             for partial in &partials {
@@ -522,9 +522,9 @@ pub async fn apply_fully_buffered_changes_loop(
             },
 
             _ = retry_interval.tick(), if scan_enabled => {
-                match find_fully_buffered_partial(&agent).await {
-                    Ok(Some(pair)) => vec![pair],
-                    Ok(None) => continue,
+                match find_fully_buffered_partials(&agent, Some(1)).await {
+                    Ok(partials) if partials.is_empty() => continue,
+                    Ok(partials) => partials,
                     Err(e) => {
                         warn!("could not query for fully buffered partials: {e}");
                         continue;
@@ -593,38 +593,20 @@ pub async fn apply_fully_buffered_changes_loop(
 
 async fn find_fully_buffered_partials(
     agent: &Agent,
+    limit: Option<i64>,
 ) -> Result<Vec<(ActorId, CrsqlDbVersion)>, ChangeError> {
     let conn = agent.pool().read().await.map_err(ChangeError::SqlitePool)?;
-    block_in_place(|| {
-        conn.prepare_cached(
-            "SELECT site_id, db_version FROM __corro_seq_bookkeeping
-             WHERE start_seq = 0 AND end_seq = last_seq",
-        )
-        .and_then(|mut stmt| {
-            stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-                .collect::<rusqlite::Result<Vec<_>>>()
-        })
-        .map_err(|source| ChangeError::Rusqlite {
-            source,
-            actor_id: None,
-            version: None,
-        })
-    })
-}
+    let limit = limit.unwrap_or(-1);
 
-async fn find_fully_buffered_partial(
-    agent: &Agent,
-) -> Result<Option<(ActorId, CrsqlDbVersion)>, ChangeError> {
-    let conn = agent.pool().read().await.map_err(ChangeError::SqlitePool)?;
     block_in_place(|| {
         conn.prepare_cached(
             "SELECT site_id, db_version FROM __corro_seq_bookkeeping
              WHERE start_seq = 0 AND end_seq = last_seq
-             LIMIT 1",
+             LIMIT ?1",
         )
         .and_then(|mut stmt| {
-            stmt.query_row([], |row| Ok((row.get(0)?, row.get(1)?)))
-                .optional()
+            stmt.query_map([limit], |row| Ok((row.get(0)?, row.get(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()
         })
         .map_err(|source| ChangeError::Rusqlite {
             source,

--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -18,7 +18,10 @@ use crate::{
 use antithesis_sdk::assert_sometimes;
 use corro_types::{
     actor::{Actor, ActorId},
-    agent::{Agent, Booked, Bookie, ChangeError, CurrentVersion, KnownDbVersion, PartialVersion},
+    agent::{
+        Agent, ApplyTrigger, Booked, Bookie, ChangeError, CurrentVersion, KnownDbVersion,
+        PartialVersion,
+    },
     api::TableName,
     base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq},
     bookie::BookieDbParams,
@@ -468,7 +471,7 @@ pub async fn sync_loop(agent: Agent, bookie: Bookie, transport: Transport, mut t
 pub async fn apply_fully_buffered_changes_loop(
     agent: Agent,
     bookie: Bookie,
-    mut rx_apply: CorroReceiver<(ActorId, CrsqlDbVersion)>,
+    mut rx_apply: CorroReceiver<ApplyTrigger>,
     mut tripwire: Tripwire,
 ) {
     info!("Starting apply_fully_buffered_changes loop");
@@ -493,17 +496,34 @@ pub async fn apply_fully_buffered_changes_loop(
     }
 
     loop {
-        let partial_version = tokio::select! {
+        let partial_versions = tokio::select! {
             biased;
             _ = &mut tripwire => break,
-            maybe_version = rx_apply.recv() => match maybe_version {
-                Some(version) => version,
+            maybe_trigger = rx_apply.recv() => match maybe_trigger {
+                Some(ApplyTrigger::Version(actor_id, version)) => {
+                    vec![(actor_id, version)]
+                }
+                Some(ApplyTrigger::SchemaChanged) => {
+                    match find_fully_buffered_partials(&agent).await {
+                        Ok(partials) if partials.is_empty() => continue,
+                        Ok(partials) => {
+                            for partial in &partials {
+                                limit_retries.unblock(partial);
+                            }
+                            partials
+                        }
+                        Err(e) => {
+                            warn!("could not query for fully buffered partials: {e}");
+                            continue;
+                        }
+                    }
+                }
                 None => break,
             },
 
             _ = retry_interval.tick(), if scan_enabled => {
                 match find_fully_buffered_partial(&agent).await {
-                    Ok(Some(pair)) => pair,
+                    Ok(Some(pair)) => vec![pair],
                     Ok(None) => continue,
                     Err(e) => {
                         warn!("could not query for fully buffered partials: {e}");
@@ -513,57 +533,83 @@ pub async fn apply_fully_buffered_changes_loop(
             },
         };
 
-        if let Some(blocked_until) = limit_retries.is_throttled(&partial_version) {
-            let next_retry = blocked_until.duration_since(Instant::now()).as_secs();
-            warn!(
-                ?partial_version,
-                "previous attempt to apply buffered changes took too long, will retry in {next_retry} seconds"
-            );
-            continue;
-        }
-
-        let (actor_id, version) = partial_version;
-        let throttle_count = limit_retries
-            .throttle_count(&(actor_id, version))
-            .min(max_timeout_increase);
-        let tx_timeout =
-            sql_tx_timeout_secs + Duration::from_secs(step_timeout_secs * throttle_count);
-
-        debug!(%actor_id, %version, ?tx_timeout, "picked up background apply of buffered changes");
-        let start = Instant::now();
-        let res =
-            process_fully_buffered_changes(&agent, &bookie, actor_id, version, tx_timeout).await;
-        let elapsed = start.elapsed();
-        match res {
-            Ok(false) => {
-                warn!(%actor_id, %version, "did not apply buffered changes");
-                limit_retries.remove(&(actor_id, version));
+        for partial_version in partial_versions {
+            if let Some(blocked_until) = limit_retries.is_throttled(&partial_version) {
+                let next_retry = blocked_until.duration_since(Instant::now()).as_secs();
+                warn!(
+                    ?partial_version,
+                    "previous attempt to apply buffered changes took too long, will retry in {next_retry} seconds"
+                );
+                continue;
             }
-            Ok(true) => {
-                debug!(%actor_id, %version, "succesfully applied buffered changes");
-                histogram!("corro.agent.changes.processing.time.seconds", "source" => "buffered")
-                    .record(elapsed.as_secs_f64());
-                limit_retries.remove(&(actor_id, version));
-            }
-            Err(e) => {
-                let is_interrupt_error = e.is_interrupt_error();
-                error!(%actor_id, %version, "could not apply fully buffered changes with timeout {tx_timeout:?}: {e}");
-                if let Some(issue) = e.fatal_db_issue() {
-                    error!("fatal DB issue detected: {issue}");
-                    agent.mark_unhealthy(issue);
+
+            let (actor_id, version) = partial_version;
+            let throttle_count = limit_retries
+                .throttle_count(&(actor_id, version))
+                .min(max_timeout_increase);
+            let tx_timeout =
+                sql_tx_timeout_secs + Duration::from_secs(step_timeout_secs * throttle_count);
+
+            debug!(%actor_id, %version, ?tx_timeout, "picked up background apply of buffered changes");
+            let start = Instant::now();
+            let res =
+                process_fully_buffered_changes(&agent, &bookie, actor_id, version, tx_timeout)
+                    .await;
+            let elapsed = start.elapsed();
+
+            match res {
+                Ok(false) => {
+                    warn!(%actor_id, %version, "did not apply buffered changes");
+                    limit_retries.remove(&(actor_id, version));
                 }
-                let details = json!({"error": e.to_string()});
-                assert_unreachable!("could not apply fully buffered changes", &details);
+                Ok(true) => {
+                    debug!(%actor_id, %version, "succesfully applied buffered changes");
+                    histogram!("corro.agent.changes.processing.time.seconds", "source" => "buffered")
+                        .record(elapsed.as_secs_f64());
+                    limit_retries.remove(&(actor_id, version));
+                }
+                Err(e) => {
+                    let is_interrupt_error = e.is_interrupt_error();
+                    error!(%actor_id, %version, "could not apply fully buffered changes with timeout {tx_timeout:?}: {e}");
 
-                // processing time came close to timeout, limit retry with exponential backoff
-                if is_interrupt_error {
-                    limit_retries.throttle((actor_id, version));
+                    if let Some(issue) = e.fatal_db_issue() {
+                        error!("fatal DB issue detected: {issue}");
+                        agent.mark_unhealthy(issue);
+                    }
+
+                    let details = json!({"error": e.to_string()});
+                    assert_unreachable!("could not apply fully buffered changes", &details);
+
+                    if is_interrupt_error {
+                        limit_retries.throttle((actor_id, version));
+                    }
                 }
             }
         }
     }
 
     info!("fully_buffered_changes_loop ended");
+}
+
+async fn find_fully_buffered_partials(
+    agent: &Agent,
+) -> Result<Vec<(ActorId, CrsqlDbVersion)>, ChangeError> {
+    let conn = agent.pool().read().await.map_err(ChangeError::SqlitePool)?;
+    block_in_place(|| {
+        conn.prepare_cached(
+            "SELECT site_id, db_version FROM __corro_seq_bookkeeping
+             WHERE start_seq = 0 AND end_seq = last_seq",
+        )
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })
+        .map_err(|source| ChangeError::Rusqlite {
+            source,
+            actor_id: None,
+            version: None,
+        })
+    })
 }
 
 async fn find_fully_buffered_partial(
@@ -1395,7 +1441,10 @@ pub async fn process_multiple_changes(
                 debug!(%actor_id, %version, "partial is now complete, notifying for background apply");
                 let tx_apply = agent.tx_apply().clone();
                 tokio::spawn(async move {
-                    if let Err(e) = tx_apply.send((actor_id, version)).await {
+                    if let Err(e) = tx_apply
+                        .send(ApplyTrigger::Version(actor_id, version))
+                        .await
+                    {
                         error!(
                             "could not send trigger for applying fully buffered changes later: {e}"
                         );
@@ -1668,6 +1717,14 @@ pub async fn execute_schema(agent: &Agent, statements: Vec<String>) -> eyre::Res
     // hold onto this lock so nothing else makes changes
     let mut schema_write = agent.schema().write();
 
+    let schema_changed = partial_schema.tables.iter().any(|(name, table)| {
+        schema_write.tables.get(name).is_none_or(|current| {
+            current.pk != table.pk
+                || current.columns != table.columns
+                || current.indexes != table.indexes
+        })
+    });
+
     // clone the previous schema and apply
     let mut new_schema = {
         let mut schema = schema_write.clone();
@@ -1707,6 +1764,16 @@ pub async fn execute_schema(agent: &Agent, statements: Vec<String>) -> eyre::Res
     apply_res?;
 
     *schema_write = new_schema;
+    drop(schema_write);
+
+    if schema_changed {
+        let tx_apply = agent.tx_apply().clone();
+        tokio::spawn(async move {
+            if let Err(e) = tx_apply.send(ApplyTrigger::SchemaChanged).await {
+                error!("could not schedule buffered changes retry after schema update: {e}");
+            }
+        });
+    }
 
     Ok(())
 }

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -54,6 +54,12 @@ use super::members::Members;
 #[derive(Clone)]
 pub struct Agent(Arc<AgentInner>);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApplyTrigger {
+    Version(ActorId, CrsqlDbVersion),
+    SchemaChanged,
+}
+
 pub struct AgentConfig {
     pub actor_id: ActorId,
     pub pool: SplitPool,
@@ -68,7 +74,7 @@ pub struct AgentConfig {
     pub bookie: Bookie,
 
     pub tx_bcast: CorroSender<BroadcastInput>,
-    pub tx_apply: CorroSender<(ActorId, CrsqlDbVersion)>,
+    pub tx_apply: CorroSender<ApplyTrigger>,
     pub tx_clear_buf: CorroSender<(ActorId, CrsqlDbVersionRange)>,
     pub tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
     pub tx_foca: CorroSender<FocaInput>,
@@ -106,7 +112,7 @@ pub struct AgentInner {
     booked: Booked,
     bookie: Bookie,
     tx_bcast: CorroSender<BroadcastInput>,
-    tx_apply: CorroSender<(ActorId, CrsqlDbVersion)>,
+    tx_apply: CorroSender<ApplyTrigger>,
     tx_clear_buf: CorroSender<(ActorId, CrsqlDbVersionRange)>,
     tx_changes: CorroSender<(ChangeV1, ChangeSource, Option<BroadcastV1>)>,
     tx_foca: CorroSender<FocaInput>,
@@ -202,7 +208,7 @@ impl Agent {
         &self.0.tx_bcast
     }
 
-    pub fn tx_apply(&self) -> &CorroSender<(ActorId, CrsqlDbVersion)> {
+    pub fn tx_apply(&self) -> &CorroSender<ApplyTrigger> {
         &self.0.tx_apply
     }
 

--- a/crates/corro-utils/src/lib.rs
+++ b/crates/corro-utils/src/lib.rs
@@ -168,6 +168,12 @@ where
         entry.throttle_count = entry.throttle_count.saturating_add(1);
     }
 
+    pub fn unblock(&mut self, key: &K) {
+        if let Some(entry) = self.inner.get_mut(key) {
+            entry.blocked_until = Instant::now();
+        }
+    }
+
     pub fn clear_expired(&mut self) {
         let now = Instant::now();
         self.inner.retain(|_, entry| entry.blocked_until > now);
@@ -224,7 +230,15 @@ mod tests {
         m.throttle("a");
         assert_eq!(m.throttle_count(&"a"), 2);
         assert!(m.is_throttled(&"a").is_some());
-        std::thread::sleep(Duration::from_millis(95));
+
+        m.unblock(&"a");
+        assert!(m.is_throttled(&"a").is_none());
+        assert_eq!(m.throttle_count(&"a"), 2);
+
+        m.throttle("a");
+        assert_eq!(m.throttle_count(&"a"), 3);
+        assert!(m.is_throttled(&"a").is_some());
+        std::thread::sleep(Duration::from_millis(175));
         assert!(m.is_throttled(&"a").is_none());
 
         m.remove(&"a");


### PR DESCRIPTION
Fixes #504.

## Summary

- Retry all fully buffered partials when the schema changes.
- Bypass the current retry wait while preserving the exponential backoff count.
- Avoid retries when a schema reload does not actually change the schema.
- Keep regular buffered-version retries subject to their existing backoff.

## Tests

- `cargo test -p corro-utils throttle_map_exponential_backoff_and_counts`
- `cargo test -p corro-agent test_apply_buffered_version_in_chunks`
- `cargo test -p corro-agent test_execute_schema_from_paths`
- `cargo test -p corro-agent test_schema_change_retries_all_fully_buffered_partials`
- `cargo fmt --all -- --check`
- `cargo clippy -p corro-utils -p corro-types -p corro-agent --all-targets -- -D warnings`
- `cargo check --workspace`