### PR TITLE
Fix Postgres transaction recovery semantics

### DIFF
--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1294,7 +1294,8 @@ fn strip_pg_ast_expr(outer_expr: &mut sqlparser::ast::Expr) {
 
 #[cfg(test)]
 mod tests {
-    use super::pg_stmt_to_sqlite_sql;
+    use super::{pg_stmt_to_sqlite_sql, ConnectionDropWriteContext, TxState};
+    use std::{collections::HashMap, sync::Arc};
 
     #[test]
     fn check_normal_pg_dialect_array_subscript() {
@@ -1349,6 +1350,7 @@ mod tests {
         // Table references should keep pg_catalog. prefix since SQLite supports schema.table
         assert!(converted.contains("pg_catalog.pg_class"));
     }
+
     #[test]
     fn connection_drop_context_holds_write_permit_until_owner_drops() {
         let semaphore = Arc::new(tokio::sync::Semaphore::new(1));

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1355,6 +1355,7 @@ enum TxState {
     Started {
         kind: OpenTxKind,
         permits: Option<(OwnedSemaphorePermit, BookieWriteGuard)>,
+        failed: bool,
     },
     #[default]
     Ended,
@@ -1365,12 +1366,14 @@ impl TxState {
         Self::Started {
             kind: OpenTxKind::Implicit,
             permits: None,
+            failed: false,
         }
     }
     fn explicit() -> Self {
         Self::Started {
             kind: OpenTxKind::Explicit,
             permits: None,
+            failed: false,
         }
     }
 
@@ -1415,6 +1418,28 @@ impl TxState {
     }
     fn is_ended(&self) -> bool {
         matches!(self, TxState::Ended)
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(
+            self,
+            TxState::Started {
+                kind: OpenTxKind::Explicit,
+                failed: true,
+                ..
+            }
+        )
+    }
+
+    fn fail_explicit(&mut self) {
+        if let TxState::Started {
+            kind: OpenTxKind::Explicit,
+            failed,
+            ..
+        } = self
+        {
+            *failed = true;
+        }
     }
 
     fn start_implicit(&mut self) {
@@ -3515,12 +3540,6 @@ pub async fn start(
                                         })?;
 
                                         discard_until_sync = true;
-
-                                        send_ready(
-                                            &mut session,
-                                            discard_until_sync,
-                                            &back_tx,
-                                        )?;
                                         continue;
                                     }
                                 }
@@ -3545,7 +3564,7 @@ pub async fn start(
                                             )?;
                                             send_ready(
                                                 &mut session,
-                                                discard_until_sync,
+                                                true,
                                                 &back_tx,
                                             )?;
                                             continue;
@@ -3581,7 +3600,7 @@ pub async fn start(
                                             })?;
                                             send_ready(
                                                 &mut session,
-                                                discard_until_sync,
+                                                true,
                                                 &back_tx,
                                             )?;
                                             continue 'outer;
@@ -3897,6 +3916,8 @@ impl<'conn> Session<'conn> {
         back_tx: &Sender<BackendResponse>,
         send_row_desc: bool,
     ) -> Result<(), QueryError> {
+        self.validate_transaction_command(cmd)?;
+
         if cmd.is_show() {
             back_tx
                 .blocking_send(
@@ -4065,6 +4086,8 @@ impl<'conn> Session<'conn> {
         max_rows: usize,
         back_tx: &Sender<BackendResponse>,
     ) -> Result<(), QueryError> {
+        self.validate_transaction_command(cmd)?;
+
         // TODO: maybe we don't need to recompute this...
         let fields = field_types(prepped, cmd, FieldFormats::Each(result_formats))?;
 
@@ -4104,8 +4127,10 @@ impl<'conn> Session<'conn> {
             } else {
                 self.commit_db()?;
             }
+        } else if cmd.is_rollback() {
+            let _permits = self.tx_state.end();
+            self.conn.execute_batch("ROLLBACK")?;
         } else if cmd.is_begin() {
-            // do nothing
             debug!("cmd is BEGIN");
         } else {
             if !self.tx_state.is_writing() && !prepped.readonly() {
@@ -4312,6 +4337,18 @@ impl<'conn> Session<'conn> {
         Ok(())
     }
 
+    fn validate_transaction_command(&self, cmd: &ParsedCmd) -> Result<(), QueryError> {
+        if self.tx_state.is_failed() && !cmd.is_rollback() {
+            return Err(QueryError::InFailedTransaction);
+        }
+
+        if self.tx_state.is_explicit() && cmd.is_begin() {
+            return Err(QueryError::ActiveTransaction);
+        }
+
+        Ok(())
+    }
+
     fn commit_db(&self) -> Result<(), ChangeError> {
         let actor_id = self.agent.actor_id();
         self.conn
@@ -4388,6 +4425,10 @@ fn send_ready(
     discard_until_sync: bool,
     back_tx: &Sender<BackendResponse>,
 ) -> Result<(), BoxError> {
+    if discard_until_sync {
+        session.tx_state.fail_explicit();
+    }
+
     let ready_status = if session.tx_state.is_implicit() {
         let permits = session.tx_state.end(); // do this first, in case of failure
         if discard_until_sync {
@@ -4406,7 +4447,7 @@ fn send_ready(
 
         TransactionStatus::Idle
     } else if session.tx_state.is_explicit() {
-        if discard_until_sync {
+        if session.tx_state.is_failed() {
             TransactionStatus::Error
         } else {
             TransactionStatus::Transaction
@@ -4444,6 +4485,10 @@ enum QueryError {
     PermitAcquire(#[from] AcquireError),
     #[error(transparent)]
     Change(#[from] ChangeError),
+    #[error("current transaction is aborted, commands ignored until end of transaction block")]
+    InFailedTransaction,
+    #[error("there is already a transaction in progress")]
+    ActiveTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -4483,6 +4528,18 @@ impl TryFrom<QueryError> for PgWireBackendMessage {
             QueryError::Change(e) => {
                 ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string()).into()
             }
+            e @ QueryError::InFailedTransaction => ErrorInfo::new(
+                "ERROR".to_owned(),
+                SqlState::IN_FAILED_SQL_TRANSACTION.code().into(),
+                e.to_string(),
+            )
+            .into(),
+            e @ QueryError::ActiveTransaction => ErrorInfo::new(
+                "ERROR".to_owned(),
+                SqlState::ACTIVE_SQL_TRANSACTION.code().into(),
+                e.to_string(),
+            )
+            .into(),
         }))
     }
 }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1450,11 +1450,25 @@ impl TxState {
         *self = Self::explicit()
     }
 
-    fn end(&mut self) -> Option<(OwnedSemaphorePermit, BookieWriteGuard)> {
-        let permits = match self {
+    fn take_write_context(&mut self) -> Option<(OwnedSemaphorePermit, BookieWriteGuard)> {
+        match self {
             TxState::Started { permits, .. } => permits.take(),
             TxState::Ended => None,
-        };
+        }
+    }
+
+    fn restore_write_context(
+        &mut self,
+        write_context: Option<(OwnedSemaphorePermit, BookieWriteGuard)>,
+    ) {
+        if let TxState::Started { permits, .. } = self {
+            debug_assert!(permits.is_none());
+            *permits = write_context;
+        }
+    }
+
+    fn end(&mut self) -> Option<(OwnedSemaphorePermit, BookieWriteGuard)> {
+        let permits = self.take_write_context();
         *self = TxState::Ended;
         permits
     }
@@ -3610,15 +3624,8 @@ pub async fn start(
                                     // automatically commit an implicit tx
                                     if session.tx_state.is_implicit() {
                                         trace!("committing IMPLICIT tx");
-                                        let permits = session.tx_state.end();
 
-                                        let commit_res = if let Some((_permit, bookie_write)) = permits {
-                                            session.handle_commit(bookie_write)
-                                        } else {
-                                            session.commit_db()
-                                        };
-
-                                        if let Err(e) = commit_res {
+                                        if let Err(e) = session.commit_tx() {
                                             back_tx.blocking_send(
                                                 (
                                                     PgWireBackendMessage::ErrorResponse(
@@ -3633,11 +3640,7 @@ pub async fn start(
                                                 )
                                                     .into(),
                                             )?;
-                                            send_ready(
-                                                &mut session,
-                                                discard_until_sync,
-                                                &back_tx,
-                                            )?;
+                                            send_ready(&mut session, true, &back_tx)?;
                                             continue;
                                         }
                                         trace!("committed IMPLICIT tx");
@@ -3951,13 +3954,7 @@ impl<'conn> Session<'conn> {
             self.tx_state.start_implicit();
         } else if self.tx_state.is_implicit() && cmd.is_begin() {
             trace!("committing IMPLICIT tx");
-            let permits = self.tx_state.end();
-
-            if let Some((_permit, bookie_write)) = permits {
-                self.handle_commit(bookie_write)?;
-            } else {
-                self.commit_db()?;
-            }
+            self.commit_tx()?;
             trace!("committed IMPLICIT tx");
         }
 
@@ -3970,16 +3967,10 @@ impl<'conn> Session<'conn> {
             self.tx_state.start_explicit();
             0
         } else if cmd.is_commit() {
-            let permits = self.tx_state.end();
-            if let Some((_permit, bookie_write)) = permits {
-                self.handle_commit(bookie_write)?;
-            } else {
-                self.commit_db()?;
-            }
+            self.commit_tx()?;
             0
         } else if cmd.is_rollback() {
-            let _permits = self.tx_state.end();
-            self.conn.execute_batch("ROLLBACK")?;
+            self.rollback_tx()?;
             0
         } else {
             let mut prepped = if cmd.is_pg() {
@@ -4121,15 +4112,9 @@ impl<'conn> Session<'conn> {
         let mut changes = 0usize;
 
         if cmd.is_commit() {
-            let permits = self.tx_state.end();
-            if let Some((_permit, bookie_write)) = permits {
-                self.handle_commit(bookie_write)?;
-            } else {
-                self.commit_db()?;
-            }
+            self.commit_tx()?;
         } else if cmd.is_rollback() {
-            let _permits = self.tx_state.end();
-            self.conn.execute_batch("ROLLBACK")?;
+            self.rollback_tx()?;
         } else if cmd.is_begin() {
             debug!("cmd is BEGIN");
         } else {
@@ -4310,12 +4295,7 @@ impl<'conn> Session<'conn> {
             }
 
             if opened_implicit_tx {
-                let permits = self.tx_state.end();
-                if let Some((_permit, bookie_write)) = permits {
-                    self.handle_commit(bookie_write)?;
-                } else {
-                    self.commit_db()?;
-                }
+                self.commit_tx()?;
             }
         }
 
@@ -4335,6 +4315,37 @@ impl<'conn> Session<'conn> {
             .map_err(|_| QueryError::BackendResponseSendFailed)?;
 
         Ok(())
+    }
+
+    fn commit_tx(&mut self) -> Result<(), ChangeError> {
+        let write_context = self.tx_state.take_write_context();
+        let result = match write_context.as_ref() {
+            Some((_permit, bookie_write)) => self.handle_commit(bookie_write),
+            None => self.commit_db(),
+        };
+
+        if result.is_ok() || self.conn.is_autocommit() {
+            let _write_context = self.tx_state.end();
+        } else {
+            self.tx_state.restore_write_context(write_context);
+            self.tx_state.fail_explicit();
+        }
+
+        result
+    }
+
+    fn rollback_tx(&mut self) -> rusqlite::Result<()> {
+        let result = if self.conn.is_autocommit() {
+            Ok(())
+        } else {
+            self.conn.execute_batch("ROLLBACK")
+        };
+
+        if self.conn.is_autocommit() {
+            let _write_context = self.tx_state.end();
+        }
+
+        result
     }
 
     fn validate_transaction_command(&self, cmd: &ParsedCmd) -> Result<(), QueryError> {
@@ -4361,7 +4372,7 @@ impl<'conn> Session<'conn> {
         Ok(())
     }
 
-    fn handle_commit(&self, bookie_write: BookieWriteGuard) -> Result<(), ChangeError> {
+    fn handle_commit(&self, bookie_write: &BookieWriteGuard) -> Result<(), ChangeError> {
         trace!("HANDLE COMMIT");
 
         let actor_id = self.agent.actor_id();
@@ -4410,12 +4421,12 @@ impl<'conn> Session<'conn> {
 impl<'conn> Drop for Session<'conn> {
     fn drop(&mut self) {
         if !self.tx_state.is_ended() {
-            let _permits = self.tx_state.end();
             if let Err(e) = self.conn.execute_batch("ROLLBACK") {
                 warn!("failed to rollback tx: {e}");
             } else {
                 debug!("rolled back tx");
             }
+            let _write_context = self.tx_state.end();
         }
     }
 }
@@ -4430,19 +4441,14 @@ fn send_ready(
     }
 
     let ready_status = if session.tx_state.is_implicit() {
-        let permits = session.tx_state.end(); // do this first, in case of failure
         if discard_until_sync {
             // an error occurred, rollback implicit tx!
             warn!("receive Sync message w/ an error to send, rolling back implicit tx");
-            session.conn.execute_batch("ROLLBACK")?;
+            session.rollback_tx()?;
         } else {
             // no error, commit implicit tx
             warn!("receive Sync message, committing implicit tx");
-            if let Some((_permit, bookie_write)) = permits {
-                session.handle_commit(bookie_write)?;
-            } else {
-                session.commit_db()?;
-            }
+            session.commit_tx()?;
         }
 
         TransactionStatus::Idle

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -7,6 +7,7 @@ mod vtab;
 use codec::VecFromSqlText;
 use eyre::WrapErr;
 use std::{
+    cell::RefCell,
     collections::{BTreeSet, HashMap, VecDeque},
     fmt,
     net::SocketAddr,
@@ -1348,6 +1349,27 @@ mod tests {
         // Table references should keep pg_catalog. prefix since SQLite supports schema.table
         assert!(converted.contains("pg_catalog.pg_class"));
     }
+    #[test]
+    fn connection_drop_context_holds_write_permit_until_owner_drops() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+        let bookie = corro_types::bookie::Bookie::new(HashMap::new());
+        let bookie_write = bookie.write_lock_blocking();
+        let mut tx_state = TxState::explicit();
+        tx_state.set_write_context(permit, bookie_write);
+
+        let connection_owner = ConnectionDropWriteContext::default();
+        let session_owner = connection_owner.clone();
+        session_owner.hold(&mut tx_state);
+        drop(session_owner);
+
+        assert!(tx_state.is_ended());
+        assert!(semaphore.clone().try_acquire_owned().is_err());
+
+        drop(connection_owner);
+
+        assert!(semaphore.try_acquire_owned().is_ok());
+    }
 }
 
 #[derive(Default)]
@@ -1471,6 +1493,20 @@ impl TxState {
         let permits = self.take_write_context();
         *self = TxState::Ended;
         permits
+    }
+}
+
+#[derive(Clone, Default)]
+struct ConnectionDropWriteContext(
+    Rc<RefCell<Option<(OwnedSemaphorePermit, BookieWriteGuard)>>>,
+);
+
+impl ConnectionDropWriteContext {
+    fn hold(&self, tx_state: &mut TxState) {
+        let write_context = tx_state.end();
+        let mut held = self.0.borrow_mut();
+        debug_assert!(held.is_none());
+        *held = write_context;
     }
 }
 
@@ -1893,6 +1929,8 @@ pub async fn start(
                 let res = tokio::task::spawn_blocking({
                     let back_tx = back_tx.clone();
                     move || {
+                        let connection_drop_write_context =
+                            ConnectionDropWriteContext::default();
                         let conn = if readonly {
                             agent.pool().client_dedicated_readonly().unwrap()
                         } else {
@@ -2693,6 +2731,7 @@ pub async fn start(
                             agent,
                             conn: &conn,
                             tx_state: TxState::default(),
+                            connection_drop_write_context: connection_drop_write_context.clone(),
                         };
 
                         let mut prepared: HashMap<CompactString, Prepared> = HashMap::new();
@@ -3910,6 +3949,7 @@ struct Session<'conn> {
     agent: Agent,
     conn: &'conn CrConn,
     tx_state: TxState,
+    connection_drop_write_context: ConnectionDropWriteContext,
 }
 
 impl<'conn> Session<'conn> {
@@ -4421,12 +4461,13 @@ impl<'conn> Session<'conn> {
 impl<'conn> Drop for Session<'conn> {
     fn drop(&mut self) {
         if !self.tx_state.is_ended() {
-            if let Err(e) = self.conn.execute_batch("ROLLBACK") {
+            if let Err(e) = self.rollback_tx() {
                 warn!("failed to rollback tx: {e}");
+                self.connection_drop_write_context
+                    .hold(&mut self.tx_state);
             } else {
                 debug!("rolled back tx");
             }
-            let _write_context = self.tx_state.end();
         }
     }
 }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1499,9 +1499,7 @@ impl TxState {
 }
 
 #[derive(Clone, Default)]
-struct ConnectionDropWriteContext(
-    Rc<RefCell<Option<(OwnedSemaphorePermit, BookieWriteGuard)>>>,
-);
+struct ConnectionDropWriteContext(Rc<RefCell<Option<(OwnedSemaphorePermit, BookieWriteGuard)>>>);
 
 impl ConnectionDropWriteContext {
     fn hold(&self, tx_state: &mut TxState) {
@@ -4465,8 +4463,7 @@ impl<'conn> Drop for Session<'conn> {
         if !self.tx_state.is_ended() {
             if let Err(e) = self.rollback_tx() {
                 warn!("failed to rollback tx: {e}");
-                self.connection_drop_write_context
-                    .hold(&mut self.tx_state);
+                self.connection_drop_write_context.hold(&mut self.tx_state);
             } else {
                 debug!("rolled back tx");
             }

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -799,6 +799,83 @@ async fn test_pg() {
     wait_for_all_pending_handles().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_transaction_errors() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+    let (client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(client_conn);
+
+    client.batch_execute("BEGIN").await.unwrap();
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (1)", &[])
+        .await
+        .unwrap();
+
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (1)", &[])
+        .await
+        .unwrap_err();
+
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+
+    client.batch_execute("ROLLBACK").await.unwrap();
+    client.query_one("SELECT 1", &[]).await.unwrap();
+
+    let row = client
+        .query_one("SELECT COUNT(*) FROM kitchensink", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i64>(0), 0);
+
+    client.batch_execute("BEGIN").await.unwrap();
+    let error = client.batch_execute("BEGIN").await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25001");
+
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+
+    client.batch_execute("ROLLBACK").await.unwrap();
+
+    client.execute("BEGIN", &[]).await.unwrap();
+    let error = client.execute("BEGIN", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25001");
+
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+
+    client.execute("ROLLBACK", &[]).await.unwrap();
+    client.query_one("SELECT 1", &[]).await.unwrap();
+
+    client.batch_execute("BEGIN").await.unwrap();
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (2)", &[])
+        .await
+        .unwrap();
+    client.batch_execute("COMMIT").await.unwrap();
+
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (3)", &[])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT COUNT(*) FROM kitchensink", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i64>(0), 2);
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
 #[tracing_test::traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pg_readonly() {

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -876,6 +876,99 @@ async fn test_pg_transaction_errors() {
     wait_for_all_pending_handles().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_transaction_finalization_failures_recover() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+    let (client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(client_conn);
+
+    client.batch_execute("BEGIN").await.unwrap();
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (100)", &[])
+        .await
+        .unwrap();
+    client
+        .batch_execute("CREATE TEMP TABLE crsql_changes (bad INTEGER)")
+        .await
+        .unwrap();
+
+    client.batch_execute("COMMIT").await.unwrap_err();
+
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+
+    client.batch_execute("ROLLBACK").await.unwrap();
+
+    let row = client
+        .query_one("SELECT COUNT(*) FROM kitchensink WHERE id = 100", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i64>(0), 0);
+
+    client.execute("BEGIN", &[]).await.unwrap();
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (101)", &[])
+        .await
+        .unwrap();
+    client
+        .execute("CREATE TEMP TABLE crsql_changes (bad INTEGER)", &[])
+        .await
+        .unwrap();
+
+    client.execute("COMMIT", &[]).await.unwrap_err();
+
+    let error = client.query_one("SELECT 1", &[]).await.unwrap_err();
+    assert_eq!(error.as_db_error().unwrap().code().code(), "25P02");
+
+    client.execute("ROLLBACK", &[]).await.unwrap();
+
+    let row = client
+        .query_one("SELECT COUNT(*) FROM kitchensink WHERE id = 101", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i64>(0), 0);
+
+    client
+        .batch_execute("CREATE TEMP TABLE crsql_changes (bad INTEGER)")
+        .await
+        .unwrap_err();
+
+    client.query_one("SELECT 1", &[]).await.unwrap();
+
+    let permit = tokio::time::timeout(
+        Duration::from_secs(5),
+        ta.agent.write_sema().clone().acquire_owned(),
+    )
+    .await
+    .expect("write permit remained blocked after transaction recovery")
+    .unwrap();
+    drop(permit);
+
+    client
+        .execute("INSERT INTO kitchensink (id) VALUES (102)", &[])
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one(
+            "SELECT COUNT(*) FROM kitchensink WHERE id IN (100, 101, 102)",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, i64>(0), 1);
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
 #[tracing_test::traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pg_readonly() {


### PR DESCRIPTION
Fixes #502.

This keeps an explicit Postgres transaction failed after a statement error until the client rolls it back. Subsequent commands return `25P02`, nested `BEGIN` returns `25001`, and extended-query errors wait for `Sync` before `ReadyForQuery`. `ROLLBACK` works through both simple and extended flows.

Transaction finalization now retains the write permit and bookkeeping guard until SQLite `COMMIT` or `ROLLBACK` has actually completed. Session teardown follows the same rule, so a failed cleanup cannot release the canonical writer early.

Regression coverage includes protocol recovery, finalization failures, rollback without leaked rows, and unit coverage for the `ConnectionDropWriteContext` ownership rule that holds the write permit until its final owner drops. [Fork validation](https://github.com/onurata26/corrosion/actions/runs/32595200234) for this head passed Linux/macOS workspace tests, lint, and book. The branch still needs upstream CI after it is brought up to date with `main`.

Related: #508.