### PR TITLE
Fix bundled SQLite and cr-sqlite integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.106",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +733,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -736,6 +768,17 @@ name = "circular-buffer"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67261db007b5f4cf8cba393c1a5c511a5cc072339ce16e12aeba1d7b9b77946"
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -1369,6 +1412,34 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crsql_bundle"
+version = "0.1.0"
+dependencies = [
+ "crsql_core",
+ "crsql_fractindex_core",
+ "libc-print",
+ "sqlite_nostd",
+]
+
+[[package]]
+name = "crsql_core"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "libc-print",
+ "num-derive",
+ "num-traits",
+ "sqlite_nostd",
+]
+
+[[package]]
+name = "crsql_fractindex_core"
+version = "0.1.0"
+dependencies = [
+ "sqlite_nostd",
+]
 
 [[package]]
 name = "crunchy"
@@ -2226,6 +2297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,10 +2832,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libc-print"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a660208db49e35faf57b37484350f1a61072f2a5becf0592af6015d9ddd4b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -2801,6 +2896,7 @@ name = "libsqlite3-sys"
 version = "0.36.0"
 dependencies = [
  "cc",
+ "crsql_bundle",
  "pkg-config",
  "vcpkg",
 ]
@@ -2854,6 +2950,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3261,6 +3363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,6 +3556,12 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -3690,6 +3809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,7 +3960,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -3864,7 +3993,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring 0.17.14",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4351,6 +4480,12 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4385,6 +4520,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -4392,7 +4540,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
 ]
 
@@ -4923,6 +5071,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite3_allocator"
+version = "0.1.0"
+dependencies = [
+ "sqlite3_capi",
+]
+
+[[package]]
+name = "sqlite3_capi"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "sqlite_nostd"
+version = "0.1.0"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "sqlite3_allocator",
+ "sqlite3_capi",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5105,7 +5277,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.60.2",
 ]
 
@@ -6041,6 +6213,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6097,7 +6281,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -6118,7 +6302,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6130,7 +6314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -6163,13 +6347,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6178,7 +6368,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6187,7 +6377,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6233,6 +6423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6287,7 +6486,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -6304,7 +6503,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -1091,7 +1091,7 @@ mod tests {
 
         {
             let db_conn = Connection::open(db_path.clone())?;
-            db_conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL")?;
+            db_conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL; VACUUM;")?;
         }
 
         println!("temp db: {db_path:?}");

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use metrics::counter;
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rusqlite::types::{ToSql, ToSqlOutput, Value};
 use rusqlite::{
@@ -13,9 +12,8 @@ use rusqlite::{
 };
 use sqlite_pool::{Committable, SqliteConn};
 use std::rc::Rc;
-use tempfile::TempDir;
 use thread_local::ThreadLocal;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, warn};
 use tripwire::Tripwire;
 
 use crate::vtab::unnest::UnnestTab;
@@ -157,30 +155,6 @@ pub fn trace_heavy_queries(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-const CRSQL_EXT_GENERIC_NAME: &str = "crsqlite";
-
-#[cfg(target_os = "macos")]
-pub const CRSQL_EXT_FILENAME: &str = "crsqlite.dylib";
-#[cfg(target_os = "linux")]
-pub const CRSQL_EXT_FILENAME: &str = "crsqlite.so";
-
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-pub const CRSQL_EXT: &[u8] = include_bytes!("../crsqlite-darwin-aarch64.dylib");
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-pub const CRSQL_EXT: &[u8] = include_bytes!("../crsqlite-linux-x86_64.so");
-#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-pub const CRSQL_EXT: &[u8] = include_bytes!("../crsqlite-linux-aarch64.so");
-
-// TODO: support windows
-
-// need to keep this alive!
-static CRSQL_EXT_DIR: Lazy<TempDir> = Lazy::new(|| {
-    let dir = TempDir::new().expect("could not create temp dir!");
-    std::fs::write(dir.path().join(CRSQL_EXT_GENERIC_NAME), CRSQL_EXT)
-        .expect("could not write crsql ext file");
-    dir
-});
-
 pub fn rusqlite_to_crsqlite_write(conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
     let conn = rusqlite_to_crsqlite(conn)?;
     conn.execute_batch("PRAGMA cache_size = -32000;")?;
@@ -188,8 +162,7 @@ pub fn rusqlite_to_crsqlite_write(conn: rusqlite::Connection) -> rusqlite::Resul
     Ok(conn)
 }
 
-pub fn rusqlite_to_crsqlite(mut conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
-    init_cr_conn(&mut conn)?;
+pub fn rusqlite_to_crsqlite(conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
     setup_conn(&conn)?;
     sqlite_functions::add_to_connection(&conn)?;
 
@@ -202,8 +175,7 @@ pub fn rusqlite_to_crsqlite(mut conn: rusqlite::Connection) -> rusqlite::Result<
 pub struct CrConn(Connection);
 
 impl CrConn {
-    pub fn init(mut conn: Connection) -> Result<Self, rusqlite::Error> {
-        init_cr_conn(&mut conn)?;
+    pub fn init(conn: Connection) -> Result<Self, rusqlite::Error> {
         Ok(Self(conn))
     }
 
@@ -251,26 +223,6 @@ impl Committable for CrConn {
             "cannot create savepoint from connection",
         )))
     }
-}
-
-fn init_cr_conn(conn: &mut Connection) -> Result<(), rusqlite::Error> {
-    let ext_dir = &CRSQL_EXT_DIR;
-    trace!(
-        "loading crsqlite extension from path: {}",
-        ext_dir.path().display()
-    );
-    unsafe {
-        trace!("enabled loading extension");
-        /*conn.load_extension_enable()?;
-        conn.load_extension(
-            ext_dir.path().join(CRSQL_EXT_GENERIC_NAME),
-            Some("sqlite3_crsqlite_init"),
-        )?;
-        conn.load_extension_disable()?;*/
-    }
-    trace!("loaded crsqlite extension");
-
-    Ok(())
 }
 
 pub fn setup_conn(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -384,6 +336,54 @@ mod tests {
     use tokio::task::block_in_place;
 
     use super::*;
+
+    #[test]
+    fn begin_concurrent_allows_independent_writers() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = tempfile::tempdir()?;
+        let path = tmpdir.path().join("begin-concurrent.db");
+
+        let conn1 = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        let auto_vacuum: i64 = conn1.query_row("PRAGMA auto_vacuum", (), |row| row.get(0))?;
+        assert_eq!(auto_vacuum, 0);
+
+        conn1.execute_batch(
+            "
+            CREATE TABLE left_writes (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE right_writes (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            ",
+        )?;
+
+        let conn2 = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        conn1.execute_batch("BEGIN CONCURRENT;")?;
+
+        conn1.execute_batch("INSERT INTO left_writes (id, value) VALUES (1, 'left');")?;
+
+        conn2.execute_batch("BEGIN CONCURRENT;")?;
+
+        conn2.execute_batch("INSERT INTO right_writes (id, value) VALUES (1, 'right');")?;
+
+        conn1.execute_batch("COMMIT;")?;
+
+        conn2.execute_batch("COMMIT;")?;
+
+        let left_count: i64 =
+            conn1.query_row("SELECT COUNT(*) FROM left_writes", (), |row| row.get(0))?;
+        let right_count: i64 =
+            conn1.query_row("SELECT COUNT(*) FROM right_writes", (), |row| row.get(0))?;
+
+        assert_eq!(left_count, 1);
+        assert_eq!(right_count, 1);
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_writes() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/sqlite3-restore/src/lib.rs
+++ b/crates/sqlite3-restore/src/lib.rs
@@ -350,6 +350,7 @@ mod tests {
                 conn.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
 
             assert_eq!(journal_mode, "wal");
+            conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
         }
 
         let restored = restore(src, &dst, Duration::from_secs(2))?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.89"
 components = ["rustfmt", "clippy"]

--- a/vendor/libsqlite3-sys/Cargo.toml
+++ b/vendor/libsqlite3-sys/Cargo.toml
@@ -14,8 +14,8 @@ exclude = ["**/*.sh"]
 
 [features]
 default = ["min_sqlite_version_3_34_1"]
-bundled = ["cc", "bundled_bindings"]
-bundled-windows = ["cc", "bundled_bindings"]
+bundled = ["cc", "bundled_bindings", "dep:crsql_bundle"]
+bundled-windows = ["cc", "bundled_bindings", "dep:crsql_bundle"]
 bundled-sqlcipher = ["bundled"]
 bundled-sqlcipher-vendored-openssl = [
     "bundled-sqlcipher",
@@ -41,6 +41,7 @@ wasm32-wasi-vfs = []
 
 [dependencies]
 openssl-sys = { version = "0.9.103", optional = true }
+crsql_bundle = { path = "vendor/cr-sqlite/core/rs/bundle", optional = true, features = ["static", "omit_load_extension", "host"] }
 
 [build-dependencies]
 bindgen = { version = "0.72", optional = true, default-features = false, features = [

--- a/vendor/libsqlite3-sys/build.rs
+++ b/vendor/libsqlite3-sys/build.rs
@@ -97,72 +97,8 @@ mod build_bundled {
     use std::env;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
 
     use super::{is_compiler, win_target};
-
-    fn build_crsqlite_rust_lib(_out_dir: &str) -> PathBuf {
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let crsqlite_bundle_dir = PathBuf::from(manifest_dir)
-            .join("vendor/cr-sqlite/core/rs/bundle_static");
-        
-        println!("cargo:rerun-if-changed={}", crsqlite_bundle_dir.join("src").display());
-        println!("cargo:rerun-if-changed={}", crsqlite_bundle_dir.join("Cargo.toml").display());
-        
-        let target = env::var("TARGET").unwrap();
-        let profile = if env::var("PROFILE").unwrap() == "release" {
-            "release"
-        } else {
-            "debug"
-        };
-        
-        // Determine the crsqlite commit SHA from the vendored cr-sqlite directory
-        let crsqlite_dir = PathBuf::from(manifest_dir).join("vendor/cr-sqlite");
-        let commit_sha = Command::new("git")
-            .args(["-C", crsqlite_dir.to_str().unwrap(), "log", "-1", "--format=%H"])
-            .output()
-            .ok()
-            .and_then(|output| {
-                if output.status.success() {
-                    String::from_utf8(output.stdout).ok()
-                } else {
-                    None
-                }
-            })
-            .map(|s| s.trim().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        
-        let mut cargo = Command::new("cargo");
-        cargo
-            .current_dir(&crsqlite_bundle_dir)
-            .env("CRSQLITE_COMMIT_SHA", &commit_sha)
-            .arg("build")
-            .arg("--target")
-            .arg(&target)
-            .arg("--features")
-            .arg("static,omit_load_extension");
-        
-        if profile == "release" {
-            cargo.arg("--release");
-        }
-        
-        let status = cargo.status().expect("Failed to build crsqlite Rust library");
-        if !status.success() {
-            panic!("Failed to build crsqlite Rust library");
-        }
-        
-        let lib_path = crsqlite_bundle_dir
-            .join("target")
-            .join(&target)
-            .join(profile)
-            .join("libcrsql_bundle_static.a");
-        
-        if !lib_path.exists() {
-            panic!("crsqlite Rust library not found at: {}", lib_path.display());
-        }
-        
-        lib_path
-    }
 
     #[expect(clippy::assertions_on_constants)] // https://github.com/rust-lang/rust-clippy/issues/16242
     pub fn main(out_dir: &str, out_path: &Path) {
@@ -205,7 +141,6 @@ mod build_bundled {
             .flag("-DSQLITE_USE_URI")
             .flag("-DHAVE_USLEEP=1")
             .flag("-DHAVE_ISNAN")
-            .flag("-DSQLITE_DEFAULT_AUTOVACUUM=2")
             .flag("-D_POSIX_THREAD_SAFE_FUNCTIONS") // cross compile with MinGW
             .warnings(false);
 
@@ -373,8 +308,6 @@ mod build_bundled {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         let crsqlite_src_dir = PathBuf::from(manifest_dir).join("vendor/cr-sqlite/core/src");
         
-        let crsqlite_rust_lib = build_crsqlite_rust_lib(out_dir);
-        
         cfg.file(crsqlite_src_dir.join("crsqlite.c"))
             .file(crsqlite_src_dir.join("changes-vtab.c"))
             .file(crsqlite_src_dir.join("ext-data.c"))
@@ -387,10 +320,8 @@ mod build_bundled {
         println!("cargo:rerun-if-changed={}", crsqlite_src_dir.join("ext-data.c").display());
         println!("cargo:rerun-if-changed={}", crsqlite_src_dir.join("core_init.c").display());
 
+        cfg.link_lib_modifier("+whole-archive");
         cfg.compile(lib_name);
-        
-        println!("cargo:rustc-link-search=native={}", crsqlite_rust_lib.parent().unwrap().display());
-        println!("cargo:rustc-link-lib=static=crsql_bundle_static");
 
         println!("cargo:lib_dir={out_dir}");
     }

--- a/vendor/libsqlite3-sys/src/lib.rs
+++ b/vendor/libsqlite3-sys/src/lib.rs
@@ -4,6 +4,13 @@
 #[cfg(feature = "bundled-sqlcipher-vendored-openssl")]
 extern crate openssl_sys;
 
+#[cfg(any(
+    feature = "bundled",
+    feature = "bundled-windows",
+    feature = "bundled-sqlcipher"
+))]
+extern crate crsql_bundle as _;
+
 pub use self::error::*;
 
 use core::mem;

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/Cargo.toml
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/Cargo.toml
@@ -42,3 +42,4 @@ omit_load_extension = [
   "crsql_fractindex_core/omit_load_extension",
   "crsql_core/omit_load_extension"
 ]
+host = ["sqlite_nostd/host"]

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/src/lib.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use core::ffi::c_char;
+#[cfg(not(feature = "host"))]
 use core::panic::PanicInfo;
 use crsql_core;
 use crsql_core::sqlite3_crsqlcore_init;
@@ -12,16 +13,18 @@ use crsql_fractindex_core::sqlite3_crsqlfractionalindex_init;
 #[cfg(feature = "test")]
 use libc_print::std_name::println;
 use sqlite_nostd as sqlite;
+#[cfg(not(feature = "host"))]
 use sqlite_nostd::SQLite3Allocator;
 
 // This must be our allocator so we can transfer ownership of memory to SQLite and have SQLite free that memory for us.
 // This drastically reduces copies when passing strings and blobs back and forth between Rust and C.
+#[cfg(not(feature = "host"))]
 #[global_allocator]
 static ALLOCATOR: SQLite3Allocator = SQLite3Allocator {};
 
 // This must be our panic handler for WASM builds. For simplicity, we make it our panic handler for
 // all builds. Abort is also more portable than unwind, enabling us to go to more embedded use cases.
-#[cfg(not(feature = "test"))]
+#[cfg(all(not(feature = "test"), not(feature = "host")))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     //core::intrinsics::abort()

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/bootstrap.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/bootstrap.rs
@@ -180,7 +180,7 @@ fn maybe_update_db_inner(
     if recorded_version < consts::CRSQLITE_VERSION_0_17_0 && !is_blank_slate {
         let cstring = CString::new(format!("Opening a db created with cr-sqlite version {} is not supported. Upcoming release 0.17.0 is a breaking change.", recorded_version))?;
         unsafe {
-            (*err_msg) = cstring.into_raw();
+            (*err_msg) = sqlite::into_sqlite_owned_cstring(cstring);
             return Err(ResultCode::ERROR);
         }
     }

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab.rs
@@ -170,10 +170,11 @@ fn changes_best_index(
     unsafe {
         (*index_info).idxNum = idx_num;
         (*index_info).orderByConsumed = if order_by_consumed { 1 } else { 0 };
-        // forget str
-        let (ptr, _, _) = str.into_raw_parts();
-        // pass to c. We've manually null terminated the string.
-        // sqlite will free it for us.
+        // Pass ownership to SQLite. We've manually null terminated the string.
+        let ptr = sqlite::into_sqlite_owned_bytes(str.into_bytes());
+        if ptr.is_null() {
+            return Err(ResultCode::NOMEM);
+        }
         (*index_info).idxStr = ptr as *mut c_char;
         (*index_info).needToFreeIdxStr = 1;
     }
@@ -324,7 +325,7 @@ unsafe fn changes_next(
 ) -> Result<ResultCode, ResultCode> {
     if (*cursor).pChangesStmt.is_null() {
         let err = CString::new("pChangesStmt is null in changes_next")?;
-        (*vtab).zErrMsg = err.into_raw();
+        (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ABORT);
     }
 
@@ -370,7 +371,7 @@ unsafe fn changes_next(
 
     if tbl_info_index.is_none() {
         let err = CString::new(format!("could not find schema for table {}", tbl))?;
-        (*vtab).zErrMsg = err.into_raw();
+        (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
     // TODO: technically safe since we checked `is_none` but this should be more idiomatic
@@ -382,7 +383,7 @@ unsafe fn changes_next(
 
     if tbl_info.pks.is_empty() {
         let err = CString::new(format!("crr {} is missing primary keys", tbl))?;
-        (*vtab).zErrMsg = err.into_raw();
+        (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -542,7 +543,7 @@ pub extern "C" fn crsql_changes_update(
         "Only INSERT and SELECT statements are allowed against the crsql changes table",
     ) {
         unsafe {
-            (*vtab).zErrMsg = err.into_raw();
+            (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         }
         ResultCode::MISUSE as c_int
     } else {

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab_write.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab_write.rs
@@ -70,7 +70,7 @@ fn did_cid_win(
         Ok(rc) | Err(rc) => {
             reset_cached_stmt(col_vrsn_stmt.stmt)?;
             let err = CString::new("Bad return code when selecting local column version")?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(rc);
         }
     }
@@ -115,7 +115,7 @@ fn did_cid_win(
                 "could not find row to merge with for tbl {}",
                 insert_tbl
             ))?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(ResultCode::ERROR);
         }
     }
@@ -154,13 +154,13 @@ fn did_site_id_win(
                 "could not find site_id for previous change, cr-sqlite clock table might be corrupt for tbl {}",
                 insert_tbl
             ))?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(ResultCode::ERROR);
         }
         Ok(rc) | Err(rc) => {
             reset_cached_stmt(col_site_id_stmt.stmt)?;
             let err = CString::new("Bad return code when selecting local column site_id")?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(rc);
         }
     }
@@ -434,7 +434,7 @@ unsafe fn merge_insert(
     let rc = crsql_ensure_table_infos_are_up_to_date(db, (*tab).pExtData, errmsg);
     if rc != ResultCode::OK as i32 {
         let err = CString::new("Failed to update CRR table information")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -442,7 +442,7 @@ unsafe fn merge_insert(
     let insert_tbl = args[2 + CrsqlChangesColumn::Tbl as usize];
     if insert_tbl.bytes() > crate::consts::MAX_TBL_NAME_LEN {
         let err = CString::new("crsql - table name exceeded max length")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -451,7 +451,7 @@ unsafe fn merge_insert(
     let insert_col = args[2 + CrsqlChangesColumn::Cid as usize];
     if insert_col.bytes() > crate::consts::MAX_TBL_NAME_LEN {
         let err = CString::new("crsql - column name exceeded max length")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -462,11 +462,16 @@ unsafe fn merge_insert(
     let insert_site_id = args[2 + CrsqlChangesColumn::SiteId as usize];
     let insert_cl = args[2 + CrsqlChangesColumn::Cl as usize].int64();
     let insert_seq = args[2 + CrsqlChangesColumn::Seq as usize].int64();
-    let insert_ts = args[2 + CrsqlChangesColumn::Ts as usize].text();
+    let insert_ts = args[2 + CrsqlChangesColumn::Ts as usize];
+    let insert_ts = if insert_ts.value_type() == sqlite::ColumnType::Null {
+        "0"
+    } else {
+        insert_ts.text()
+    };
 
     if insert_site_id.bytes() > crate::consts::SITE_ID_LEN {
         let err = CString::new("crsql - site id exceeded max length")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -484,7 +489,7 @@ unsafe fn merge_insert(
             "crsql - could not find the schema information for table {}",
             insert_tbl
         ))?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
     // TODO: technically safe since we checked `is_none` but this should be more idiomatic
@@ -717,7 +722,7 @@ unsafe fn merge_insert(
                 "Unable to insert db version {} for site id {:?}",
                 insert_db_vrsn, insert_site_id
             ))?;
-            *errmsg = err.into_raw();
+            *errmsg = sqlite::into_sqlite_owned_cstring(err);
             return Err(rc);
         }
 

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/sha.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/sha.rs
@@ -1,2 +1,5 @@
 // The sha of the commit that this version of crsqlite was built from.
-pub const SHA: &'static str = core::env!("CRSQLITE_COMMIT_SHA");
+pub const SHA: &str = match core::option_env!("CRSQLITE_COMMIT_SHA") {
+    Some(sha) => sha,
+    None => "unknown",
+};

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/unpack_columns_vtab.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/unpack_columns_vtab.rs
@@ -78,7 +78,7 @@ extern "C" fn best_index(vtab: *mut sqlite::vtab, index_info: *mut sqlite::index
                     "no package column specified. Got {:?} instead",
                     Columns::PACKAGE
                 ))
-                .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
             }
             return ResultCode::MISUSE as c_int;
         } else {
@@ -134,7 +134,7 @@ extern "C" fn filter(
     if args.len() < 1 {
         unsafe {
             (*(*cursor).pVtab).zErrMsg = CString::new("Zero args passed to filter")
-                .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
         }
         return ResultCode::MISUSE as c_int;
     }
@@ -210,7 +210,7 @@ extern "C" fn column(
                 ResultCode::OK as c_int
             } else {
                 (*(*cursor).pVtab).zErrMsg = CString::new("No columns to unpack!")
-                    .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                    .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
                 ResultCode::ABORT as c_int
             }
         }
@@ -218,7 +218,7 @@ extern "C" fn column(
         unsafe {
             (*(*cursor).pVtab).zErrMsg =
                 CString::new(format!("Selected a column besides cell! {}", col_num))
-                    .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                    .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
         }
         ResultCode::MISUSE as c_int
     }

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite3_capi/src/capi.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite3_capi/src/capi.rs
@@ -563,6 +563,9 @@ pub fn value_bytes(arg1: *mut value) -> c_int {
 pub fn value_blob<'a>(value: *mut value) -> &'a [u8] {
     unsafe {
         let n = value_bytes(value);
+        if n == 0 {
+            return &[];
+        }
         let b = invoke_sqlite!(value_blob, value);
         core::slice::from_raw_parts(b.cast::<u8>(), n as usize)
     }

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/Cargo.toml
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/Cargo.toml
@@ -17,3 +17,4 @@ num-derive = "0.4.1"
 loadable_extension = ["sqlite3_capi/loadable_extension"]
 static = ["sqlite3_capi/static"]
 omit_load_extension = ["sqlite3_capi/omit_load_extension"]
+host = []

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/src/nostd.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/src/nostd.rs
@@ -693,6 +693,14 @@ impl ManagedStmt {
     #[inline]
     pub fn column_blob(&self, i: i32) -> Result<&[u8], ResultCode> {
         let len = column_bytes(self.stmt, i);
+        if len == 0 {
+            return if self.column_type(i)? == ColumnType::Null {
+                Err(ResultCode::NULL)
+            } else {
+                Ok(&[])
+            };
+        }
+
         let ptr = column_blob(self.stmt, i);
         if ptr.is_null() {
             Err(ResultCode::NULL)
@@ -823,15 +831,24 @@ impl Context for *mut context {
     /// The blob must have been allocated with `sqlite3_malloc`!
     #[inline]
     fn result_text_owned(&self, text: String) {
-        let (ptr, len, _) = text.into_raw_parts();
+        #[cfg(feature = "host")]
         result_text(
             *self,
-            ptr as *const c_char,
-            len as i32,
-            // TODO: this drop code does not seem to work
-            // Valgrind tells us we have a memory leak when using `result_text_owned`
-            Destructor::CUSTOM(droprust),
+            text.as_ptr() as *const c_char,
+            text.len() as i32,
+            Destructor::TRANSIENT,
         );
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = text.into_raw_parts();
+            result_text(
+                *self,
+                ptr as *const c_char,
+                len as i32,
+                Destructor::CUSTOM(droprust),
+            );
+        }
     }
 
     /// Takes a reference to a string, has SQLite copy the contents
@@ -862,8 +879,19 @@ impl Context for *mut context {
     /// The blob must have been allocated with `sqlite3_malloc`!
     #[inline]
     fn result_blob_owned(&self, blob: Vec<u8>) {
-        let (ptr, len, _) = blob.into_raw_parts();
-        result_blob(*self, ptr, len as i32, Destructor::CUSTOM(droprust));
+        #[cfg(feature = "host")]
+        result_blob(
+            *self,
+            blob.as_ptr(),
+            blob.len() as i32,
+            Destructor::TRANSIENT,
+        );
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = blob.into_raw_parts();
+            result_blob(*self, ptr, len as i32, Destructor::CUSTOM(droprust));
+        }
     }
 
     /// SQLite will make a copy of the blob
@@ -970,14 +998,28 @@ impl Stmt for *mut stmt {
 
     #[inline]
     fn bind_blob_owned(&self, i: i32, val: Vec<u8>) -> Result<ResultCode, ResultCode> {
-        let (ptr, len, _) = val.into_raw_parts();
-        convert_rc(bind_blob(
-            *self,
-            i,
-            ptr as *const c_void,
-            len as i32,
-            Destructor::CUSTOM(droprust),
-        ))
+        #[cfg(feature = "host")]
+        {
+            return convert_rc(bind_blob(
+                *self,
+                i,
+                val.as_ptr() as *const c_void,
+                val.len() as i32,
+                Destructor::TRANSIENT,
+            ));
+        }
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = val.into_raw_parts();
+            convert_rc(bind_blob(
+                *self,
+                i,
+                ptr as *const c_void,
+                len as i32,
+                Destructor::CUSTOM(droprust),
+            ))
+        }
     }
 
     #[inline]
@@ -1003,14 +1045,28 @@ impl Stmt for *mut stmt {
 
     #[inline]
     fn bind_text_owned(&self, i: i32, text: String) -> Result<ResultCode, ResultCode> {
-        let (ptr, len, _) = text.into_raw_parts();
-        convert_rc(bind_text(
-            *self,
-            i,
-            ptr as *const c_char,
-            len as i32,
-            Destructor::CUSTOM(droprust),
-        ))
+        #[cfg(feature = "host")]
+        {
+            return convert_rc(bind_text(
+                *self,
+                i,
+                text.as_ptr() as *const c_char,
+                text.len() as i32,
+                Destructor::TRANSIENT,
+            ));
+        }
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = text.into_raw_parts();
+            convert_rc(bind_text(
+                *self,
+                i,
+                ptr as *const c_char,
+                len as i32,
+                Destructor::CUSTOM(droprust),
+            ))
+        }
     }
 
     #[inline]
@@ -1051,6 +1107,10 @@ impl Stmt for *mut stmt {
     #[inline]
     fn column_blob(&self, i: i32) -> &[u8] {
         let len = column_bytes(*self, i);
+        if len == 0 {
+            return &[];
+        }
+
         let ptr = column_blob(*self, i);
         unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) }
     }
@@ -1142,6 +1202,50 @@ impl Value for *mut value {
     }
 }
 
+pub fn into_sqlite_owned_cstring(value: CString) -> *mut c_char {
+    #[cfg(feature = "host")]
+    {
+        let bytes = value.as_bytes_with_nul();
+        let ptr = malloc(bytes.len());
+        if ptr.is_null() {
+            return null_mut();
+        }
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
+        }
+
+        ptr as *mut c_char
+    }
+
+    #[cfg(not(feature = "host"))]
+    {
+        value.into_raw()
+    }
+}
+
+pub fn into_sqlite_owned_bytes(value: Vec<u8>) -> *mut u8 {
+    #[cfg(feature = "host")]
+    {
+        let ptr = malloc(value.len());
+        if ptr.is_null() {
+            return null_mut();
+        }
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(value.as_ptr(), ptr, value.len());
+        }
+
+        ptr
+    }
+
+    #[cfg(not(feature = "host"))]
+    {
+        let (ptr, _, _) = value.into_raw_parts();
+        ptr
+    }
+}
+
 pub trait StrRef {
     fn set(&self, val: &str);
 }
@@ -1157,11 +1261,9 @@ impl StrRef for *mut *mut c_char {
                 return;
             }
             if let Ok(cstring) = CString::new(val) {
-                **self = cstring.into_raw();
-            } else {
-                if let Ok(s) = CString::new("Failed setting error message.") {
-                    **self = s.into_raw();
-                }
+                **self = into_sqlite_owned_cstring(cstring);
+            } else if let Ok(s) = CString::new("Failed setting error message.") {
+                **self = into_sqlite_owned_cstring(s);
             }
         }
     }
@@ -1209,7 +1311,7 @@ impl VTab for *mut vtab {
                 return;
             }
             if let Ok(e) = CString::new(val) {
-                (**self).zErrMsg = e.into_raw();
+                (**self).zErrMsg = into_sqlite_owned_cstring(e);
             }
         }
     }


### PR DESCRIPTION
Follow-up to #414.

This fixes the bundled SQLite/cr-sqlite integration used by `custom-sqlite-bundle`. `crsql_bundle` is now a normal Rust dependency, while the C archive is kept whole so its Rust/C symbols remain linked. The vendored Rust code uses a host mode instead of installing its own allocator or panic handler, SQLite-owned values cross the boundary safely, and bundled `core_init` replaces runtime extension extraction.

The change also removes the default auto-vacuum setting that disables `BEGIN CONCURRENT`, adds a two-connection writer regression, and fixes nullable timestamps, zero-length blobs, and the vacuum/WAL fixtures.

[Run 32596152374](https://github.com/onurata26/corrosion/actions/runs/32596152374) tested source head [78b8618](https://github.com/onurata26/corrosion/commit/78b8618df2318dc9f5a15ddca525e8c92792ffc9): Linux and macOS each passed 71 tests with one skip; the existing macOS pubsub test passed on its third attempt, and docs passed. Linux clippy still fails on the pre-existing #414 warning at `crates/corro-pg/src/lib.rs:1072`; this PR does not touch that code.

Before this stack can land on `main`, refresh #414, then rebase/apply #522 and rerun full CI.