### PR TITLE
Implement concurrent API and PG writers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.106",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +733,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -736,6 +768,17 @@ name = "circular-buffer"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67261db007b5f4cf8cba393c1a5c511a5cc072339ce16e12aeba1d7b9b77946"
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -1369,6 +1412,34 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crsql_bundle"
+version = "0.1.0"
+dependencies = [
+ "crsql_core",
+ "crsql_fractindex_core",
+ "libc-print",
+ "sqlite_nostd",
+]
+
+[[package]]
+name = "crsql_core"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "libc-print",
+ "num-derive",
+ "num-traits",
+ "sqlite_nostd",
+]
+
+[[package]]
+name = "crsql_fractindex_core"
+version = "0.1.0"
+dependencies = [
+ "sqlite_nostd",
+]
 
 [[package]]
 name = "crunchy"
@@ -2226,6 +2297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,10 +2832,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libc-print"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a660208db49e35faf57b37484350f1a61072f2a5becf0592af6015d9ddd4b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -2801,6 +2896,7 @@ name = "libsqlite3-sys"
 version = "0.36.0"
 dependencies = [
  "cc",
+ "crsql_bundle",
  "pkg-config",
  "vcpkg",
 ]
@@ -2854,6 +2950,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3261,6 +3363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,6 +3556,12 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -3690,6 +3809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,7 +3960,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -3864,7 +3993,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring 0.17.14",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -4351,6 +4480,12 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -4385,6 +4520,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -4392,7 +4540,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
 ]
 
@@ -4923,6 +5071,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite3_allocator"
+version = "0.1.0"
+dependencies = [
+ "sqlite3_capi",
+]
+
+[[package]]
+name = "sqlite3_capi"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "sqlite_nostd"
+version = "0.1.0"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "sqlite3_allocator",
+ "sqlite3_capi",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5105,7 +5277,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.60.2",
 ]
 
@@ -6041,6 +6213,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6097,7 +6281,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -6118,7 +6302,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6130,7 +6314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -6163,13 +6347,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6178,7 +6368,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6187,7 +6377,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6233,6 +6423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6287,7 +6486,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -6304,7 +6503,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -454,22 +454,28 @@ fn wal_checkpoint(conn: &rusqlite::Connection, timeout: u64) -> eyre::Result<()>
 /// until it is below the limit
 ///
 async fn vacuum_db(pool: &SplitPool, lim: u64) -> eyre::Result<()> {
-    let mut freelist: u64 = {
+    let (vacuum, mut freelist): (u64, u64) = {
         let conn = pool.read().await?;
 
-        let vacuum: u64 = conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
-        if vacuum != 2 {
-            warn!("auto_vacuum isn't set to INCREMENTAL");
-            return Err(rusqlite::Error::ModuleError(
-                "auto_vacuum has to be set to INCREMENTAL".to_string(),
-            )
-            .into());
-        }
-
-        conn.pragma_query_value(None, "freelist_count", |row| row.get(0))?
+        (
+            conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?,
+            conn.pragma_query_value(None, "freelist_count", |row| row.get(0))?,
+        )
     };
 
+    gauge!("corro.db.freelist.pages").set(freelist as f64);
     debug!("freelist count: {freelist:?}");
+
+    if vacuum == 0 {
+        return Ok(());
+    }
+
+    if vacuum != 2 {
+        warn!("unexpected auto_vacuum mode: {vacuum}");
+        return Err(
+            rusqlite::Error::ModuleError(format!("unexpected auto_vacuum mode: {vacuum}")).into(),
+        );
+    }
 
     let (busy_timeout, cache_size) = {
         // update settings in write conn

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -1097,7 +1097,7 @@ mod tests {
 
         {
             let db_conn = Connection::open(db_path.clone())?;
-            db_conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL")?;
+            db_conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL; VACUUM;")?;
         }
 
         println!("temp db: {db_path:?}");

--- a/crates/corro-agent/src/agent/setup.rs
+++ b/crates/corro-agent/src/agent/setup.rs
@@ -66,6 +66,26 @@ pub struct AgentOptions {
     pub tripwire: Tripwire,
 }
 
+fn prepare_db_for_concurrent_writes(conn: &Connection) -> rusqlite::Result<()> {
+    let auto_vacuum: u64 = conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
+
+    if auto_vacuum != 0 {
+        info!(
+            auto_vacuum,
+            "migrating database to auto_vacuum=NONE for concurrent writes"
+        );
+
+        conn.execute_batch(
+            "
+            PRAGMA auto_vacuum = NONE;
+            VACUUM;
+            ",
+        )?;
+    }
+
+    Ok(())
+}
+
 /// Setup an agent runtime and state with a configuration
 pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, AgentOptions)> {
     debug!("setting up corrosion @ {}", conf.db.path);
@@ -78,9 +98,8 @@ pub async fn setup(conf: Config, tripwire: Tripwire) -> eyre::Result<(Agent, Age
     let members = Members::new(conf.gossip.member_id);
 
     let actor_id = {
-        // we need to set auto_vacuum before any tables are created
         let db_conn = Connection::open(&conf.db.path)?;
-        db_conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL")?;
+        prepare_db_for_concurrent_writes(&db_conn)?;
 
         let conn = CrConn::init(db_conn)?;
         conn.query_row("SELECT crsql_site_id();", [], |row| {
@@ -344,4 +363,73 @@ async fn setup_spawn_subscriptions(
     }
 
     Ok(Arc::new(TokioRwLock::new(subs_bcast_cache)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrates_legacy_auto_vacuum_for_concurrent_writes() -> eyre::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("legacy-auto-vacuum.db");
+
+        {
+            let conn = Connection::open(&path)?;
+
+            conn.execute_batch(
+                "
+                PRAGMA auto_vacuum = INCREMENTAL;
+                VACUUM;
+
+                CREATE TABLE legacy_probe (
+                    id INTEGER PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+
+                INSERT INTO legacy_probe (id, value)
+                VALUES (1, 'preserved');
+                ",
+            )?;
+
+            let auto_vacuum: u64 =
+                conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
+
+            assert_eq!(
+                auto_vacuum, 2,
+                "legacy fixture must actually use INCREMENTAL auto_vacuum"
+            );
+        }
+
+        let conn = Connection::open(&path)?;
+
+        let before: u64 = conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
+        assert_eq!(before, 2);
+
+        let before_value: String =
+            conn.query_row("SELECT value FROM legacy_probe WHERE id = 1", (), |row| {
+                row.get(0)
+            })?;
+        assert_eq!(before_value, "preserved");
+
+        prepare_db_for_concurrent_writes(&conn)?;
+
+        let after: u64 = conn.pragma_query_value(None, "auto_vacuum", |row| row.get(0))?;
+        assert_eq!(after, 0);
+
+        let after_value: String =
+            conn.query_row("SELECT value FROM legacy_probe WHERE id = 1", (), |row| {
+                row.get(0)
+            })?;
+        assert_eq!(after_value, "preserved");
+
+        conn.execute_batch(
+            "
+            BEGIN CONCURRENT;
+            ROLLBACK;
+            ",
+        )?;
+
+        Ok(())
+    }
 }

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1422,23 +1422,24 @@ mod tests {
                     None,
                     BTreeSet::from(["tests".to_owned()]),
                     move |tx| {
-                    tx.execute(
-                        "INSERT INTO tests (id, text) VALUES ('schema-race', 'old-schema')",
-                        &[],
-                    )
-                    .map_err(|source| ChangeError::Rusqlite {
-                        source,
-                        actor_id: None,
-                        version: None,
-                    })?;
+                        tx.execute(
+                            "INSERT INTO tests (id, text) VALUES ('schema-race', 'old-schema')",
+                            &[],
+                        )
+                        .map_err(|source| ChangeError::Rusqlite {
+                            source,
+                            actor_id: None,
+                            version: None,
+                        })?;
 
-                    let _ = entered_tx.send(());
-                    release_rx
-                        .recv_timeout(Duration::from_secs(5))
-                        .expect("speculative write was not released");
+                        let _ = entered_tx.send(());
+                        release_rx
+                            .recv_timeout(Duration::from_secs(5))
+                            .expect("speculative write was not released");
 
-                    Ok(())
-                })
+                        Ok(())
+                    },
+                )
                 .await
             })
         };
@@ -1478,10 +1479,11 @@ mod tests {
             (),
             |row| row.get(0),
         )?;
-        let audit_rows: i64 =
-            conn.query_row("SELECT COUNT(*) FROM http_schema_race_audit", (), |row| {
-                row.get(0)
-            })?;
+        let audit_rows: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM http_schema_race_audit",
+            (),
+            |row| row.get(0),
+        )?;
 
         assert_eq!(tracked_rows, 0);
         assert_eq!(audit_rows, 0);
@@ -1518,23 +1520,24 @@ mod tests {
                     None,
                     BTreeSet::from(["tests".to_owned()]),
                     move |tx| {
-                    tx.execute(
-                        "INSERT INTO tests (id, text) VALUES ('speculative-open', 'client')",
-                        &[],
-                    )
-                    .map_err(|source| ChangeError::Rusqlite {
-                        source,
-                        actor_id: None,
-                        version: None,
-                    })?;
+                        tx.execute(
+                            "INSERT INTO tests (id, text) VALUES ('speculative-open', 'client')",
+                            &[],
+                        )
+                        .map_err(|source| ChangeError::Rusqlite {
+                            source,
+                            actor_id: None,
+                            version: None,
+                        })?;
 
-                    let _ = entered_tx.send(());
-                    release_rx
-                        .recv_timeout(Duration::from_secs(5))
-                        .expect("speculative write was not released");
+                        let _ = entered_tx.send(());
+                        release_rx
+                            .recv_timeout(Duration::from_secs(5))
+                            .expect("speculative write was not released");
 
-                    Ok(())
-                })
+                        Ok(())
+                    },
+                )
                 .await
             })
         };
@@ -1611,20 +1614,21 @@ mod tests {
                     None,
                     BTreeSet::from(["tests".to_owned()]),
                     move |tx| {
-                    let concurrent = enter(&gate);
+                        let concurrent = enter(&gate);
 
-                    tx.execute(
-                        "INSERT INTO tests (id, text) VALUES ('parallel-1', 'first')",
-                        &[],
-                    )
-                    .map_err(|source| ChangeError::Rusqlite {
-                        source,
-                        actor_id: None,
-                        version: None,
-                    })?;
+                        tx.execute(
+                            "INSERT INTO tests (id, text) VALUES ('parallel-1', 'first')",
+                            &[],
+                        )
+                        .map_err(|source| ChangeError::Rusqlite {
+                            source,
+                            actor_id: None,
+                            version: None,
+                        })?;
 
-                    Ok(concurrent)
-                })
+                        Ok(concurrent)
+                    },
+                )
                 .await
             })
         };
@@ -1639,20 +1643,21 @@ mod tests {
                     None,
                     BTreeSet::from(["tests".to_owned()]),
                     move |tx| {
-                    let concurrent = enter(&gate);
+                        let concurrent = enter(&gate);
 
-                    tx.execute(
-                        "INSERT INTO tests (id, text) VALUES ('parallel-2', 'second')",
-                        &[],
-                    )
-                    .map_err(|source| ChangeError::Rusqlite {
-                        source,
-                        actor_id: None,
-                        version: None,
-                    })?;
+                        tx.execute(
+                            "INSERT INTO tests (id, text) VALUES ('parallel-2', 'second')",
+                            &[],
+                        )
+                        .map_err(|source| ChangeError::Rusqlite {
+                            source,
+                            actor_id: None,
+                            version: None,
+                        })?;
 
-                    Ok(concurrent)
-                })
+                        Ok(concurrent)
+                    },
+                )
                 .await
             })
         };

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1001,6 +1001,7 @@ pub async fn api_v1_table_stats(
 
 #[cfg(test)]
 mod tests {
+    use corro_tests::TEST_SCHEMA;
     use corro_types::{
         api::RowId,
         base::CrsqlDbVersion,
@@ -1008,7 +1009,6 @@ mod tests {
         config::Config,
         schema::SqliteType,
     };
-    use corro_tests::TEST_SCHEMA;
     use futures::StreamExt;
     use tokio::sync::mpsc::error::TryRecvError;
     use tokio_util::codec::{Decoder, LinesCodec};
@@ -1131,8 +1131,9 @@ mod tests {
         assert!(body.0.version.is_none());
 
         let conn = agent.pool().read().await?;
-        let row: String =
-            conn.query_row("SELECT text FROM tests WHERE id = 981", (), |row| row.get(0))?;
+        let row: String = conn.query_row("SELECT text FROM tests WHERE id = 981", (), |row| {
+            row.get(0)
+        })?;
         assert_eq!(row, "canonical");
 
         Ok(())
@@ -1214,8 +1215,7 @@ mod tests {
 
         drop(writer);
 
-        let (status_code, body) =
-            tokio::time::timeout(Duration::from_secs(5), request).await??;
+        let (status_code, body) = tokio::time::timeout(Duration::from_secs(5), request).await??;
         assert_eq!(status_code, StatusCode::OK, "{body:?}");
 
         let conn = agent.pool().read().await?;
@@ -1479,11 +1479,10 @@ mod tests {
             (),
             |row| row.get(0),
         )?;
-        let audit_rows: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM http_schema_race_audit",
-            (),
-            |row| row.get(0),
-        )?;
+        let audit_rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM http_schema_race_audit", (), |row| {
+                row.get(0)
+            })?;
 
         assert_eq!(tracked_rows, 0);
         assert_eq!(audit_rows, 0);

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -20,7 +20,8 @@ use corro_types::{
     broadcast::Timestamp,
     change::{
         database_has_foreign_keys, database_has_user_triggers, database_schema_version,
-        insert_local_changes, InsertChangesInfo, PendingLocalChanges, SqliteValue,
+        database_table_is_crr, insert_local_changes, InsertChangesInfo, PendingLocalChanges,
+        SqliteValue,
     },
     persistent_gauge,
     schema::{apply_schema, parse_sql},
@@ -75,6 +76,7 @@ impl<T> SpeculativeChanges<T> {
 async fn make_broadcastable_changes<F, T>(
     agent: &Agent,
     timeout: Option<u64>,
+    replayable_tables: BTreeSet<String>,
     f: F,
 ) -> Result<SpeculativeChanges<T>, ChangeError>
 where
@@ -109,7 +111,10 @@ where
                 version: None,
             })?;
 
-        let replay_safe = !database_has_user_triggers(&conn).unwrap_or(true)
+        let replay_safe = replayable_tables
+            .iter()
+            .all(|table| database_table_is_crr(&conn, table).unwrap_or(false))
+            && !database_has_user_triggers(&conn).unwrap_or(true)
             && !database_has_foreign_keys(&conn).unwrap_or(true);
 
         if !replay_safe {
@@ -358,24 +363,28 @@ where
     }
 }
 
-fn transaction_is_replayable(agent: &Agent, statements: &[Statement]) -> bool {
+fn replayable_transaction_tables(
+    agent: &Agent,
+    statements: &[Statement],
+) -> Option<BTreeSet<String>> {
     let schema = agent.schema().read();
+    let mut tables = BTreeSet::new();
 
-    statements.iter().all(|statement| {
+    for statement in statements {
         let sql = statement.query().trim().trim_end_matches(';').trim();
         if sql.is_empty() {
-            return false;
+            return None;
         }
 
         let mut parser = sqlite3_parser::lexer::sql::Parser::new(sql.as_bytes());
 
         let cmd = match parser.next() {
             Ok(Some(cmd)) => cmd,
-            _ => return false,
+            _ => return None,
         };
 
         if !matches!(parser.next(), Ok(None)) {
-            return false;
+            return None;
         }
 
         let table = match cmd {
@@ -384,11 +393,17 @@ fn transaction_is_replayable(agent: &Agent, statements: &[Statement]) -> bool {
                 | SqliteStmt::Update { tbl_name, .. }
                 | SqliteStmt::Delete { tbl_name, .. },
             ) if tbl_name.db_name.is_none() => tbl_name.name.0,
-            _ => return false,
+            _ => return None,
         };
 
-        schema.tables.contains_key(&table)
-    })
+        if !schema.tables.contains_key(&table) {
+            return None;
+        }
+
+        tables.insert(table);
+    }
+
+    Some(tables)
 }
 
 #[tracing::instrument(skip_all, err)]
@@ -484,10 +499,10 @@ pub async fn api_v1_transactions(
 
     counter!("corro.api.connection.count", "protocol" => "http").increment(1);
     assert_sometimes!(true, "Corrosion receives transactions through HTTP API");
-    let replayable = transaction_is_replayable(&agent, &statements);
+    let replayable_tables = replayable_transaction_tables(&agent, &statements);
 
-    let res = if replayable {
-        match make_broadcastable_changes(&agent, params.timeout, |tx| {
+    let res = if let Some(replayable_tables) = replayable_tables {
+        match make_broadcastable_changes(&agent, params.timeout, replayable_tables, |tx| {
             execute_transaction_statements(tx, &statements)
         })
         .await
@@ -1076,6 +1091,53 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_api_stale_tracked_schema_forces_canonical_path() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![
+                Statement::Simple("DROP TABLE tests".into()),
+                Statement::Simple(
+                    "CREATE TABLE tests (
+                        id INTEGER NOT NULL PRIMARY KEY,
+                        text TEXT NOT NULL DEFAULT ''
+                    ) WITHOUT ROWID"
+                        .into(),
+                ),
+            ]),
+        )
+        .await;
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+
+        assert!(agent.schema().read().tables.contains_key("tests"));
+        {
+            let conn = agent.pool().read().await?;
+            assert!(!database_table_is_crr(&conn, "tests")?);
+        }
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![Statement::Simple(
+                "INSERT INTO tests (id, text) VALUES (981, 'canonical')".into(),
+            )]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+        assert!(body.0.version.is_none());
+
+        let conn = agent.pool().read().await?;
+        let row: String =
+            conn.query_row("SELECT text FROM tests WHERE id = 981", (), |row| row.get(0))?;
+        assert_eq!(row, "canonical");
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_api_user_trigger_forces_canonical_path() -> eyre::Result<()> {
         let (_dir, agent) = setup_api_test_agent().await?;
 
@@ -1354,7 +1416,11 @@ mod tests {
             let agent = agent.clone();
 
             tokio::spawn(async move {
-                make_broadcastable_changes(&agent, None, move |tx| {
+                make_broadcastable_changes(
+                    &agent,
+                    None,
+                    BTreeSet::from(["tests".to_owned()]),
+                    move |tx| {
                     tx.execute(
                         "INSERT INTO tests (id, text) VALUES ('schema-race', 'old-schema')",
                         &[],
@@ -1446,7 +1512,11 @@ mod tests {
             let agent = agent.clone();
 
             tokio::spawn(async move {
-                make_broadcastable_changes(&agent, None, move |tx| {
+                make_broadcastable_changes(
+                    &agent,
+                    None,
+                    BTreeSet::from(["tests".to_owned()]),
+                    move |tx| {
                     tx.execute(
                         "INSERT INTO tests (id, text) VALUES ('speculative-open', 'client')",
                         &[],
@@ -1535,7 +1605,11 @@ mod tests {
             let gate = gate.clone();
 
             tokio::spawn(async move {
-                make_broadcastable_changes(&agent, None, move |tx| {
+                make_broadcastable_changes(
+                    &agent,
+                    None,
+                    BTreeSet::from(["tests".to_owned()]),
+                    move |tx| {
                     let concurrent = enter(&gate);
 
                     tx.execute(
@@ -1559,7 +1633,11 @@ mod tests {
             let gate = gate.clone();
 
             tokio::spawn(async move {
-                make_broadcastable_changes(&agent, None, move |tx| {
+                make_broadcastable_changes(
+                    &agent,
+                    None,
+                    BTreeSet::from(["tests".to_owned()]),
+                    move |tx| {
                     let concurrent = enter(&gate);
 
                     tx.execute(

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -19,8 +19,8 @@ use corro_types::{
     base::CrsqlDbVersion,
     broadcast::Timestamp,
     change::{
-        database_has_foreign_keys, database_has_user_triggers, insert_local_changes,
-        InsertChangesInfo, PendingLocalChanges, SqliteValue,
+        database_has_foreign_keys, database_has_user_triggers, database_schema_version,
+        insert_local_changes, InsertChangesInfo, PendingLocalChanges, SqliteValue,
     },
     persistent_gauge,
     schema::{apply_schema, parse_sql},
@@ -102,6 +102,13 @@ where
                 version: None,
             })?;
 
+        let schema_version =
+            database_schema_version(&conn).map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
         let replay_safe = !database_has_user_triggers(&conn).unwrap_or(true)
             && !database_has_foreign_keys(&conn).unwrap_or(true);
 
@@ -156,10 +163,10 @@ where
                 version: None,
             })?;
 
-        Ok::<_, ChangeError>(Some((ret, pending)))
+        Ok::<_, ChangeError>(Some((ret, pending, schema_version)))
     })?;
 
-    let Some((ret, pending)) = speculative else {
+    let Some((ret, pending, schema_version)) = speculative else {
         return Ok(SpeculativeChanges::RequiresCanonical);
     };
 
@@ -184,6 +191,20 @@ where
                 actor_id: Some(actor_id),
                 version: None,
             })?;
+
+        let current_schema_version =
+            database_schema_version(&tx).map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
+        if current_schema_version != schema_version {
+            return Err(ChangeError::SchemaChanged {
+                expected: schema_version,
+                actual: current_schema_version,
+            });
+        }
 
         let reserved_version = pending
             .replay(&tx)
@@ -1304,6 +1325,99 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(recovery_rows, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_api_schema_change_aborts_speculative_replay() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        {
+            let conn = agent.pool().write_priority().await?;
+            block_in_place(|| {
+                conn.execute_batch(
+                    "
+                    CREATE TABLE http_schema_race_audit (
+                        id INTEGER PRIMARY KEY,
+                        seen TEXT NOT NULL
+                    );
+                    ",
+                )
+            })?;
+        }
+
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let speculative = {
+            let agent = agent.clone();
+
+            tokio::spawn(async move {
+                make_broadcastable_changes(&agent, None, move |tx| {
+                    tx.execute(
+                        "INSERT INTO tests (id, text) VALUES ('schema-race', 'old-schema')",
+                        &[],
+                    )
+                    .map_err(|source| ChangeError::Rusqlite {
+                        source,
+                        actor_id: None,
+                        version: None,
+                    })?;
+
+                    let _ = entered_tx.send(());
+                    release_rx
+                        .recv_timeout(Duration::from_secs(5))
+                        .expect("speculative write was not released");
+
+                    Ok(())
+                })
+                .await
+            })
+        };
+
+        entered_rx.await?;
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let mut conn = agent.pool().write_normal().await?;
+
+            block_in_place(|| -> eyre::Result<()> {
+                let tx = conn.immediate_transaction()?;
+                tx.execute_batch(
+                    "
+                    CREATE TRIGGER tests_schema_race_audit
+                    AFTER INSERT ON tests
+                    BEGIN
+                        INSERT INTO http_schema_race_audit (id, seen)
+                        VALUES (NEW.id, NEW.text);
+                    END;
+                    ",
+                )?;
+                tx.commit()?;
+                Ok(())
+            })
+        })
+        .await
+        .expect("schema change was blocked by speculative transaction")??;
+
+        release_tx.send(())?;
+
+        let result = speculative.await?;
+        assert!(matches!(result, Err(ChangeError::SchemaChanged { .. })));
+
+        let conn = agent.pool().read().await?;
+        let tracked_rows: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM tests WHERE id = 'schema-race'",
+            (),
+            |row| row.get(0),
+        )?;
+        let audit_rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM http_schema_race_audit", (), |row| {
+                row.get(0)
+            })?;
+
+        assert_eq!(tracked_rows, 0);
+        assert_eq!(audit_rows, 0);
 
         Ok(())
     }

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -18,7 +18,10 @@ use corro_types::{
     },
     base::CrsqlDbVersion,
     broadcast::Timestamp,
-    change::{insert_local_changes, InsertChangesInfo, PendingLocalChanges, SqliteValue},
+    change::{
+        database_has_foreign_keys, database_has_user_triggers, insert_local_changes,
+        InsertChangesInfo, PendingLocalChanges, SqliteValue,
+    },
     persistent_gauge,
     schema::{apply_schema, parse_sql},
     sqlite::{CrConn, SqlitePoolError},
@@ -54,11 +57,26 @@ pub struct TimeoutParams {
     pub timeout: Option<u64>,
 }
 
-pub async fn make_broadcastable_changes<F, T>(
+enum SpeculativeChanges<T> {
+    Completed((T, Option<CrsqlDbVersion>, Duration)),
+    RequiresCanonical,
+}
+
+#[cfg(test)]
+impl<T> SpeculativeChanges<T> {
+    fn into_completed(self) -> (T, Option<CrsqlDbVersion>, Duration) {
+        match self {
+            Self::Completed(result) => result,
+            Self::RequiresCanonical => panic!("speculative transaction required canonical replay"),
+        }
+    }
+}
+
+async fn make_broadcastable_changes<F, T>(
     agent: &Agent,
     timeout: Option<u64>,
     f: F,
-) -> Result<(T, Option<CrsqlDbVersion>, Duration), ChangeError>
+) -> Result<SpeculativeChanges<T>, ChangeError>
 where
     F: FnOnce(&InterruptibleTransaction<CrConn>) -> Result<T, ChangeError>,
 {
@@ -76,13 +94,26 @@ where
             version: None,
         })?;
 
-    let (ret, pending) = block_in_place(move || {
+    let speculative = block_in_place(move || {
         conn.execute_batch("BEGIN CONCURRENT;")
             .map_err(|source| ChangeError::Rusqlite {
                 source,
                 actor_id: Some(actor_id),
                 version: None,
             })?;
+
+        let replay_safe = !database_has_user_triggers(&conn).unwrap_or(true)
+            && !database_has_foreign_keys(&conn).unwrap_or(true);
+
+        if !replay_safe {
+            conn.execute_batch("ROLLBACK;")
+                .map_err(|source| ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: None,
+                })?;
+            return Ok(None);
+        }
 
         let tx = InterruptibleTransaction::new(conn, timeout, "local_changes");
 
@@ -125,14 +156,18 @@ where
                 version: None,
             })?;
 
-        Ok::<_, ChangeError>((ret, pending))
+        Ok::<_, ChangeError>(Some((ret, pending)))
     })?;
+
+    let Some((ret, pending)) = speculative else {
+        return Ok(SpeculativeChanges::RequiresCanonical);
+    };
 
     if pending.is_empty() {
         let elapsed = start.elapsed();
         histogram!("corro.agent.changes.processing.time.seconds", "source" => "local")
             .record(elapsed);
-        return Ok((ret, None, elapsed));
+        return Ok(SpeculativeChanges::Completed((ret, None, elapsed)));
     }
 
     let mut conn = agent.pool().write_priority().await?;
@@ -195,12 +230,16 @@ where
     histogram!("corro.agent.changes.processing.time.seconds", "source" => "local").record(elapsed);
 
     match insert_info {
-        None => Ok((ret, None, elapsed)),
+        None => Ok(SpeculativeChanges::Completed((ret, None, elapsed))),
         Some((db_version, last_seq, ts)) => {
             let agent = agent.clone();
             spawn_counted(async move { broadcast_changes(agent, db_version, last_seq, ts).await });
 
-            Ok((ret, Some(db_version), elapsed))
+            Ok(SpeculativeChanges::Completed((
+                ret,
+                Some(db_version),
+                elapsed,
+            )))
         }
     }
 }
@@ -427,10 +466,20 @@ pub async fn api_v1_transactions(
     let replayable = transaction_is_replayable(&agent, &statements);
 
     let res = if replayable {
-        make_broadcastable_changes(&agent, params.timeout, |tx| {
+        match make_broadcastable_changes(&agent, params.timeout, |tx| {
             execute_transaction_statements(tx, &statements)
         })
         .await
+        {
+            Ok(SpeculativeChanges::Completed(result)) => Ok(result),
+            Ok(SpeculativeChanges::RequiresCanonical) => {
+                make_canonical_broadcastable_changes(&agent, params.timeout, |tx| {
+                    execute_transaction_statements(tx, &statements)
+                })
+                .await
+            }
+            Err(err) => Err(err),
+        }
     } else {
         make_canonical_broadcastable_changes(&agent, params.timeout, |tx| {
             execute_transaction_statements(tx, &statements)
@@ -1006,6 +1055,99 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_api_user_trigger_forces_canonical_path() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        let trigger_schema = "
+            CREATE TABLE http_trigger_target (
+                id INTEGER NOT NULL PRIMARY KEY,
+                first TEXT NOT NULL DEFAULT '',
+                second TEXT NOT NULL DEFAULT ''
+            );
+        ";
+
+        let (status_code, _) = api_v1_db_schema(
+            Extension(agent.clone()),
+            axum::Json(vec![TEST_SCHEMA.to_owned(), trigger_schema.to_owned()]),
+        )
+        .await;
+        assert_eq!(status_code, StatusCode::OK);
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![
+                Statement::Simple(
+                    "CREATE TABLE http_trigger_audit (
+                        id INTEGER PRIMARY KEY,
+                        seen TEXT NOT NULL
+                    )"
+                    .into(),
+                ),
+                Statement::Simple(
+                    "CREATE TRIGGER http_trigger_target_audit
+                     AFTER INSERT ON http_trigger_target
+                     BEGIN
+                         INSERT INTO http_trigger_audit (id, seen)
+                         VALUES (NEW.id, NEW.first || ':' || NEW.second);
+                     END"
+                    .into(),
+                ),
+            ]),
+        )
+        .await;
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+
+        {
+            let conn = agent.pool().read().await?;
+            assert!(database_has_user_triggers(&conn)?);
+        }
+
+        let statements = vec![Statement::Simple(
+            "INSERT INTO http_trigger_target (id, first, second)
+             VALUES (1, 'left', 'right')"
+                .into(),
+        )];
+
+        let writer = agent.pool().write_priority().await?;
+        let mut request = tokio::spawn({
+            let agent = agent.clone();
+            async move {
+                api_v1_transactions(
+                    Extension(agent),
+                    axum::extract::Query(TimeoutParams { timeout: None }),
+                    axum::Json(statements),
+                )
+                .await
+            }
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), &mut request)
+                .await
+                .is_err()
+        );
+
+        drop(writer);
+
+        let (status_code, body) =
+            tokio::time::timeout(Duration::from_secs(5), request).await??;
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+
+        let conn = agent.pool().read().await?;
+        let (count, seen): (i64, String) = conn.query_row(
+            "SELECT COUNT(*), MIN(seen) FROM http_trigger_audit",
+            (),
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+
+        assert_eq!(count, 1);
+        assert_eq!(seen, "left:right");
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_api_speculative_failure_rolls_back_and_releases_writer() -> eyre::Result<()> {
         let (_dir, agent) = setup_api_test_agent().await?;
         let booked_before = agent
@@ -1229,7 +1371,7 @@ mod tests {
 
         release_tx.send(())?;
 
-        let (_, version, _) = speculative.await??;
+        let (_, version, _) = speculative.await??.into_completed();
         assert!(version.is_some());
 
         let conn = agent.pool().read().await?;
@@ -1322,8 +1464,8 @@ mod tests {
             })
         };
 
-        let first = first.await??;
-        let second = second.await??;
+        let first = first.await??.into_completed();
+        let second = second.await??.into_completed();
 
         assert!(first.0);
         assert!(second.0);

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1008,6 +1008,7 @@ mod tests {
         config::Config,
         schema::SqliteType,
     };
+    use corro_tests::TEST_SCHEMA;
     use futures::StreamExt;
     use tokio::sync::mpsc::error::TryRecvError;
     use tokio_util::codec::{Decoder, LinesCodec};
@@ -1464,7 +1465,7 @@ mod tests {
             })
         })
         .await
-        .expect("schema change was blocked by speculative transaction")??;
+        .expect("schema change was blocked by speculative transaction")?;
 
         release_tx.send(())?;
 

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -18,16 +18,18 @@ use corro_types::{
     },
     base::CrsqlDbVersion,
     broadcast::Timestamp,
-    change::{insert_local_changes, InsertChangesInfo, SqliteValue},
+    change::{insert_local_changes, InsertChangesInfo, PendingLocalChanges, SqliteValue},
     persistent_gauge,
     schema::{apply_schema, parse_sql},
-    sqlite::SqlitePoolError,
+    sqlite::{CrConn, SqlitePoolError},
 };
 use hyper::StatusCode;
 use metrics::{counter, histogram};
+use rusqlite::fallible_iterator::FallibleIterator;
 use rusqlite::{params_from_iter, ToSql, Transaction};
 use serde::Deserialize;
 use spawn::spawn_counted;
+use sqlite3_parser::ast::{Cmd, Stmt as SqliteStmt};
 use sqlite_pool::{Committable, InterruptibleTransaction};
 
 use tokio::{
@@ -58,24 +60,88 @@ pub async fn make_broadcastable_changes<F, T>(
     f: F,
 ) -> Result<(T, Option<CrsqlDbVersion>, Duration), ChangeError>
 where
-    F: FnOnce(&InterruptibleTransaction<Transaction>) -> Result<T, ChangeError>,
+    F: FnOnce(&InterruptibleTransaction<CrConn>) -> Result<T, ChangeError>,
 {
-    trace!("getting conn...");
-    let mut conn = agent.pool().write_priority().await?;
-    trace!("got conn");
-
     let actor_id = agent.actor_id();
-    // maybe we should do this earlier, but there can only ever be 1 write conn at a time,
-    // so it probably doesn't matter too much, except for reads of internal state
+    let start = Instant::now();
+    let ts = Timestamp::from(agent.clock().new_timestamp());
+    let timeout = timeout.map(Duration::from_secs);
+
+    let conn = agent
+        .pool()
+        .client_dedicated()
+        .map_err(|source| ChangeError::Rusqlite {
+            source,
+            actor_id: Some(actor_id),
+            version: None,
+        })?;
+
+    let (ret, pending) = block_in_place(move || {
+        conn.execute_batch("BEGIN CONCURRENT;")
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
+        let tx = InterruptibleTransaction::new(conn, timeout, "local_changes");
+
+        if let Err(source) = tx
+            .prepare_cached("SELECT crsql_set_ts(?)")
+            .and_then(|mut stmt| stmt.query_row([&ts], |row| row.get::<_, String>(0)))
+        {
+            let _ = tx.execute_batch("ROLLBACK;");
+            return Err(ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            });
+        }
+
+        let ret = match f(&tx) {
+            Ok(ret) => ret,
+            Err(err) => {
+                let _ = tx.execute_batch("ROLLBACK;");
+                return Err(err);
+            }
+        };
+
+        let pending = match PendingLocalChanges::capture(&tx, actor_id) {
+            Ok(pending) => pending,
+            Err(source) => {
+                let _ = tx.execute_batch("ROLLBACK;");
+                return Err(ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: None,
+                });
+            }
+        };
+
+        tx.execute_batch("ROLLBACK;")
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
+        Ok::<_, ChangeError>((ret, pending))
+    })?;
+
+    if pending.is_empty() {
+        let elapsed = start.elapsed();
+        histogram!("corro.agent.changes.processing.time.seconds", "source" => "local")
+            .record(elapsed);
+        return Ok((ret, None, elapsed));
+    }
+
+    let mut conn = agent.pool().write_priority().await?;
     let mut book_writer = agent
         .booked()
         .write::<&str, _>("make_broadcastable_changes(booked writer)", None)
         .await;
 
-    let start = Instant::now();
-    let ts = Timestamp::from(agent.clock().new_timestamp());
-
-    block_in_place(move || {
+    let insert_info = block_in_place(move || {
         let tx = conn
             .immediate_transaction()
             .map_err(|source| ChangeError::Rusqlite {
@@ -84,58 +150,184 @@ where
                 version: None,
             })?;
 
-        let timeout = timeout.map(Duration::from_secs);
-        let tx = InterruptibleTransaction::new(tx, timeout, "local_changes");
-
-        let _ = tx
-            .prepare_cached("SELECT crsql_set_ts(?)")
-            .map_err(|source| ChangeError::Rusqlite {
-                source,
-                actor_id: Some(actor_id),
-                version: None,
-            })?
-            .query_row([&ts], |row| row.get::<_, String>(0))
+        let reserved_version = pending
+            .replay(&tx)
             .map_err(|source| ChangeError::Rusqlite {
                 source,
                 actor_id: Some(actor_id),
                 version: None,
             })?;
 
-        // Execute whatever might mutate state data
-        let ret = f(&tx)?;
-
         let insert_info = insert_local_changes(agent, &tx, &mut book_writer)?;
+
+        if reserved_version.is_some() && insert_info.is_none() {
+            tx.rollback().map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: reserved_version,
+            })?;
+            return Ok(None);
+        }
+
         tx.commit().map_err(|source| ChangeError::Rusqlite {
             source,
             actor_id: Some(actor_id),
             version: insert_info.as_ref().map(|info| info.db_version),
         })?;
 
-        let elapsed = start.elapsed();
-        histogram!("corro.agent.changes.processing.time.seconds", "source" => "local")
-            .record(start.elapsed());
-
-        match insert_info {
-            None => Ok((ret, None, elapsed)),
+        let committed = match insert_info {
+            None => None,
             Some(InsertChangesInfo {
                 db_version,
                 last_seq,
                 ts,
                 snap,
             }) => {
-                trace!("committed tx, db_version: {db_version}, last_seq: {last_seq:?}");
-
                 book_writer.commit_snapshot(snap);
-
-                let agent = agent.clone();
-
-                spawn_counted(
-                    async move { broadcast_changes(agent, db_version, last_seq, ts).await },
-                );
-
-                Ok::<_, ChangeError>((ret, Some(db_version), elapsed))
+                Some((db_version, last_seq, ts))
             }
+        };
+
+        Ok::<_, ChangeError>(committed)
+    })?;
+
+    let elapsed = start.elapsed();
+    histogram!("corro.agent.changes.processing.time.seconds", "source" => "local").record(elapsed);
+
+    match insert_info {
+        None => Ok((ret, None, elapsed)),
+        Some((db_version, last_seq, ts)) => {
+            let agent = agent.clone();
+            spawn_counted(async move { broadcast_changes(agent, db_version, last_seq, ts).await });
+
+            Ok((ret, Some(db_version), elapsed))
         }
+    }
+}
+
+async fn make_canonical_broadcastable_changes<F, T>(
+    agent: &Agent,
+    timeout: Option<u64>,
+    f: F,
+) -> Result<(T, Option<CrsqlDbVersion>, Duration), ChangeError>
+where
+    F: FnOnce(&InterruptibleTransaction<Transaction>) -> Result<T, ChangeError>,
+{
+    let actor_id = agent.actor_id();
+    let start = Instant::now();
+    let ts = Timestamp::from(agent.clock().new_timestamp());
+    let timeout = timeout.map(Duration::from_secs);
+
+    let mut conn = agent.pool().write_priority().await?;
+    let mut book_writer = agent
+        .booked()
+        .write::<&str, _>("make_canonical_broadcastable_changes(booked writer)", None)
+        .await;
+
+    let (ret, insert_info) = block_in_place(move || {
+        let tx = conn
+            .immediate_transaction()
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
+        let tx = InterruptibleTransaction::new(tx, timeout, "local_changes");
+
+        if let Err(source) = tx
+            .prepare_cached("SELECT crsql_set_ts(?)")
+            .and_then(|mut stmt| stmt.query_row([&ts], |row| row.get::<_, String>(0)))
+        {
+            let _ = tx.execute_batch("ROLLBACK;");
+            return Err(ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            });
+        }
+
+        let ret = match f(&tx) {
+            Ok(ret) => ret,
+            Err(err) => {
+                let _ = tx.execute_batch("ROLLBACK;");
+                return Err(err);
+            }
+        };
+
+        let insert_info = match insert_local_changes(agent, &tx, &mut book_writer) {
+            Ok(insert_info) => insert_info,
+            Err(err) => {
+                let _ = tx.execute_batch("ROLLBACK;");
+                return Err(err);
+            }
+        };
+
+        tx.commit().map_err(|source| ChangeError::Rusqlite {
+            source,
+            actor_id: Some(actor_id),
+            version: insert_info.as_ref().map(|info| info.db_version),
+        })?;
+
+        let committed = insert_info.map(
+            |InsertChangesInfo {
+                 db_version,
+                 last_seq,
+                 ts,
+                 snap,
+             }| {
+                book_writer.commit_snapshot(snap);
+                (db_version, last_seq, ts)
+            },
+        );
+
+        Ok::<_, ChangeError>((ret, committed))
+    })?;
+
+    let elapsed = start.elapsed();
+    histogram!("corro.agent.changes.processing.time.seconds", "source" => "local").record(elapsed);
+
+    match insert_info {
+        None => Ok((ret, None, elapsed)),
+        Some((db_version, last_seq, ts)) => {
+            let agent = agent.clone();
+            spawn_counted(async move { broadcast_changes(agent, db_version, last_seq, ts).await });
+
+            Ok((ret, Some(db_version), elapsed))
+        }
+    }
+}
+
+fn transaction_is_replayable(agent: &Agent, statements: &[Statement]) -> bool {
+    let schema = agent.schema().read();
+
+    statements.iter().all(|statement| {
+        let sql = statement.query().trim().trim_end_matches(';').trim();
+        if sql.is_empty() {
+            return false;
+        }
+
+        let mut parser = sqlite3_parser::lexer::sql::Parser::new(sql.as_bytes());
+
+        let cmd = match parser.next() {
+            Ok(Some(cmd)) => cmd,
+            _ => return false,
+        };
+
+        if !matches!(parser.next(), Ok(None)) {
+            return false;
+        }
+
+        let table = match cmd {
+            Cmd::Stmt(
+                SqliteStmt::Insert { tbl_name, .. }
+                | SqliteStmt::Update { tbl_name, .. }
+                | SqliteStmt::Delete { tbl_name, .. },
+            ) if tbl_name.db_name.is_none() => tbl_name.name.0,
+            _ => return false,
+        };
+
+        schema.tables.contains_key(&table)
     })
 }
 
@@ -175,6 +367,39 @@ where
     }
 }
 
+fn execute_transaction_statements<T>(
+    tx: &InterruptibleTransaction<T>,
+    statements: &[Statement],
+) -> Result<Vec<ExecResult>, ChangeError>
+where
+    T: Deref<Target = rusqlite::Connection> + Committable,
+{
+    let mut total_rows_affected = 0;
+
+    statements
+        .iter()
+        .map(|stmt| {
+            let start = Instant::now();
+            let res = execute_statement(tx, stmt).map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: None,
+                version: None,
+            });
+
+            match res {
+                Ok(rows_affected) => {
+                    total_rows_affected += rows_affected;
+                    Ok(ExecResult::Execute {
+                        rows_affected,
+                        time: start.elapsed().as_secs_f64(),
+                    })
+                }
+                Err(err) => Err(err),
+            }
+        })
+        .collect()
+}
+
 #[tracing::instrument(skip_all)]
 pub async fn api_v1_transactions(
     // axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
@@ -199,35 +424,19 @@ pub async fn api_v1_transactions(
 
     counter!("corro.api.connection.count", "protocol" => "http").increment(1);
     assert_sometimes!(true, "Corrosion receives transactions through HTTP API");
-    let res = make_broadcastable_changes(&agent, params.timeout, move |tx| {
-        let mut total_rows_affected = 0;
+    let replayable = transaction_is_replayable(&agent, &statements);
 
-        let results = statements
-            .iter()
-            .map(|stmt| {
-                let start = Instant::now();
-                let res = execute_statement(tx, stmt).map_err(|e| ChangeError::Rusqlite {
-                    source: e,
-                    actor_id: None,
-                    version: None,
-                });
-
-                match res {
-                    Ok(rows_affected) => {
-                        total_rows_affected += rows_affected;
-                        Ok(ExecResult::Execute {
-                            rows_affected,
-                            time: start.elapsed().as_secs_f64(),
-                        })
-                    }
-                    Err(e) => Err(e),
-                }
-            })
-            .collect::<Result<Vec<ExecResult>, ChangeError>>();
-
-        results
-    })
-    .await;
+    let res = if replayable {
+        make_broadcastable_changes(&agent, params.timeout, |tx| {
+            execute_transaction_statements(tx, &statements)
+        })
+        .await
+    } else {
+        make_canonical_broadcastable_changes(&agent, params.timeout, |tx| {
+            execute_transaction_statements(tx, &statements)
+        })
+        .await
+    };
 
     let (results, version, elapsed) = match res {
         Ok(res) => res,
@@ -722,6 +931,256 @@ mod tests {
     use super::*;
 
     use crate::agent::setup;
+
+    async fn setup_api_test_agent() -> eyre::Result<(tempfile::TempDir, Agent)> {
+        let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+        let dir = tempfile::tempdir()?;
+
+        let (agent, _agent_options) = setup(
+            Config::builder()
+                .db_path(dir.path().join("corrosion.db").display().to_string())
+                .gossip_addr("127.0.0.1:0".parse()?)
+                .api_addr("127.0.0.1:0".parse()?)
+                .build()?,
+            tripwire,
+        )
+        .await?;
+
+        let (status_code, _) = api_v1_db_schema(
+            Extension(agent.clone()),
+            axum::Json(vec![corro_tests::TEST_SCHEMA.into()]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::OK);
+
+        Ok((dir, agent))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_api_non_replayable_transaction_uses_canonical_path() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![
+                Statement::Simple(
+                    "INSERT INTO tests (id, text) VALUES ('canonical-http', 'preserved')".into(),
+                ),
+                Statement::Simple(
+                    "CREATE TABLE http_canonical_marker (id INTEGER PRIMARY KEY)".into(),
+                ),
+            ]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+
+        let conn = agent.pool().read().await?;
+
+        let value: String = conn.query_row(
+            "SELECT text FROM tests WHERE id = 'canonical-http'",
+            (),
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(value, "preserved");
+
+        let marker_exists: bool = conn.query_row(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM sqlite_schema
+                WHERE type = 'table'
+                  AND name = 'http_canonical_marker'
+            )
+            ",
+            (),
+            |row| row.get(0),
+        )?;
+
+        assert!(marker_exists);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_api_speculative_write_does_not_block_normal_writer() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        {
+            let conn = agent.pool().write_priority().await?;
+            block_in_place(|| {
+                conn.execute_batch(
+                    "
+                    CREATE TABLE issue503_writer_probe (
+                        id INTEGER PRIMARY KEY
+                    );
+                    ",
+                )
+            })?;
+        }
+
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let speculative = {
+            let agent = agent.clone();
+
+            tokio::spawn(async move {
+                make_broadcastable_changes(&agent, None, move |tx| {
+                    tx.execute(
+                        "INSERT INTO tests (id, text) VALUES ('speculative-open', 'client')",
+                        &[],
+                    )
+                    .map_err(|source| ChangeError::Rusqlite {
+                        source,
+                        actor_id: None,
+                        version: None,
+                    })?;
+
+                    let _ = entered_tx.send(());
+                    release_rx
+                        .recv_timeout(Duration::from_secs(5))
+                        .expect("speculative write was not released");
+
+                    Ok(())
+                })
+                .await
+            })
+        };
+
+        entered_rx.await?;
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let mut conn = agent.pool().write_normal().await?;
+
+            block_in_place(|| -> eyre::Result<()> {
+                let tx = conn.immediate_transaction()?;
+                tx.execute("INSERT INTO issue503_writer_probe (id) VALUES (1)", ())?;
+                tx.commit()?;
+                Ok(())
+            })
+        })
+        .await
+        .expect("normal writer was blocked by speculative client")?;
+
+        release_tx.send(())?;
+
+        let (_, version, _) = speculative.await??;
+        assert!(version.is_some());
+
+        let conn = agent.pool().read().await?;
+
+        let client_row: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM tests WHERE id = 'speculative-open'",
+            (),
+            |row| row.get(0),
+        )?;
+
+        let normal_row: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM issue503_writer_probe WHERE id = 1",
+            (),
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(client_row, 1);
+        assert_eq!(normal_row, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_api_writes_execute_speculatively_in_parallel() -> eyre::Result<()> {
+        use std::sync::{Arc, Condvar, Mutex};
+        use std::time::Duration;
+
+        fn enter(gate: &(Mutex<usize>, Condvar)) -> bool {
+            let mut count = gate.0.lock().unwrap();
+            *count += 1;
+            gate.1.notify_all();
+
+            let (count, timeout) = gate
+                .1
+                .wait_timeout_while(count, Duration::from_secs(5), |count| *count < 2)
+                .unwrap();
+
+            *count >= 2 && !timeout.timed_out()
+        }
+
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        let gate = Arc::new((Mutex::new(0usize), Condvar::new()));
+
+        let first = {
+            let agent = agent.clone();
+            let gate = gate.clone();
+
+            tokio::spawn(async move {
+                make_broadcastable_changes(&agent, None, move |tx| {
+                    let concurrent = enter(&gate);
+
+                    tx.execute(
+                        "INSERT INTO tests (id, text) VALUES ('parallel-1', 'first')",
+                        &[],
+                    )
+                    .map_err(|source| ChangeError::Rusqlite {
+                        source,
+                        actor_id: None,
+                        version: None,
+                    })?;
+
+                    Ok(concurrent)
+                })
+                .await
+            })
+        };
+
+        let second = {
+            let agent = agent.clone();
+            let gate = gate.clone();
+
+            tokio::spawn(async move {
+                make_broadcastable_changes(&agent, None, move |tx| {
+                    let concurrent = enter(&gate);
+
+                    tx.execute(
+                        "INSERT INTO tests (id, text) VALUES ('parallel-2', 'second')",
+                        &[],
+                    )
+                    .map_err(|source| ChangeError::Rusqlite {
+                        source,
+                        actor_id: None,
+                        version: None,
+                    })?;
+
+                    Ok(concurrent)
+                })
+                .await
+            })
+        };
+
+        let first = first.await??;
+        let second = second.await??;
+
+        assert!(first.0);
+        assert!(second.0);
+        assert!(first.1.is_some());
+        assert!(second.1.is_some());
+        assert_ne!(first.1, second.1);
+
+        let conn = agent.pool().read().await?;
+        let rows: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM tests WHERE id IN ('parallel-1', 'parallel-2')",
+            (),
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(rows, 2);
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_api_db_execute() -> eyre::Result<()> {

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1107,12 +1107,8 @@ mod tests {
                     "INSERT INTO tests (id, text) VALUES ('http-canonical-failure', 'first')"
                         .into(),
                 ),
-                Statement::Simple(
-                    "INSERT INTO http_canonical_side (id) VALUES (1)".into(),
-                ),
-                Statement::Simple(
-                    "INSERT INTO http_canonical_side (id) VALUES (1)".into(),
-                ),
+                Statement::Simple("INSERT INTO http_canonical_side (id) VALUES (1)".into()),
+                Statement::Simple("INSERT INTO http_canonical_side (id) VALUES (1)".into()),
             ]),
         )
         .await;

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1050,17 +1050,30 @@ mod tests {
             .last();
         assert_eq!(booked_after, booked_before);
 
-        let (status_code, body) = api_v1_transactions(
-            Extension(agent.clone()),
-            axum::extract::Query(TimeoutParams { timeout: None }),
-            axum::Json(vec![Statement::Simple(
-                "INSERT INTO tests (id, text) VALUES ('http-speculative-recovery', 'ok')".into(),
-            )]),
+        let (status_code, body) = tokio::time::timeout(
+            Duration::from_secs(5),
+            api_v1_transactions(
+                Extension(agent.clone()),
+                axum::extract::Query(TimeoutParams { timeout: None }),
+                axum::Json(vec![Statement::Simple(
+                    "INSERT INTO tests (id, text) VALUES ('http-speculative-recovery', 'ok')"
+                        .into(),
+                )]),
+            ),
         )
-        .await;
+        .await
+        .expect("writer remained blocked after speculative rollback");
 
         assert_eq!(status_code, StatusCode::OK, "{body:?}");
         assert!(body.0.version.is_some());
+
+        let conn = agent.pool().read().await?;
+        let recovery_rows: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM tests WHERE id = 'http-speculative-recovery'",
+            (),
+            |row| row.get(0),
+        )?;
+        assert_eq!(recovery_rows, 1);
 
         Ok(())
     }
@@ -1130,17 +1143,29 @@ mod tests {
             .last();
         assert_eq!(booked_after, booked_before);
 
-        let (status_code, body) = api_v1_transactions(
-            Extension(agent.clone()),
-            axum::extract::Query(TimeoutParams { timeout: None }),
-            axum::Json(vec![Statement::Simple(
-                "INSERT INTO tests (id, text) VALUES ('http-canonical-recovery', 'ok')".into(),
-            )]),
+        let (status_code, body) = tokio::time::timeout(
+            Duration::from_secs(5),
+            api_v1_transactions(
+                Extension(agent.clone()),
+                axum::extract::Query(TimeoutParams { timeout: None }),
+                axum::Json(vec![Statement::Simple(
+                    "INSERT INTO tests (id, text) VALUES ('http-canonical-recovery', 'ok')".into(),
+                )]),
+            ),
         )
-        .await;
+        .await
+        .expect("writer remained blocked after canonical rollback");
 
         assert_eq!(status_code, StatusCode::OK, "{body:?}");
         assert!(body.0.version.is_some());
+
+        let conn = agent.pool().read().await?;
+        let recovery_rows: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM tests WHERE id = 'http-canonical-recovery'",
+            (),
+            |row| row.get(0),
+        )?;
+        assert_eq!(recovery_rows, 1);
 
         Ok(())
     }

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -1005,6 +1005,146 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_api_speculative_failure_rolls_back_and_releases_writer() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+        let booked_before = agent
+            .booked()
+            .read::<&str, _>("test_api_speculative_failure", None)
+            .await
+            .last();
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![
+                Statement::Simple(
+                    "INSERT INTO tests (id, text) VALUES ('http-speculative-failure', 'first')"
+                        .into(),
+                ),
+                Statement::Simple(
+                    "INSERT INTO tests (id, text) VALUES ('http-speculative-failure', 'duplicate')"
+                        .into(),
+                ),
+            ]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.0.version.is_none());
+
+        {
+            let conn = agent.pool().read().await?;
+            let rows: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM tests WHERE id = 'http-speculative-failure'",
+                (),
+                |row| row.get(0),
+            )?;
+            assert_eq!(rows, 0);
+        }
+
+        let booked_after = agent
+            .booked()
+            .read::<&str, _>("test_api_speculative_failure", None)
+            .await
+            .last();
+        assert_eq!(booked_after, booked_before);
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![Statement::Simple(
+                "INSERT INTO tests (id, text) VALUES ('http-speculative-recovery', 'ok')".into(),
+            )]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+        assert!(body.0.version.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_api_canonical_failure_rolls_back_and_releases_writer() -> eyre::Result<()> {
+        let (_dir, agent) = setup_api_test_agent().await?;
+
+        {
+            let conn = agent.pool().write_priority().await?;
+            block_in_place(|| {
+                conn.execute_batch(
+                    "CREATE TABLE http_canonical_side (
+                        id INTEGER PRIMARY KEY
+                    )",
+                )
+            })?;
+        }
+
+        let booked_before = agent
+            .booked()
+            .read::<&str, _>("test_api_canonical_failure", None)
+            .await
+            .last();
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![
+                Statement::Simple(
+                    "INSERT INTO tests (id, text) VALUES ('http-canonical-failure', 'first')"
+                        .into(),
+                ),
+                Statement::Simple(
+                    "INSERT INTO http_canonical_side (id) VALUES (1)".into(),
+                ),
+                Statement::Simple(
+                    "INSERT INTO http_canonical_side (id) VALUES (1)".into(),
+                ),
+            ]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.0.version.is_none());
+
+        {
+            let conn = agent.pool().read().await?;
+            let tracked_rows: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM tests WHERE id = 'http-canonical-failure'",
+                (),
+                |row| row.get(0),
+            )?;
+            let side_rows: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM http_canonical_side WHERE id = 1",
+                (),
+                |row| row.get(0),
+            )?;
+            assert_eq!(tracked_rows, 0);
+            assert_eq!(side_rows, 0);
+        }
+
+        let booked_after = agent
+            .booked()
+            .read::<&str, _>("test_api_canonical_failure", None)
+            .await
+            .last();
+        assert_eq!(booked_after, booked_before);
+
+        let (status_code, body) = api_v1_transactions(
+            Extension(agent.clone()),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(vec![Statement::Simple(
+                "INSERT INTO tests (id, text) VALUES ('http-canonical-recovery', 'ok')".into(),
+            )]),
+        )
+        .await;
+
+        assert_eq!(status_code, StatusCode::OK, "{body:?}");
+        assert!(body.0.version.is_some());
+
+        Ok(())
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_api_speculative_write_does_not_block_normal_writer() -> eyre::Result<()> {
         let (_dir, agent) = setup_api_test_agent().await?;

--- a/crates/corro-agent/src/api/public/pubsub.rs
+++ b/crates/corro-agent/src/api/public/pubsub.rs
@@ -1115,7 +1115,7 @@ mod tests {
         }
 
         /// Prepares a statement that can be executed multiple times with different parameters
-        fn prepare_statement(&self, sql: &'static str) -> PreparedStatement {
+        fn prepare_statement(&self, sql: &'static str) -> PreparedStatement<'_> {
             PreparedStatement { agent: self, sql }
         }
 

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1912,29 +1912,27 @@ pub async fn start(
                                         if failed {
                                             session.rollback_sqlite_tx()?;
                                             let _permit = session.tx_state.end();
-                                        } else {
-                                            if let Err(e) = session.commit_tx() {
-                                                back_tx.blocking_send(
-                                                    (
-                                                        PgWireBackendMessage::ErrorResponse(
-                                                            ErrorInfo::new(
-                                                                "ERROR".to_owned(),
-                                                                "XX000".to_owned(),
-                                                                e.to_string(),
-                                                            )
-                                                            .into(),
-                                                        ),
-                                                        true,
-                                                    )
+                                        } else if let Err(e) = session.commit_tx() {
+                                            back_tx.blocking_send(
+                                                (
+                                                    PgWireBackendMessage::ErrorResponse(
+                                                        ErrorInfo::new(
+                                                            "ERROR".to_owned(),
+                                                            "XX000".to_owned(),
+                                                            e.to_string(),
+                                                        )
                                                         .into(),
-                                                )?;
-                                                send_ready(
-                                                    &mut session,
-                                                    discard_until_sync,
-                                                    &back_tx,
-                                                )?;
-                                                continue;
-                                            }
+                                                    ),
+                                                    true,
+                                                )
+                                                    .into(),
+                                            )?;
+                                            send_ready(
+                                                &mut session,
+                                                discard_until_sync,
+                                                &back_tx,
+                                            )?;
+                                            continue;
                                         }
                                         trace!("committed IMPLICIT tx");
                                     }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1323,6 +1323,7 @@ pub async fn start(
                                                             )
                                                                 .into(),
                                                         )?;
+                                                        discard_until_sync = true;
                                                         continue 'outer;
                                                     }
                                                 };
@@ -1836,12 +1837,6 @@ pub async fn start(
                                         })?;
 
                                         discard_until_sync = true;
-
-                                        send_ready(
-                                            &mut session,
-                                            discard_until_sync,
-                                            &back_tx,
-                                        )?;
                                         continue;
                                     }
                                 }
@@ -1918,10 +1913,7 @@ pub async fn start(
                                             session.rollback_sqlite_tx()?;
                                             let _permit = session.tx_state.end();
                                         } else {
-                                            let permit = session.tx_state.end();
-                                            if let Err(e) =
-                                                session.handle_commit(permit.is_some())
-                                            {
+                                            if let Err(e) = session.commit_tx() {
                                                 back_tx.blocking_send(
                                                     (
                                                         PgWireBackendMessage::ErrorResponse(
@@ -2407,9 +2399,7 @@ impl<'conn> Session<'conn> {
             self.tx_state.start_implicit();
         } else if self.tx_state.is_implicit() && cmd.is_begin() {
             trace!("committing IMPLICIT tx");
-            let permit = self.tx_state.end();
-
-            self.handle_commit(permit.is_some())?;
+            self.commit_tx()?;
             trace!("committed IMPLICIT tx");
         }
 
@@ -2426,8 +2416,7 @@ impl<'conn> Session<'conn> {
                 self.rollback_sqlite_tx()?;
                 let _permit = self.tx_state.end();
             } else {
-                let permit = self.tx_state.end();
-                self.handle_commit(permit.is_some())?;
+                self.commit_tx()?;
             }
             0
         } else if cmd.is_rollback() {
@@ -2591,8 +2580,7 @@ impl<'conn> Session<'conn> {
                 self.rollback_sqlite_tx()?;
                 let _permit = self.tx_state.end();
             } else {
-                let permit = self.tx_state.end();
-                self.handle_commit(permit.is_some())?;
+                self.commit_tx()?;
             }
         } else if cmd.is_rollback() {
             self.rollback_sqlite_tx()?;
@@ -2745,8 +2733,7 @@ impl<'conn> Session<'conn> {
             }
 
             if opened_implicit_tx {
-                let permit = self.tx_state.end();
-                self.handle_commit(permit.is_some())?;
+                self.commit_tx()?;
             }
         }
 
@@ -2766,6 +2753,18 @@ impl<'conn> Session<'conn> {
             .map_err(|_| QueryError::BackendResponseSendFailed)?;
 
         Ok(())
+    }
+
+    fn commit_tx(&mut self) -> Result<(), ChangeError> {
+        let result = self.handle_commit(self.tx_state.is_canonical());
+
+        if result.is_ok() || self.conn.is_autocommit() {
+            let _permit = self.tx_state.end();
+        } else {
+            self.tx_state.mark_failed();
+        }
+
+        result
     }
 
     fn handle_commit(&self, canonical: bool) -> Result<(), ChangeError> {
@@ -2953,8 +2952,7 @@ fn send_ready(
             let _permit = session.tx_state.end();
         } else {
             warn!("receive Sync message, committing implicit tx");
-            let permit = session.tx_state.end();
-            session.handle_commit(permit.is_some())?;
+            session.commit_tx()?;
         }
 
         TransactionStatus::Idle

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -356,7 +356,6 @@ enum TxState {
     Started {
         kind: OpenTxKind,
         writing: bool,
-        sqlite_tx_active: bool,
         failed: bool,
         write_permit: Option<OwnedSemaphorePermit>,
         ts: Option<Timestamp>,
@@ -370,7 +369,6 @@ impl TxState {
         Self::Started {
             kind: OpenTxKind::Implicit,
             writing: false,
-            sqlite_tx_active: true,
             failed: false,
             write_permit: None,
             ts: None,
@@ -381,7 +379,6 @@ impl TxState {
         Self::Started {
             kind: OpenTxKind::Explicit,
             writing: false,
-            sqlite_tx_active: true,
             failed: false,
             write_permit: None,
             ts: None,
@@ -400,25 +397,6 @@ impl TxState {
                 ..
             }
         )
-    }
-
-    fn sqlite_tx_active(&self) -> bool {
-        matches!(
-            self,
-            TxState::Started {
-                sqlite_tx_active: true,
-                ..
-            }
-        )
-    }
-
-    fn set_sqlite_tx_active(&mut self, active: bool) {
-        if let TxState::Started {
-            sqlite_tx_active, ..
-        } = self
-        {
-            *sqlite_tx_active = active;
-        }
     }
 
     fn is_failed(&self) -> bool {
@@ -1868,6 +1846,7 @@ pub async fn start(
                                     let parsed_query = match parse_query(&query.query) {
                                         Ok(q) => q,
                                         Err(e) => {
+                                            session.tx_state.mark_failed();
                                             back_tx.blocking_send(
                                                 (
                                                     PgWireBackendMessage::ErrorResponse(
@@ -2245,21 +2224,6 @@ impl<'conn> Session<'conn> {
                     if !db_name.0.as_str().eq_ignore_ascii_case("main") {
                         return Ok(false);
                     }
-                } else {
-                    let shadowed: bool = self.conn.query_row(
-                        "SELECT EXISTS (
-                            SELECT 1
-                            FROM sqlite_temp_schema
-                            WHERE name = ?1 COLLATE NOCASE
-                              AND type IN ('table', 'view')
-                        )",
-                        [tbl_name.name.0.as_str()],
-                        |row| row.get(0),
-                    )?;
-
-                    if shadowed {
-                        return Ok(false);
-                    }
                 }
 
                 &tbl_name.name.0
@@ -2267,7 +2231,15 @@ impl<'conn> Session<'conn> {
             _ => return Ok(false),
         };
 
-        Ok(self.agent.schema().read().tables.contains_key(table))
+        if !self.agent.schema().read().tables.contains_key(table) {
+            return Ok(false);
+        }
+
+        self.conn.query_row(
+            "SELECT NOT EXISTS (SELECT 1 FROM sqlite_temp_schema LIMIT 1)",
+            (),
+            |row| row.get(0),
+        )
     }
 
     fn prepare_write(&mut self, cmd: &ParsedCmd) -> Result<(), QueryError> {
@@ -2298,9 +2270,7 @@ impl<'conn> Session<'conn> {
             self.conn.execute_batch("ROLLBACK")
         };
 
-        let active = !self.conn.is_autocommit();
-        self.tx_state.set_sqlite_tx_active(active);
-        if !active {
+        if self.conn.is_autocommit() {
             self.tx_state.release_write_permit();
         }
 
@@ -2334,7 +2304,6 @@ impl<'conn> Session<'conn> {
 
         let result = (|| -> rusqlite::Result<()> {
             self.conn.execute_batch("BEGIN IMMEDIATE")?;
-            self.tx_state.set_sqlite_tx_active(true);
 
             if let Some(ts) = ts {
                 self.set_ts_value(ts)?;
@@ -2345,7 +2314,7 @@ impl<'conn> Session<'conn> {
                     r#"
                     SELECT EXISTS (
                         SELECT 1
-                        FROM crsql_changes
+                        FROM main.crsql_changes
                         WHERE site_id = ?
                           AND db_version = ?
                     )
@@ -2374,13 +2343,25 @@ impl<'conn> Session<'conn> {
             return Err(err.into());
         }
 
-        self.tx_state.set_sqlite_tx_active(true);
         counter!("corro.acquired.write.permit.count", "protocol" => "pg").increment(1);
 
         Ok(())
     }
 
     fn handle_query(
+        &mut self,
+        cmd: &ParsedCmd,
+        back_tx: &Sender<BackendResponse>,
+        send_row_desc: bool,
+    ) -> Result<(), QueryError> {
+        let result = self.handle_query_inner(cmd, back_tx, send_row_desc);
+        if result.is_err() && !self.tx_state.is_ended() {
+            self.tx_state.mark_failed();
+        }
+        result
+    }
+
+    fn handle_query_inner(
         &mut self,
         cmd: &ParsedCmd,
         back_tx: &Sender<BackendResponse>,
@@ -2543,6 +2524,22 @@ impl<'conn> Session<'conn> {
 
     #[allow(clippy::too_many_arguments)]
     fn handle_execute(
+        &mut self,
+        prepped: &mut Statement<'conn>,
+        result_formats: &[FieldFormat],
+        cmd: &ParsedCmd,
+        max_rows: usize,
+        back_tx: &Sender<BackendResponse>,
+    ) -> Result<(), QueryError> {
+        let result = self.handle_execute_inner(prepped, result_formats, cmd, max_rows, back_tx);
+        if result.is_err() && !self.tx_state.is_ended() {
+            self.tx_state.mark_failed();
+        }
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn handle_execute_inner(
         &mut self,
         prepped: &mut Statement<'conn>,
         result_formats: &[FieldFormat],
@@ -2942,6 +2939,10 @@ fn send_ready(
     discard_until_sync: bool,
     back_tx: &Sender<BackendResponse>,
 ) -> Result<(), BoxError> {
+    if discard_until_sync && !session.tx_state.is_ended() {
+        session.tx_state.mark_failed();
+    }
+
     let ready_status = if session.tx_state.is_implicit() {
         if discard_until_sync || session.tx_state.is_failed() {
             warn!("receive Sync message w/ an error to send, rolling back implicit tx");

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -356,6 +356,8 @@ enum TxState {
     Started {
         kind: OpenTxKind,
         writing: bool,
+        sqlite_tx_active: bool,
+        failed: bool,
         write_permit: Option<OwnedSemaphorePermit>,
         ts: Option<Timestamp>,
     },
@@ -368,6 +370,8 @@ impl TxState {
         Self::Started {
             kind: OpenTxKind::Implicit,
             writing: false,
+            sqlite_tx_active: true,
+            failed: false,
             write_permit: None,
             ts: None,
         }
@@ -377,6 +381,8 @@ impl TxState {
         Self::Started {
             kind: OpenTxKind::Explicit,
             writing: false,
+            sqlite_tx_active: true,
+            failed: false,
             write_permit: None,
             ts: None,
         }
@@ -396,6 +402,35 @@ impl TxState {
         )
     }
 
+    fn sqlite_tx_active(&self) -> bool {
+        matches!(
+            self,
+            TxState::Started {
+                sqlite_tx_active: true,
+                ..
+            }
+        )
+    }
+
+    fn set_sqlite_tx_active(&mut self, active: bool) {
+        if let TxState::Started {
+            sqlite_tx_active, ..
+        } = self
+        {
+            *sqlite_tx_active = active;
+        }
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, TxState::Started { failed: true, .. })
+    }
+
+    fn mark_failed(&mut self) {
+        if let TxState::Started { failed, .. } = self {
+            *failed = true;
+        }
+    }
+
     fn mark_writing(&mut self, ts: Timestamp) {
         if let TxState::Started {
             writing, ts: tx_ts, ..
@@ -411,6 +446,12 @@ impl TxState {
     fn set_write_permit(&mut self, permit: OwnedSemaphorePermit) {
         if let TxState::Started { write_permit, .. } = self {
             *write_permit = Some(permit);
+        }
+    }
+
+    fn release_write_permit(&mut self) {
+        if let TxState::Started { write_permit, .. } = self {
+            *write_permit = None;
         }
     }
 
@@ -1889,29 +1930,37 @@ pub async fn start(
                                     // automatically commit an implicit tx
                                     if session.tx_state.is_implicit() {
                                         trace!("committing IMPLICIT tx");
-                                        let permit = session.tx_state.end();
+                                        let failed = session.tx_state.is_failed();
 
-                                        if let Err(e) = session.handle_commit(permit.is_some()) {
-                                            back_tx.blocking_send(
-                                                (
-                                                    PgWireBackendMessage::ErrorResponse(
-                                                        ErrorInfo::new(
-                                                            "ERROR".to_owned(),
-                                                            "XX000".to_owned(),
-                                                            e.to_string(),
-                                                        )
+                                        if failed {
+                                            session.rollback_sqlite_tx()?;
+                                            let _permit = session.tx_state.end();
+                                        } else {
+                                            let permit = session.tx_state.end();
+                                            if let Err(e) =
+                                                session.handle_commit(permit.is_some())
+                                            {
+                                                back_tx.blocking_send(
+                                                    (
+                                                        PgWireBackendMessage::ErrorResponse(
+                                                            ErrorInfo::new(
+                                                                "ERROR".to_owned(),
+                                                                "XX000".to_owned(),
+                                                                e.to_string(),
+                                                            )
+                                                            .into(),
+                                                        ),
+                                                        true,
+                                                    )
                                                         .into(),
-                                                    ),
-                                                    true,
-                                                )
-                                                    .into(),
-                                            )?;
-                                            send_ready(
-                                                &mut session,
-                                                discard_until_sync,
-                                                &back_tx,
-                                            )?;
-                                            continue;
+                                                )?;
+                                                send_ready(
+                                                    &mut session,
+                                                    discard_until_sync,
+                                                    &back_tx,
+                                                )?;
+                                                continue;
+                                            }
                                         }
                                         trace!("committed IMPLICIT tx");
                                     }
@@ -2185,7 +2234,7 @@ struct Session<'conn> {
 }
 
 impl<'conn> Session<'conn> {
-    fn write_is_replayable(&self, cmd: &ParsedCmd) -> bool {
+    fn write_is_replayable(&self, cmd: &ParsedCmd) -> rusqlite::Result<bool> {
         let table = match cmd {
             ParsedCmd::Sqlite(Cmd::Stmt(
                 Stmt::Insert { tbl_name, .. }
@@ -2194,16 +2243,31 @@ impl<'conn> Session<'conn> {
             )) => {
                 if let Some(db_name) = &tbl_name.db_name {
                     if !db_name.0.as_str().eq_ignore_ascii_case("main") {
-                        return false;
+                        return Ok(false);
+                    }
+                } else {
+                    let shadowed: bool = self.conn.query_row(
+                        "SELECT EXISTS (
+                            SELECT 1
+                            FROM sqlite_temp_schema
+                            WHERE name = ?1 COLLATE NOCASE
+                              AND type IN ('table', 'view')
+                        )",
+                        [tbl_name.name.0.as_str()],
+                        |row| row.get(0),
+                    )?;
+
+                    if shadowed {
+                        return Ok(false);
                     }
                 }
 
                 &tbl_name.name.0
             }
-            _ => return false,
+            _ => return Ok(false),
         };
 
-        self.agent.schema().read().tables.contains_key(table)
+        Ok(self.agent.schema().read().tables.contains_key(table))
     }
 
     fn prepare_write(&mut self, cmd: &ParsedCmd) -> Result<(), QueryError> {
@@ -2212,24 +2276,65 @@ impl<'conn> Session<'conn> {
             self.tx_state.mark_writing(ts);
         }
 
-        if !self.tx_state.is_canonical() && !self.write_is_replayable(cmd) {
+        let replayable = match self.write_is_replayable(cmd) {
+            Ok(replayable) => replayable,
+            Err(err) => {
+                self.tx_state.mark_failed();
+                return Err(err.into());
+            }
+        };
+
+        if !self.tx_state.is_canonical() && !replayable {
             self.upgrade_to_canonical()?;
         }
 
         Ok(())
     }
 
+    fn rollback_sqlite_tx(&mut self) -> rusqlite::Result<()> {
+        let result = if self.conn.is_autocommit() {
+            Ok(())
+        } else {
+            self.conn.execute_batch("ROLLBACK")
+        };
+
+        let active = !self.conn.is_autocommit();
+        self.tx_state.set_sqlite_tx_active(active);
+        if !active {
+            self.tx_state.release_write_permit();
+        }
+
+        result
+    }
+
     fn upgrade_to_canonical(&mut self) -> Result<(), QueryError> {
         let actor_id = self.agent.actor_id();
-        let pending = PendingLocalChanges::capture(self.conn, actor_id)?;
+        let pending = match PendingLocalChanges::capture(self.conn, actor_id) {
+            Ok(pending) => pending,
+            Err(err) => {
+                self.tx_state.mark_failed();
+                return Err(err.into());
+            }
+        };
         let ts = self.tx_state.timestamp();
 
-        self.conn.execute_batch("ROLLBACK")?;
+        if let Err(err) = self.rollback_sqlite_tx() {
+            self.tx_state.mark_failed();
+            return Err(err.into());
+        }
 
-        let permit = self.agent.write_permit_blocking()?;
+        let permit = match self.agent.write_permit_blocking() {
+            Ok(permit) => permit,
+            Err(err) => {
+                self.tx_state.mark_failed();
+                return Err(err.into());
+            }
+        };
+        self.tx_state.set_write_permit(permit);
 
         let result = (|| -> rusqlite::Result<()> {
             self.conn.execute_batch("BEGIN IMMEDIATE")?;
+            self.tx_state.set_sqlite_tx_active(true);
 
             if let Some(ts) = ts {
                 self.set_ts_value(ts)?;
@@ -2262,12 +2367,15 @@ impl<'conn> Session<'conn> {
         })();
 
         if let Err(err) = result {
-            let _ = self.conn.execute_batch("ROLLBACK");
+            self.tx_state.mark_failed();
+            if let Err(cleanup_err) = self.rollback_sqlite_tx() {
+                return Err(cleanup_err.into());
+            }
             return Err(err.into());
         }
 
+        self.tx_state.set_sqlite_tx_active(true);
         counter!("corro.acquired.write.permit.count", "protocol" => "pg").increment(1);
-        self.tx_state.set_write_permit(permit);
 
         Ok(())
     }
@@ -2278,6 +2386,10 @@ impl<'conn> Session<'conn> {
         back_tx: &Sender<BackendResponse>,
         send_row_desc: bool,
     ) -> Result<(), QueryError> {
+        if self.tx_state.is_failed() && !cmd.is_commit() && !cmd.is_rollback() {
+            return Err(QueryError::TransactionAborted);
+        }
+
         if cmd.is_show() {
             back_tx
                 .blocking_send(
@@ -2326,12 +2438,17 @@ impl<'conn> Session<'conn> {
             self.tx_state.start_explicit();
             0
         } else if cmd.is_commit() {
-            let permit = self.tx_state.end();
-            self.handle_commit(permit.is_some())?;
+            if self.tx_state.is_failed() {
+                self.rollback_sqlite_tx()?;
+                let _permit = self.tx_state.end();
+            } else {
+                let permit = self.tx_state.end();
+                self.handle_commit(permit.is_some())?;
+            }
             0
         } else if cmd.is_rollback() {
+            self.rollback_sqlite_tx()?;
             let _permit = self.tx_state.end();
-            self.conn.execute_batch("ROLLBACK")?;
             0
         } else {
             let mut prepped = if cmd.is_pg() {
@@ -2433,6 +2550,10 @@ impl<'conn> Session<'conn> {
         max_rows: usize,
         back_tx: &Sender<BackendResponse>,
     ) -> Result<(), QueryError> {
+        if self.tx_state.is_failed() && !cmd.is_commit() && !cmd.is_rollback() {
+            return Err(QueryError::TransactionAborted);
+        }
+
         // TODO: maybe we don't need to recompute this...
         let fields = field_types(prepped, cmd, FieldFormats::Each(result_formats))?;
 
@@ -2466,8 +2587,16 @@ impl<'conn> Session<'conn> {
         let mut changes = 0usize;
 
         if cmd.is_commit() {
-            let permit = self.tx_state.end();
-            self.handle_commit(permit.is_some())?;
+            if self.tx_state.is_failed() {
+                self.rollback_sqlite_tx()?;
+                let _permit = self.tx_state.end();
+            } else {
+                let permit = self.tx_state.end();
+                self.handle_commit(permit.is_some())?;
+            }
+        } else if cmd.is_rollback() {
+            self.rollback_sqlite_tx()?;
+            let _permit = self.tx_state.end();
         } else if cmd.is_begin() {
             // do nothing
             debug!("cmd is BEGIN");
@@ -2798,12 +2927,12 @@ impl<'conn> Session<'conn> {
 impl<'conn> Drop for Session<'conn> {
     fn drop(&mut self) {
         if !self.tx_state.is_ended() {
-            let _permit = self.tx_state.end();
-            if let Err(e) = self.conn.execute_batch("ROLLBACK") {
+            if let Err(e) = self.rollback_sqlite_tx() {
                 warn!("failed to rollback tx: {e}");
             } else {
                 debug!("rolled back tx");
             }
+            let _permit = self.tx_state.end();
         }
     }
 }
@@ -2814,20 +2943,19 @@ fn send_ready(
     back_tx: &Sender<BackendResponse>,
 ) -> Result<(), BoxError> {
     let ready_status = if session.tx_state.is_implicit() {
-        let permit = session.tx_state.end(); // do this first, in case of failure
-        if discard_until_sync {
-            // an error occured, rollback implicit tx!
+        if discard_until_sync || session.tx_state.is_failed() {
             warn!("receive Sync message w/ an error to send, rolling back implicit tx");
-            session.conn.execute_batch("ROLLBACK")?;
+            session.rollback_sqlite_tx()?;
+            let _permit = session.tx_state.end();
         } else {
-            // no error, commit implicit tx
             warn!("receive Sync message, committing implicit tx");
+            let permit = session.tx_state.end();
             session.handle_commit(permit.is_some())?;
         }
 
         TransactionStatus::Idle
     } else if session.tx_state.is_explicit() {
-        if discard_until_sync {
+        if discard_until_sync || session.tx_state.is_failed() {
             TransactionStatus::Error
         } else {
             TransactionStatus::Transaction
@@ -2865,6 +2993,8 @@ enum QueryError {
     PermitAcquire(#[from] AcquireError),
     #[error(transparent)]
     Change(#[from] ChangeError),
+    #[error("current transaction is aborted, commands ignored until end of transaction block")]
+    TransactionAborted,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -2898,11 +3028,14 @@ impl TryFrom<QueryError> for PgWireBackendMessage {
                 ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string()).into()
             }
             e @ QueryError::PermitAcquire(_) => {
-                ErrorInfo::new("FATAL".to_owned(), "XX000".to_owned(), e.to_string()).into()
+                ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string()).into()
             }
             QueryError::BackendResponseSendFailed => return Err(ChannelClosed),
             QueryError::Change(e) => {
                 ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string()).into()
+            }
+            e @ QueryError::TransactionAborted => {
+                ErrorInfo::new("ERROR".to_owned(), "25P02".to_owned(), e.to_string()).into()
             }
         }))
     }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -25,7 +25,10 @@ use compact_str::CompactString;
 use corro_types::{
     agent::{Agent, ChangeError},
     broadcast::{broadcast_changes, Timestamp},
-    change::{insert_local_changes, InsertChangesInfo, PendingLocalChanges},
+    change::{
+        database_has_foreign_keys, database_has_user_triggers, insert_local_changes,
+        InsertChangesInfo, PendingLocalChanges,
+    },
     config::PgConfig,
     persistent_gauge,
     schema::{parse_sql, Column, Schema, SchemaError, SqliteType, Table},
@@ -2225,6 +2228,10 @@ impl<'conn> Session<'conn> {
         };
 
         if !self.agent.schema().read().tables.contains_key(table) {
+            return Ok(false);
+        }
+
+        if database_has_user_triggers(self.conn)? || database_has_foreign_keys(self.conn)? {
             return Ok(false);
         }
 

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -28,7 +28,7 @@ use corro_types::{
     broadcast::{broadcast_changes, Timestamp},
     change::{
         database_has_foreign_keys, database_has_user_triggers, database_schema_version,
-        insert_local_changes, InsertChangesInfo, PendingLocalChanges,
+        database_table_is_crr, insert_local_changes, InsertChangesInfo, PendingLocalChanges,
     },
     config::PgConfig,
     persistent_gauge,
@@ -2286,6 +2286,10 @@ impl<'conn> Session<'conn> {
         };
 
         if !self.agent.schema().read().tables.contains_key(table) {
+            return Ok(false);
+        }
+
+        if !database_table_is_crr(self.conn, table)? {
             return Ok(false);
         }
 

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2331,12 +2331,11 @@ impl<'conn> Session<'conn> {
             return Ok(());
         };
 
-        let actual =
-            database_schema_version(conn).map_err(|source| ChangeError::Rusqlite {
-                source,
-                actor_id: Some(self.agent.actor_id()),
-                version: None,
-            })?;
+        let actual = database_schema_version(conn).map_err(|source| ChangeError::Rusqlite {
+            source,
+            actor_id: Some(self.agent.actor_id()),
+            version: None,
+        })?;
 
         if actual != expected {
             return Err(ChangeError::SchemaChanged { expected, actual });
@@ -3018,8 +3017,7 @@ impl<'conn> Drop for Session<'conn> {
         if !self.tx_state.is_ended() {
             if let Err(e) = self.rollback_sqlite_tx() {
                 warn!("failed to rollback tx: {e}");
-                self.connection_drop_write_permit
-                    .hold(&mut self.tx_state);
+                self.connection_drop_write_permit.hold(&mut self.tx_state);
             } else {
                 debug!("rolled back tx");
                 let _permit = self.tx_state.end();

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -25,7 +25,7 @@ use compact_str::CompactString;
 use corro_types::{
     agent::{Agent, ChangeError},
     broadcast::{broadcast_changes, Timestamp},
-    change::{insert_local_changes, InsertChangesInfo},
+    change::{insert_local_changes, InsertChangesInfo, PendingLocalChanges},
     config::PgConfig,
     persistent_gauge,
     schema::{parse_sql, Column, Schema, SchemaError, SqliteType, Table},
@@ -355,7 +355,9 @@ fn parse_query(sql: &str) -> Result<VecDeque<ParsedCmd>, ParseError> {
 enum TxState {
     Started {
         kind: OpenTxKind,
+        writing: bool,
         write_permit: Option<OwnedSemaphorePermit>,
+        ts: Option<Timestamp>,
     },
     #[default]
     Ended,
@@ -365,17 +367,26 @@ impl TxState {
     fn implicit() -> Self {
         Self::Started {
             kind: OpenTxKind::Implicit,
+            writing: false,
             write_permit: None,
+            ts: None,
         }
     }
+
     fn explicit() -> Self {
         Self::Started {
             kind: OpenTxKind::Explicit,
+            writing: false,
             write_permit: None,
+            ts: None,
         }
     }
 
     fn is_writing(&self) -> bool {
+        matches!(self, TxState::Started { writing: true, .. })
+    }
+
+    fn is_canonical(&self) -> bool {
         matches!(
             self,
             TxState::Started {
@@ -385,12 +396,28 @@ impl TxState {
         )
     }
 
-    fn set_write_permit(&mut self, permit: OwnedSemaphorePermit) {
-        match self {
-            TxState::Started { write_permit, .. } => *write_permit = Some(permit),
-            TxState::Ended => {
-                // do nothing, maybe bomb?
+    fn mark_writing(&mut self, ts: Timestamp) {
+        if let TxState::Started {
+            writing, ts: tx_ts, ..
+        } = self
+        {
+            *writing = true;
+            if tx_ts.is_none() {
+                *tx_ts = Some(ts);
             }
+        }
+    }
+
+    fn set_write_permit(&mut self, permit: OwnedSemaphorePermit) {
+        if let TxState::Started { write_permit, .. } = self {
+            *write_permit = Some(permit);
+        }
+    }
+
+    fn timestamp(&self) -> Option<Timestamp> {
+        match self {
+            TxState::Started { ts, .. } => *ts,
+            TxState::Ended => None,
         }
     }
 
@@ -403,6 +430,7 @@ impl TxState {
             }
         )
     }
+
     fn is_explicit(&self) -> bool {
         matches!(
             self,
@@ -412,6 +440,7 @@ impl TxState {
             }
         )
     }
+
     fn is_ended(&self) -> bool {
         matches!(self, TxState::Ended)
     }
@@ -429,6 +458,7 @@ impl TxState {
             TxState::Started { write_permit, .. } => write_permit.take(),
             TxState::Ended => None,
         };
+
         *self = TxState::Ended;
         permit
     }
@@ -1859,9 +1889,9 @@ pub async fn start(
                                     // automatically commit an implicit tx
                                     if session.tx_state.is_implicit() {
                                         trace!("committing IMPLICIT tx");
-                                        let _permit = session.tx_state.end();
+                                        let permit = session.tx_state.end();
 
-                                        if let Err(e) = session.handle_commit() {
+                                        if let Err(e) = session.handle_commit(permit.is_some()) {
                                             back_tx.blocking_send(
                                                 (
                                                     PgWireBackendMessage::ErrorResponse(
@@ -2155,6 +2185,93 @@ struct Session<'conn> {
 }
 
 impl<'conn> Session<'conn> {
+    fn write_is_replayable(&self, cmd: &ParsedCmd) -> bool {
+        let table = match cmd {
+            ParsedCmd::Sqlite(Cmd::Stmt(
+                Stmt::Insert { tbl_name, .. }
+                | Stmt::Update { tbl_name, .. }
+                | Stmt::Delete { tbl_name, .. },
+            )) => {
+                if let Some(db_name) = &tbl_name.db_name {
+                    if !db_name.0.as_str().eq_ignore_ascii_case("main") {
+                        return false;
+                    }
+                }
+
+                &tbl_name.name.0
+            }
+            _ => return false,
+        };
+
+        self.agent.schema().read().tables.contains_key(table)
+    }
+
+    fn prepare_write(&mut self, cmd: &ParsedCmd) -> Result<(), QueryError> {
+        if !self.tx_state.is_writing() {
+            let ts = self.set_ts()?;
+            self.tx_state.mark_writing(ts);
+        }
+
+        if !self.tx_state.is_canonical() && !self.write_is_replayable(cmd) {
+            self.upgrade_to_canonical()?;
+        }
+
+        Ok(())
+    }
+
+    fn upgrade_to_canonical(&mut self) -> Result<(), QueryError> {
+        let actor_id = self.agent.actor_id();
+        let pending = PendingLocalChanges::capture(self.conn, actor_id)?;
+        let ts = self.tx_state.timestamp();
+
+        self.conn.execute_batch("ROLLBACK")?;
+
+        let permit = self.agent.write_permit_blocking()?;
+
+        let result = (|| -> rusqlite::Result<()> {
+            self.conn.execute_batch("BEGIN IMMEDIATE")?;
+
+            if let Some(ts) = ts {
+                self.set_ts_value(ts)?;
+            }
+
+            if let Some(reserved_version) = pending.replay(self.conn)? {
+                let replayed: bool = self.conn.query_row(
+                    r#"
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM crsql_changes
+                        WHERE site_id = ?
+                          AND db_version = ?
+                    )
+                    "#,
+                    (actor_id, reserved_version),
+                    |row| row.get(0),
+                )?;
+
+                if !replayed {
+                    self.conn.execute_batch("ROLLBACK; BEGIN IMMEDIATE;")?;
+
+                    if let Some(ts) = ts {
+                        self.set_ts_value(ts)?;
+                    }
+                }
+            }
+
+            Ok(())
+        })();
+
+        if let Err(err) = result {
+            let _ = self.conn.execute_batch("ROLLBACK");
+            return Err(err.into());
+        }
+
+        counter!("corro.acquired.write.permit.count", "protocol" => "pg").increment(1);
+        self.tx_state.set_write_permit(permit);
+
+        Ok(())
+    }
+
     fn handle_query(
         &mut self,
         cmd: &ParsedCmd,
@@ -2189,14 +2306,14 @@ impl<'conn> Session<'conn> {
 
         // need to start an implicit transaction
         if self.tx_state.is_ended() && !cmd.is_begin() {
-            self.conn.execute_batch("BEGIN")?;
+            self.conn.execute_batch("BEGIN CONCURRENT")?;
             trace!("started IMPLICIT tx");
             self.tx_state.start_implicit();
         } else if self.tx_state.is_implicit() && cmd.is_begin() {
             trace!("committing IMPLICIT tx");
-            let _permit = self.tx_state.end();
+            let permit = self.tx_state.end();
 
-            self.handle_commit()?;
+            self.handle_commit(permit.is_some())?;
             trace!("committed IMPLICIT tx");
         }
 
@@ -2205,12 +2322,12 @@ impl<'conn> Session<'conn> {
         let mut changes = 0usize;
 
         let count = if cmd.is_begin() {
-            self.conn.execute_batch("BEGIN")?;
+            self.conn.execute_batch("BEGIN CONCURRENT")?;
             self.tx_state.start_explicit();
             0
         } else if cmd.is_commit() {
-            let _permit = self.tx_state.end();
-            self.handle_commit()?;
+            let permit = self.tx_state.end();
+            self.handle_commit(permit.is_some())?;
             0
         } else if cmd.is_rollback() {
             let _permit = self.tx_state.end();
@@ -2241,13 +2358,9 @@ impl<'conn> Session<'conn> {
 
             let schema = Arc::new(fields);
 
-            if !self.tx_state.is_writing() && !prepped.readonly() {
-                trace!("query statement writes, acquiring permit...");
-                self.tx_state
-                    .set_write_permit(self.agent.write_permit_blocking()?);
-
-                counter!("corro.acquired.write.permit.count", "protocol" => "pg").increment(1);
-                self.set_ts()?;
+            if !prepped.readonly() {
+                trace!("query statement writes");
+                self.prepare_write(cmd)?;
             }
 
             let mut rows = prepped.raw_query();
@@ -2335,13 +2448,13 @@ impl<'conn> Session<'conn> {
             if !cmd.is_begin() && !prepped.readonly() {
                 debug!("tx is_ended && !cmd.is_begin() && !prepped.readonly()");
                 // NOT in a tx and statement mutates DB...
-                self.conn.execute_batch("BEGIN")?;
+                self.conn.execute_batch("BEGIN CONCURRENT")?;
 
                 self.tx_state.start_implicit();
                 opened_implicit_tx = true;
             } else if cmd.is_begin() {
                 debug!("cmd is BEGIN");
-                self.conn.execute_batch("BEGIN")?;
+                self.conn.execute_batch("BEGIN CONCURRENT")?;
                 self.tx_state.start_explicit();
                 debug!("started EXPLICIT tx");
             }
@@ -2353,18 +2466,15 @@ impl<'conn> Session<'conn> {
         let mut changes = 0usize;
 
         if cmd.is_commit() {
-            let _permit = self.tx_state.end();
-            self.handle_commit()?;
+            let permit = self.tx_state.end();
+            self.handle_commit(permit.is_some())?;
         } else if cmd.is_begin() {
             // do nothing
             debug!("cmd is BEGIN");
         } else {
-            if !self.tx_state.is_writing() && !prepped.readonly() {
-                trace!("statement writes, acquiring permit...");
-                self.tx_state
-                    .set_write_permit(self.agent.write_permit_blocking()?);
-
-                self.set_ts()?;
+            if !prepped.readonly() {
+                trace!("statement writes");
+                self.prepare_write(cmd)?;
             }
             let mut rows = prepped.raw_query();
             loop {
@@ -2506,8 +2616,8 @@ impl<'conn> Session<'conn> {
             }
 
             if opened_implicit_tx {
-                let _permit = self.tx_state.end();
-                self.handle_commit()?;
+                let permit = self.tx_state.end();
+                self.handle_commit(permit.is_some())?;
             }
         }
 
@@ -2529,24 +2639,122 @@ impl<'conn> Session<'conn> {
         Ok(())
     }
 
-    fn handle_commit(&self) -> Result<(), ChangeError> {
+    fn handle_commit(&self, canonical: bool) -> Result<(), ChangeError> {
         trace!("HANDLE COMMIT");
-
-        let mut book_writer = self
-            .agent
-            .booked()
-            .blocking_write::<&str, _>("handle_write_tx(book_writer)", None);
 
         let actor_id = self.agent.actor_id();
 
-        let insert_info = insert_local_changes(&self.agent, self.conn, &mut book_writer)?;
+        if canonical {
+            let mut book_writer = self
+                .agent
+                .booked()
+                .blocking_write::<&str, _>("handle_write_tx(booked writer)", None);
+
+            let result = (|| {
+                let insert_info = insert_local_changes(&self.agent, self.conn, &mut book_writer)?;
+
+                self.conn
+                    .execute_batch("COMMIT")
+                    .map_err(|source| ChangeError::Rusqlite {
+                        source,
+                        actor_id: Some(actor_id),
+                        version: insert_info.as_ref().map(|info| info.db_version),
+                    })?;
+
+                Ok::<_, ChangeError>(insert_info)
+            })();
+
+            let insert_info = match result {
+                Ok(insert_info) => insert_info,
+                Err(err) => {
+                    let _ = self.conn.execute_batch("ROLLBACK");
+                    return Err(err);
+                }
+            };
+
+            if let Some(InsertChangesInfo {
+                db_version,
+                last_seq,
+                ts,
+                snap,
+            }) = insert_info
+            {
+                book_writer.commit_snapshot(snap);
+
+                let agent = self.agent.clone();
+                spawn_counted(
+                    async move { broadcast_changes(agent, db_version, last_seq, ts).await },
+                );
+            }
+
+            return Ok(());
+        }
+
+        let pending = match PendingLocalChanges::capture(self.conn, actor_id) {
+            Ok(pending) => pending,
+            Err(source) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                return Err(ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: None,
+                });
+            }
+        };
+
         self.conn
-            .execute_batch("COMMIT")
+            .execute_batch("ROLLBACK")
             .map_err(|source| ChangeError::Rusqlite {
                 source,
                 actor_id: Some(actor_id),
                 version: None,
             })?;
+
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn =
+            tokio::runtime::Handle::current().block_on(self.agent.pool().write_priority())?;
+
+        let mut book_writer = self
+            .agent
+            .booked()
+            .blocking_write::<&str, _>("handle_write_tx(booked writer)", None);
+
+        let tx = conn
+            .immediate_transaction()
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
+        let reserved_version = pending
+            .replay(&tx)
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: None,
+            })?;
+
+        let insert_info = insert_local_changes(&self.agent, &tx, &mut book_writer)?;
+
+        if reserved_version.is_some() && insert_info.is_none() {
+            tx.rollback().map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: reserved_version,
+            })?;
+
+            return Ok(());
+        }
+
+        tx.commit().map_err(|source| ChangeError::Rusqlite {
+            source,
+            actor_id: Some(actor_id),
+            version: insert_info.as_ref().map(|info| info.db_version),
+        })?;
 
         if let Some(InsertChangesInfo {
             db_version,
@@ -2560,20 +2768,28 @@ impl<'conn> Session<'conn> {
             book_writer.commit_snapshot(snap);
 
             let agent = self.agent.clone();
-
             spawn_counted(async move { broadcast_changes(agent, db_version, last_seq, ts).await });
         }
 
         Ok(())
     }
 
-    fn set_ts(&self) -> Result<(), rusqlite::Error> {
+    fn set_ts(&self) -> Result<Timestamp, rusqlite::Error> {
         let ts = Timestamp::from(self.agent.clock().new_timestamp());
 
-        let _ = self
+        let _: String = self
             .conn
             .prepare_cached("SELECT crsql_set_ts(?)")?
-            .query_row([&ts], |row| row.get::<_, String>(0))?;
+            .query_row([&ts], |row| row.get(0))?;
+
+        Ok(ts)
+    }
+
+    fn set_ts_value(&self, ts: Timestamp) -> Result<(), rusqlite::Error> {
+        let _: String = self
+            .conn
+            .prepare_cached("SELECT crsql_set_ts(?)")?
+            .query_row([&ts], |row| row.get(0))?;
 
         Ok(())
     }
@@ -2598,7 +2814,7 @@ fn send_ready(
     back_tx: &Sender<BackendResponse>,
 ) -> Result<(), BoxError> {
     let ready_status = if session.tx_state.is_implicit() {
-        let _permit = session.tx_state.end(); // do this first, in case of failure
+        let permit = session.tx_state.end(); // do this first, in case of failure
         if discard_until_sync {
             // an error occured, rollback implicit tx!
             warn!("receive Sync message w/ an error to send, rolling back implicit tx");
@@ -2606,7 +2822,7 @@ fn send_ready(
         } else {
             // no error, commit implicit tx
             warn!("receive Sync message, committing implicit tx");
-            session.handle_commit()?;
+            session.handle_commit(permit.is_some())?;
         }
 
         TransactionStatus::Idle

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -1115,18 +1115,21 @@ pub async fn start(
                                             debug!("prepped parameter count: {}", prepped.parameter_count());
 
                                             if param_types.len() != prepped.parameter_count() {
-                                                let extracted_types = parameter_types(&schema, &parsed_cmd);
-
-                                                if extracted_types.is_err() {
-                                                        let e = extracted_types.unwrap_err();
-                                                        back_tx.blocking_send(BackendResponse::Message {
-                                                            message: e.into(),
-                                                            flush: true,
-                                                        })?;
-                                                        discard_until_sync = true;
-                                                        continue;
-                                                    }
-                                                param_types = extracted_types.unwrap().params
+                                                let extracted_types =
+                                                    match parameter_types(&schema, &parsed_cmd) {
+                                                        Ok(extracted_types) => extracted_types,
+                                                        Err(e) => {
+                                                            back_tx.blocking_send(
+                                                                BackendResponse::Message {
+                                                                    message: e.into(),
+                                                                    flush: true,
+                                                                },
+                                                            )?;
+                                                            discard_until_sync = true;
+                                                            continue;
+                                                        }
+                                                    };
+                                                param_types = extracted_types.params
                                                     .into_iter()
                                                     .map(|param| {
                                                         trace!("got param: {param:?}");

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -27,8 +27,8 @@ use corro_types::{
     agent::{Agent, ChangeError},
     broadcast::{broadcast_changes, Timestamp},
     change::{
-        database_has_foreign_keys, database_has_user_triggers, insert_local_changes,
-        InsertChangesInfo, PendingLocalChanges,
+        database_has_foreign_keys, database_has_user_triggers, database_schema_version,
+        insert_local_changes, InsertChangesInfo, PendingLocalChanges,
     },
     config::PgConfig,
     persistent_gauge,
@@ -363,6 +363,7 @@ enum TxState {
         failed: bool,
         write_permit: Option<OwnedSemaphorePermit>,
         ts: Option<Timestamp>,
+        schema_version: Option<i64>,
     },
     #[default]
     Ended,
@@ -376,6 +377,7 @@ impl TxState {
             failed: false,
             write_permit: None,
             ts: None,
+            schema_version: None,
         }
     }
 
@@ -386,6 +388,7 @@ impl TxState {
             failed: false,
             write_permit: None,
             ts: None,
+            schema_version: None,
         }
     }
 
@@ -413,14 +416,20 @@ impl TxState {
         }
     }
 
-    fn mark_writing(&mut self, ts: Timestamp) {
+    fn mark_writing(&mut self, ts: Timestamp, schema_version: i64) {
         if let TxState::Started {
-            writing, ts: tx_ts, ..
+            writing,
+            ts: tx_ts,
+            schema_version: tx_schema_version,
+            ..
         } = self
         {
             *writing = true;
             if tx_ts.is_none() {
                 *tx_ts = Some(ts);
+            }
+            if tx_schema_version.is_none() {
+                *tx_schema_version = Some(schema_version);
             }
         }
     }
@@ -440,6 +449,13 @@ impl TxState {
     fn timestamp(&self) -> Option<Timestamp> {
         match self {
             TxState::Started { ts, .. } => *ts,
+            TxState::Ended => None,
+        }
+    }
+
+    fn schema_version(&self) -> Option<i64> {
+        match self {
+            TxState::Started { schema_version, .. } => *schema_version,
             TxState::Ended => None,
         }
     }
@@ -2287,7 +2303,8 @@ impl<'conn> Session<'conn> {
     fn prepare_write(&mut self, cmd: &ParsedCmd) -> Result<(), QueryError> {
         if !self.tx_state.is_writing() {
             let ts = self.set_ts()?;
-            self.tx_state.mark_writing(ts);
+            let schema_version = database_schema_version(self.conn)?;
+            self.tx_state.mark_writing(ts, schema_version);
         }
 
         let replayable = match self.write_is_replayable(cmd) {
@@ -2300,6 +2317,25 @@ impl<'conn> Session<'conn> {
 
         if !self.tx_state.is_canonical() && !replayable {
             self.upgrade_to_canonical()?;
+        }
+
+        Ok(())
+    }
+
+    fn ensure_schema_unchanged(&self, conn: &Connection) -> Result<(), ChangeError> {
+        let Some(expected) = self.tx_state.schema_version() else {
+            return Ok(());
+        };
+
+        let actual =
+            database_schema_version(conn).map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(self.agent.actor_id()),
+                version: None,
+            })?;
+
+        if actual != expected {
+            return Err(ChangeError::SchemaChanged { expected, actual });
         }
 
         Ok(())
@@ -2344,8 +2380,9 @@ impl<'conn> Session<'conn> {
         };
         self.tx_state.set_write_permit(permit);
 
-        let result = (|| -> rusqlite::Result<()> {
+        let result = (|| -> Result<(), QueryError> {
             self.conn.execute_batch("BEGIN IMMEDIATE")?;
+            self.ensure_schema_unchanged(self.conn)?;
 
             if let Some(ts) = ts {
                 self.set_ts_value(ts)?;
@@ -2382,7 +2419,7 @@ impl<'conn> Session<'conn> {
             if let Err(cleanup_err) = self.rollback_sqlite_tx() {
                 return Err(cleanup_err.into());
             }
-            return Err(err.into());
+            return Err(err);
         }
 
         counter!("corro.acquired.write.permit.count", "protocol" => "pg").increment(1);
@@ -2904,6 +2941,8 @@ impl<'conn> Session<'conn> {
                 actor_id: Some(actor_id),
                 version: None,
             })?;
+
+        self.ensure_schema_unchanged(&tx)?;
 
         let reserved_version = pending
             .replay(&tx)

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -2449,9 +2449,7 @@ impl<'conn> Session<'conn> {
         back_tx: &Sender<BackendResponse>,
         send_row_desc: bool,
     ) -> Result<(), QueryError> {
-        if self.tx_state.is_failed() && !cmd.is_commit() && !cmd.is_rollback() {
-            return Err(QueryError::TransactionAborted);
-        }
+        self.validate_transaction_command(cmd)?;
 
         if cmd.is_show() {
             back_tx
@@ -2499,12 +2497,7 @@ impl<'conn> Session<'conn> {
             self.tx_state.start_explicit();
             0
         } else if cmd.is_commit() {
-            if self.tx_state.is_failed() {
-                self.rollback_sqlite_tx()?;
-                let _permit = self.tx_state.end();
-            } else {
-                self.commit_tx()?;
-            }
+            self.commit_tx()?;
             0
         } else if cmd.is_rollback() {
             self.rollback_sqlite_tx()?;
@@ -2626,9 +2619,7 @@ impl<'conn> Session<'conn> {
         max_rows: usize,
         back_tx: &Sender<BackendResponse>,
     ) -> Result<(), QueryError> {
-        if self.tx_state.is_failed() && !cmd.is_commit() && !cmd.is_rollback() {
-            return Err(QueryError::TransactionAborted);
-        }
+        self.validate_transaction_command(cmd)?;
 
         // TODO: maybe we don't need to recompute this...
         let fields = field_types(prepped, cmd, FieldFormats::Each(result_formats))?;
@@ -2663,12 +2654,7 @@ impl<'conn> Session<'conn> {
         let mut changes = 0usize;
 
         if cmd.is_commit() {
-            if self.tx_state.is_failed() {
-                self.rollback_sqlite_tx()?;
-                let _permit = self.tx_state.end();
-            } else {
-                self.commit_tx()?;
-            }
+            self.commit_tx()?;
         } else if cmd.is_rollback() {
             self.rollback_sqlite_tx()?;
             let _permit = self.tx_state.end();
@@ -2838,6 +2824,18 @@ impl<'conn> Session<'conn> {
                     .into(),
             )
             .map_err(|_| QueryError::BackendResponseSendFailed)?;
+
+        Ok(())
+    }
+
+    fn validate_transaction_command(&self, cmd: &ParsedCmd) -> Result<(), QueryError> {
+        if self.tx_state.is_failed() && !cmd.is_rollback() {
+            return Err(QueryError::TransactionAborted);
+        }
+
+        if self.tx_state.is_explicit() && cmd.is_begin() {
+            return Err(QueryError::ActiveTransaction);
+        }
 
         Ok(())
     }
@@ -3087,6 +3085,8 @@ enum QueryError {
     Change(#[from] ChangeError),
     #[error("current transaction is aborted, commands ignored until end of transaction block")]
     TransactionAborted,
+    #[error("there is already a transaction in progress")]
+    ActiveTransaction,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -3126,9 +3126,18 @@ impl TryFrom<QueryError> for PgWireBackendMessage {
             QueryError::Change(e) => {
                 ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), e.to_string()).into()
             }
-            e @ QueryError::TransactionAborted => {
-                ErrorInfo::new("ERROR".to_owned(), "25P02".to_owned(), e.to_string()).into()
-            }
+            e @ QueryError::TransactionAborted => ErrorInfo::new(
+                "ERROR".to_owned(),
+                SqlState::IN_FAILED_SQL_TRANSACTION.code().into(),
+                e.to_string(),
+            )
+            .into(),
+            e @ QueryError::ActiveTransaction => ErrorInfo::new(
+                "ERROR".to_owned(),
+                SqlState::ACTIVE_SQL_TRANSACTION.code().into(),
+                e.to_string(),
+            )
+            .into(),
         }))
     }
 }

--- a/crates/corro-pg/src/lib.rs
+++ b/crates/corro-pg/src/lib.rs
@@ -7,6 +7,7 @@ mod vtab;
 use codec::VecFromSqlText;
 use eyre::WrapErr;
 use std::{
+    cell::RefCell,
     collections::{BTreeSet, HashMap, VecDeque},
     fmt,
     net::SocketAddr,
@@ -486,6 +487,44 @@ impl TxState {
     }
 }
 
+#[derive(Clone, Default)]
+struct ConnectionDropWritePermit(Rc<RefCell<Option<OwnedSemaphorePermit>>>);
+
+impl ConnectionDropWritePermit {
+    fn hold(&self, tx_state: &mut TxState) {
+        let permit = tx_state.end();
+        let mut held = self.0.borrow_mut();
+        debug_assert!(held.is_none());
+        *held = permit;
+    }
+}
+
+#[cfg(test)]
+mod connection_drop_tests {
+    use super::{ConnectionDropWritePermit, TxState};
+    use std::sync::Arc;
+
+    #[test]
+    fn write_permit_is_held_until_connection_owner_drops() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = semaphore.clone().try_acquire_owned().unwrap();
+        let mut tx_state = TxState::explicit();
+        tx_state.set_write_permit(permit);
+
+        let connection_owner = ConnectionDropWritePermit::default();
+        let session_owner = connection_owner.clone();
+        session_owner.hold(&mut tx_state);
+        drop(session_owner);
+
+        assert!(tx_state.is_ended());
+        assert!(semaphore.clone().try_acquire_owned().is_err());
+
+        drop(connection_owner);
+
+        assert!(semaphore.try_acquire_owned().is_ok());
+    }
+}
+
 #[derive(Debug)]
 enum OpenTxKind {
     Implicit,
@@ -903,6 +942,7 @@ pub async fn start(
                 let res = tokio::task::spawn_blocking({
                     let back_tx = back_tx.clone();
                     move || {
+                        let connection_drop_write_permit = ConnectionDropWritePermit::default();
                         let conn = if readonly {
                             agent.pool().client_dedicated_readonly().unwrap()
                         } else {
@@ -993,6 +1033,7 @@ pub async fn start(
                             agent,
                             conn: &conn,
                             tx_state: TxState::default(),
+                            connection_drop_write_permit: connection_drop_write_permit.clone(),
                         };
 
                         let mut prepared: HashMap<CompactString, Prepared> = HashMap::new();
@@ -2206,6 +2247,7 @@ struct Session<'conn> {
     agent: Agent,
     conn: &'conn CrConn,
     tx_state: TxState,
+    connection_drop_write_permit: ConnectionDropWritePermit,
 }
 
 impl<'conn> Session<'conn> {
@@ -2933,10 +2975,12 @@ impl<'conn> Drop for Session<'conn> {
         if !self.tx_state.is_ended() {
             if let Err(e) = self.rollback_sqlite_tx() {
                 warn!("failed to rollback tx: {e}");
+                self.connection_drop_write_permit
+                    .hold(&mut self.tx_state);
             } else {
                 debug!("rolled back tx");
+                let _permit = self.tx_state.end();
             }
-            let _permit = self.tx_state.end();
         }
     }
 }

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -555,6 +555,84 @@ async fn test_pg_canonical_upgrade_error_rolls_back_and_releases_writer() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pg_disconnect_rolls_back_and_releases_writer() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    {
+        let (client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        let client_conn = tokio::spawn(client_conn);
+
+        client
+            .batch_execute(
+                "CREATE TABLE pg_disconnect_side (
+                    id BIGINT PRIMARY KEY NOT NULL
+                )",
+            )
+            .await
+            .unwrap();
+
+        client
+            .batch_execute(
+                "BEGIN;
+                 INSERT INTO tests (id, text) VALUES (340, 'disconnect');
+                 INSERT INTO pg_disconnect_side (id) VALUES (1);",
+            )
+            .await
+            .unwrap();
+
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(5), client_conn)
+            .await
+            .expect("server did not close the disconnected PG session")
+            .expect("PG connection task panicked")
+            .expect("PG connection closed with an error");
+
+        let (recovery, recovery_conn) =
+            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        tokio::spawn(recovery_conn);
+
+        let tracked_rows = recovery
+            .query_one("SELECT COUNT(*) FROM tests WHERE id = 340", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        let side_rows = recovery
+            .query_one(
+                "SELECT COUNT(*) FROM pg_disconnect_side WHERE id = 1",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(tracked_rows, 0);
+        assert_eq!(side_rows, 0);
+
+        let affected = tokio::time::timeout(
+            Duration::from_secs(5),
+            recovery.execute(
+                "INSERT INTO pg_disconnect_side (id) VALUES (2)",
+                &[],
+            ),
+        )
+        .await
+        .expect("writer remained blocked after PG disconnect")
+        .unwrap();
+        assert_eq!(affected, 1);
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
 

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -309,11 +309,9 @@ async fn test_pg_schema_change_aborts_speculative_replay() {
 
     let conn = ta.agent.pool().read().await.unwrap();
     let tracked_rows: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM tests WHERE id = 951",
-            (),
-            |row| row.get(0),
-        )
+        .query_row("SELECT COUNT(*) FROM tests WHERE id = 951", (), |row| {
+            row.get(0)
+        })
         .unwrap();
     let audit_rows: i64 = conn
         .query_row("SELECT COUNT(*) FROM pg_schema_race_audit", (), |row| {

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -644,7 +644,7 @@ async fn test_pg_simple_query_error_rolls_back_implicit_transaction() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_pg_constraint_error_aborts_explicit_transaction() {
+async fn test_pg_transaction_errors_require_rollback() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
     let (ta, server) = setup_pg_test_server(tripwire, None).await;
 
@@ -670,10 +670,21 @@ async fn test_pg_constraint_error_aborts_explicit_transaction() {
         .await
         .expect_err("the duplicate statement must fail");
 
+        let rejected_commit = tx
+            .execute("COMMIT", &[])
+            .await
+            .expect_err("commit must not recover a failed transaction");
+        assert_eq!(
+            rejected_commit
+                .as_db_error()
+                .map(|error| error.code().code()),
+            Some("25P02")
+        );
+
         let aborted = tx
             .query_one("SELECT 1", &[])
             .await
-            .expect_err("constraint failure must abort the explicit transaction");
+            .expect_err("rejected commit must leave the transaction failed");
         assert_eq!(
             aborted.as_db_error().map(|error| error.code().code()),
             Some("25P02")
@@ -687,6 +698,83 @@ async fn test_pg_constraint_error_aborts_explicit_transaction() {
             .unwrap()
             .get::<_, i64>(0);
         assert_eq!(rows, 0);
+
+        client.batch_execute("BEGIN").await.unwrap();
+        client
+            .batch_execute("INSERT INTO tests (id, text) VALUES (322, 'first')")
+            .await
+            .unwrap();
+        client
+            .batch_execute("INSERT INTO tests (id, text) VALUES (322, 'duplicate')")
+            .await
+            .expect_err("the duplicate statement must fail");
+
+        let rejected_commit = client
+            .batch_execute("COMMIT")
+            .await
+            .expect_err("commit must not recover a failed transaction");
+        assert_eq!(
+            rejected_commit
+                .as_db_error()
+                .map(|error| error.code().code()),
+            Some("25P02")
+        );
+
+        let aborted = client
+            .batch_execute("SELECT 1")
+            .await
+            .expect_err("rejected commit must leave the transaction failed");
+        assert_eq!(
+            aborted.as_db_error().map(|error| error.code().code()),
+            Some("25P02")
+        );
+
+        client.batch_execute("ROLLBACK").await.unwrap();
+
+        let rows = client
+            .query_one("SELECT COUNT(*) FROM tests WHERE id = 322", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(rows, 0);
+
+        client.batch_execute("BEGIN").await.unwrap();
+        let active = client
+            .batch_execute("BEGIN")
+            .await
+            .expect_err("nested begin must fail");
+        assert_eq!(
+            active.as_db_error().map(|error| error.code().code()),
+            Some("25001")
+        );
+        let aborted = client
+            .batch_execute("SELECT 1")
+            .await
+            .expect_err("nested begin must abort the transaction");
+        assert_eq!(
+            aborted.as_db_error().map(|error| error.code().code()),
+            Some("25P02")
+        );
+        client.batch_execute("ROLLBACK").await.unwrap();
+
+        client.execute("BEGIN", &[]).await.unwrap();
+        let active = client
+            .execute("BEGIN", &[])
+            .await
+            .expect_err("nested begin must fail");
+        assert_eq!(
+            active.as_db_error().map(|error| error.code().code()),
+            Some("25001")
+        );
+        let aborted = client
+            .query_one("SELECT 1", &[])
+            .await
+            .expect_err("nested begin must abort the transaction");
+        assert_eq!(
+            aborted.as_db_error().map(|error| error.code().code()),
+            Some("25P02")
+        );
+        client.execute("ROLLBACK", &[]).await.unwrap();
 
         let permit = tokio::time::timeout(
             Duration::from_secs(5),

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -189,6 +189,65 @@ async fn test_pg_concurrent_writers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pg_stale_tracked_schema_forces_canonical_path() {
+    let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    let (mut client, conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(conn);
+
+    client
+        .batch_execute(
+            "DROP TABLE tests;
+             CREATE TABLE tests (
+                 id INTEGER NOT NULL PRIMARY KEY,
+                 text TEXT NOT NULL DEFAULT ''
+             ) WITHOUT ROWID",
+        )
+        .await
+        .unwrap();
+
+    assert!(ta.agent.schema().read().tables.contains_key("tests"));
+
+    let permit = ta.agent.write_sema().acquire().await.unwrap();
+    let tx = client.transaction().await.unwrap();
+    let mut write = Box::pin(tx.execute(
+        "INSERT INTO tests (id, text) VALUES (961, 'canonical')",
+        &[],
+    ));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), &mut write)
+            .await
+            .is_err()
+    );
+
+    drop(permit);
+
+    let affected = tokio::time::timeout(Duration::from_secs(5), &mut write)
+        .await
+        .expect("canonical write remained blocked")
+        .unwrap();
+    assert_eq!(affected, 1);
+
+    drop(write);
+    tx.commit().await.unwrap();
+
+    let row = client
+        .query_one("SELECT text FROM tests WHERE id = 961", &[])
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<_, String>(0), "canonical");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg_schema_change_aborts_speculative_replay() {
     let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
     let (_ta, server) = setup_pg_test_server(tripwire, None).await;

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -189,6 +189,139 @@ async fn test_pg_concurrent_writers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pg_temp_table_shadow_is_not_silently_rolled_back() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    {
+        let (mut client, client_conn) =
+            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        tokio::spawn(client_conn);
+
+        client
+            .batch_execute(
+                "CREATE TEMP TABLE tests (
+                    id BIGINT PRIMARY KEY NOT NULL,
+                    text TEXT NOT NULL
+                )",
+            )
+            .await
+            .unwrap();
+
+        let tx = client.transaction().await.unwrap();
+        let affected = tx
+            .execute(
+                "INSERT INTO tests (id, text) VALUES (301, 'temp-shadow')",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(affected, 1);
+        tx.commit().await.unwrap();
+
+        let temp_count = client
+            .query_one(
+                "SELECT COUNT(*) FROM temp.tests WHERE id = 301",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(temp_count, 1);
+
+        let main_count = client
+            .query_one(
+                "SELECT COUNT(*) FROM main.tests WHERE id = 301",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(main_count, 0);
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_upgrade_acquire_failure_remains_rollbackable() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    {
+        let (mut client, client_conn) =
+            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        tokio::spawn(client_conn);
+
+        client
+            .batch_execute(
+                "CREATE TEMP TABLE upgrade_target (
+                    id BIGINT PRIMARY KEY NOT NULL
+                )",
+            )
+            .await
+            .unwrap();
+
+        let tx = client.transaction().await.unwrap();
+        tx.execute(
+            "INSERT INTO main.tests (id, text) VALUES (302, 'rolled-back')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        ta.agent.write_sema().close();
+
+        tx.execute("INSERT INTO temp.upgrade_target (id) VALUES (1)", &[])
+            .await
+            .expect_err("canonical upgrade must fail after the write semaphore closes");
+
+        let aborted = tx
+            .query_one("SELECT 1", &[])
+            .await
+            .expect_err("failed upgrade must abort the explicit transaction");
+        assert_eq!(
+            aborted.as_db_error().map(|error| error.code().code()),
+            Some("25P02")
+        );
+
+        tx.rollback()
+            .await
+            .expect("failed upgrade must leave the explicit transaction rollbackable");
+
+        let main_count = client
+            .query_one(
+                "SELECT COUNT(*) FROM main.tests WHERE id = 302",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(main_count, 0);
+
+        client.simple_query("SELECT 1").await.unwrap();
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
 

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -222,11 +222,9 @@ async fn test_pg_stale_tracked_schema_forces_canonical_path() {
         &[],
     ));
 
-    assert!(
-        tokio::time::timeout(Duration::from_millis(200), &mut write)
-            .await
-            .is_err()
-    );
+    assert!(tokio::time::timeout(Duration::from_millis(200), &mut write)
+        .await
+        .is_err());
 
     drop(permit);
 
@@ -299,7 +297,9 @@ async fn test_pg_schema_change_aborts_speculative_replay() {
     .unwrap();
 
     let err = tx.commit().await.unwrap_err();
-    let db_error = err.as_db_error().expect("commit error was not a database error");
+    let db_error = err
+        .as_db_error()
+        .expect("commit error was not a database error");
     assert!(
         db_error
             .message()
@@ -365,11 +365,9 @@ async fn test_pg_user_trigger_forces_canonical_path() {
         &[],
     ));
 
-    assert!(
-        tokio::time::timeout(Duration::from_millis(200), &mut write)
-            .await
-            .is_err()
-    );
+    assert!(tokio::time::timeout(Duration::from_millis(200), &mut write)
+        .await
+        .is_err());
 
     drop(permit);
 
@@ -420,10 +418,7 @@ async fn test_pg_foreign_key_forces_canonical_path() {
         .unwrap();
 
     client
-        .execute(
-            "INSERT INTO tests (id, text) VALUES (911, 'parent')",
-            &[],
-        )
+        .execute("INSERT INTO tests (id, text) VALUES (911, 'parent')", &[])
         .await
         .unwrap();
 
@@ -437,16 +432,11 @@ async fn test_pg_foreign_key_forces_canonical_path() {
 
     let permit = ta.agent.write_sema().acquire().await.unwrap();
     let tx = client.transaction().await.unwrap();
-    let mut write = Box::pin(tx.execute(
-        "UPDATE tests SET id = 912 WHERE id = 911",
-        &[],
-    ));
+    let mut write = Box::pin(tx.execute("UPDATE tests SET id = 912 WHERE id = 911", &[]));
 
-    assert!(
-        tokio::time::timeout(Duration::from_millis(200), &mut write)
-            .await
-            .is_err()
-    );
+    assert!(tokio::time::timeout(Duration::from_millis(200), &mut write)
+        .await
+        .is_err());
 
     drop(permit);
 

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -248,7 +248,7 @@ async fn test_pg_stale_tracked_schema_forces_canonical_path() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pg_schema_change_aborts_speculative_replay() {
     let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
-    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
 
     let conn_str = format!(
         "host={} port={} user=testuser",
@@ -307,18 +307,22 @@ async fn test_pg_schema_change_aborts_speculative_replay() {
         "{db_error:?}"
     );
 
-    let row = client2
-        .query_one(
-            "SELECT
-                 (SELECT COUNT(*) FROM tests WHERE id = 951),
-                 (SELECT COUNT(*) FROM pg_schema_race_audit)",
-            &[],
+    let conn = ta.agent.pool().read().await.unwrap();
+    let tracked_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM tests WHERE id = 951",
+            (),
+            |row| row.get(0),
         )
-        .await
+        .unwrap();
+    let audit_rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pg_schema_race_audit", (), |row| {
+            row.get(0)
+        })
         .unwrap();
 
-    assert_eq!(row.get::<_, i64>(0), 0);
-    assert_eq!(row.get::<_, i64>(1), 0);
+    assert_eq!(tracked_rows, 0);
+    assert_eq!(audit_rows, 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -189,6 +189,153 @@ async fn test_pg_concurrent_writers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pg_user_trigger_forces_canonical_path() {
+    let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    let (mut client, conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(conn);
+
+    client
+        .batch_execute(
+            "CREATE TABLE pg_trigger_audit (
+                id INTEGER PRIMARY KEY,
+                seen TEXT NOT NULL
+            )",
+        )
+        .await
+        .unwrap();
+
+    client
+        .batch_execute(
+            "CREATE TRIGGER kitchensink_audit
+             AFTER INSERT ON kitchensink
+             BEGIN
+                 INSERT INTO pg_trigger_audit (id, seen)
+                 VALUES (NEW.id, NEW.other_ts || ':' || NEW.updated_at);
+             END",
+        )
+        .await
+        .unwrap();
+
+    let permit = ta.agent.write_sema().acquire().await.unwrap();
+    let tx = client.transaction().await.unwrap();
+    let mut write = Box::pin(tx.execute(
+        "INSERT INTO kitchensink (id, other_ts, updated_at)
+         VALUES (901, '2024-01-02T03:04:05', '2025-06-07T08:09:10')",
+        &[],
+    ));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), &mut write)
+            .await
+            .is_err()
+    );
+
+    drop(permit);
+
+    let affected = tokio::time::timeout(Duration::from_secs(5), &mut write)
+        .await
+        .expect("canonical write remained blocked")
+        .unwrap();
+    assert_eq!(affected, 1);
+
+    drop(write);
+    tx.commit().await.unwrap();
+
+    let row = client
+        .query_one("SELECT COUNT(*), MIN(seen) FROM pg_trigger_audit", &[])
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<_, i64>(0), 1);
+    assert_eq!(
+        row.get::<_, String>(1),
+        "2024-01-02T03:04:05:2025-06-07T08:09:10"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_foreign_key_forces_canonical_path() {
+    let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    let (mut client, conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(conn);
+
+    client
+        .batch_execute(
+            "CREATE TABLE pg_fk_child (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER NOT NULL
+                    REFERENCES tests(id) ON UPDATE CASCADE
+            )",
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO tests (id, text) VALUES (911, 'parent')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    client
+        .execute(
+            "INSERT INTO pg_fk_child (id, parent_id) VALUES (1, 911)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let permit = ta.agent.write_sema().acquire().await.unwrap();
+    let tx = client.transaction().await.unwrap();
+    let mut write = Box::pin(tx.execute(
+        "UPDATE tests SET id = 912 WHERE id = 911",
+        &[],
+    ));
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), &mut write)
+            .await
+            .is_err()
+    );
+
+    drop(permit);
+
+    let affected = tokio::time::timeout(Duration::from_secs(5), &mut write)
+        .await
+        .expect("canonical write remained blocked")
+        .unwrap();
+    assert_eq!(affected, 1);
+
+    drop(write);
+    tx.commit().await.unwrap();
+
+    let parent_id = client
+        .query_one("SELECT parent_id FROM pg_fk_child WHERE id = 1", &[])
+        .await
+        .unwrap()
+        .get::<_, i64>(0);
+
+    assert_eq!(parent_id, 912);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg_temp_table_shadow_is_not_silently_rolled_back() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
     let (_ta, server) = setup_pg_test_server(tripwire, None).await;

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -189,6 +189,80 @@ async fn test_pg_concurrent_writers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pg_schema_change_aborts_speculative_replay() {
+    let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    let (mut client1, conn1) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    let (client2, conn2) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(conn1);
+    tokio::spawn(conn2);
+
+    client2
+        .batch_execute(
+            "CREATE TABLE pg_schema_race_audit (
+                id INTEGER PRIMARY KEY,
+                seen TEXT NOT NULL
+            )",
+        )
+        .await
+        .unwrap();
+
+    let tx = client1.transaction().await.unwrap();
+    let affected = tx
+        .execute(
+            "INSERT INTO tests (id, text) VALUES (951, 'old-schema')",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(affected, 1);
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        client2.batch_execute(
+            "CREATE TRIGGER tests_schema_race_audit
+             AFTER INSERT ON tests
+             BEGIN
+                 INSERT INTO pg_schema_race_audit (id, seen)
+                 VALUES (NEW.id, NEW.text);
+             END",
+        ),
+    )
+    .await
+    .expect("schema change was blocked by speculative transaction")
+    .unwrap();
+
+    let err = tx.commit().await.unwrap_err();
+    let db_error = err.as_db_error().expect("commit error was not a database error");
+    assert!(
+        db_error
+            .message()
+            .contains("database schema changed during speculative transaction"),
+        "{db_error:?}"
+    );
+
+    let row = client2
+        .query_one(
+            "SELECT
+                 (SELECT COUNT(*) FROM tests WHERE id = 951),
+                 (SELECT COUNT(*) FROM pg_schema_race_audit)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<_, i64>(0), 0);
+    assert_eq!(row.get::<_, i64>(1), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg_user_trigger_forces_canonical_path() {
     let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
     let (ta, server) = setup_pg_test_server(tripwire, None).await;

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -74,6 +74,121 @@ async fn setup_pg_test_server(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_pg_mixed_transaction_upgrades_to_canonical() {
+    let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    let (mut client, conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    tokio::spawn(conn);
+
+    let tx = client.transaction().await.unwrap();
+
+    let affected = tx
+        .execute(
+            "INSERT INTO tests VALUES ($1, $2)",
+            &[&201i64, &"before-upgrade"],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(affected, 1);
+
+    tx.batch_execute(
+        "CREATE TABLE pg_upgrade_marker (
+            id INTEGER PRIMARY KEY
+        )",
+    )
+    .await
+    .unwrap();
+
+    tx.commit().await.unwrap();
+
+    let row = client
+        .query_one("SELECT text FROM tests WHERE id = 201", &[])
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<_, String>(0), "before-upgrade");
+
+    let row = client
+        .query_one(
+            "SELECT COUNT(*) FROM sqlite_schema \
+             WHERE type = 'table' AND name = 'pg_upgrade_marker'",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<_, i64>(0), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_concurrent_writers() {
+    let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let sema = ta.agent.write_sema().clone();
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    let (mut client1, conn1) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+    let (mut client2, conn2) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+
+    tokio::spawn(conn1);
+    tokio::spawn(conn2);
+
+    let tx1 = client1.transaction().await.unwrap();
+    let tx2 = client2.transaction().await.unwrap();
+
+    let permit = sema.acquire().await.unwrap();
+
+    let (write1, write2) = tokio::join!(
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            tx1.execute(
+                "INSERT INTO tests VALUES ($1, $2)",
+                &[&101i64, &"writer-one"],
+            ),
+        ),
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            tx2.execute(
+                "INSERT INTO tests VALUES ($1, $2)",
+                &[&102i64, &"writer-two"],
+            ),
+        ),
+    );
+
+    assert_eq!(write1.expect("first speculative write blocked").unwrap(), 1);
+    assert_eq!(
+        write2.expect("second speculative write blocked").unwrap(),
+        1
+    );
+
+    drop(permit);
+
+    let (commit1, commit2) = tokio::join!(tx1.commit(), tx2.commit());
+    commit1.unwrap();
+    commit2.unwrap();
+
+    let row = client1
+        .query_one("SELECT COUNT(*) FROM tests WHERE id IN (101, 102)", &[])
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<_, i64>(0), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pg() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
 

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -200,8 +200,7 @@ async fn test_pg_temp_table_shadow_is_not_silently_rolled_back() {
     );
 
     {
-        let (mut client, client_conn) =
-            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        let (mut client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
         tokio::spawn(client_conn);
 
         client
@@ -226,20 +225,14 @@ async fn test_pg_temp_table_shadow_is_not_silently_rolled_back() {
         tx.commit().await.unwrap();
 
         let temp_count = client
-            .query_one(
-                "SELECT COUNT(*) FROM temp.tests WHERE id = 301",
-                &[],
-            )
+            .query_one("SELECT COUNT(*) FROM temp.tests WHERE id = 301", &[])
             .await
             .unwrap()
             .get::<_, i64>(0);
         assert_eq!(temp_count, 1);
 
         let main_count = client
-            .query_one(
-                "SELECT COUNT(*) FROM main.tests WHERE id = 301",
-                &[],
-            )
+            .query_one("SELECT COUNT(*) FROM main.tests WHERE id = 301", &[])
             .await
             .unwrap()
             .get::<_, i64>(0);
@@ -255,10 +248,7 @@ async fn test_pg_temp_table_shadow_is_not_silently_rolled_back() {
         assert_eq!(affected, 1);
 
         let qualified_main_count = client
-            .query_one(
-                "SELECT COUNT(*) FROM main.tests WHERE id = 303",
-                &[],
-            )
+            .query_one("SELECT COUNT(*) FROM main.tests WHERE id = 303", &[])
             .await
             .unwrap()
             .get::<_, i64>(0);
@@ -282,8 +272,7 @@ async fn test_pg_upgrade_acquire_failure_remains_rollbackable() {
     );
 
     {
-        let (mut client, client_conn) =
-            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        let (mut client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
         tokio::spawn(client_conn);
 
         client
@@ -323,10 +312,7 @@ async fn test_pg_upgrade_acquire_failure_remains_rollbackable() {
             .expect("failed upgrade must leave the explicit transaction rollbackable");
 
         let main_count = client
-            .query_one(
-                "SELECT COUNT(*) FROM main.tests WHERE id = 302",
-                &[],
-            )
+            .query_one("SELECT COUNT(*) FROM main.tests WHERE id = 302", &[])
             .await
             .unwrap()
             .get::<_, i64>(0);
@@ -372,10 +358,7 @@ async fn test_pg_simple_query_error_rolls_back_implicit_transaction() {
 
         let affected = tokio::time::timeout(
             Duration::from_secs(5),
-            client.execute(
-                "INSERT INTO tests (id, text) VALUES (311, 'recovery')",
-                &[],
-            ),
+            client.execute("INSERT INTO tests (id, text) VALUES (311, 'recovery')", &[]),
         )
         .await
         .expect("writer remained blocked after implicit rollback")
@@ -400,17 +383,13 @@ async fn test_pg_constraint_error_aborts_explicit_transaction() {
     );
 
     {
-        let (mut client, client_conn) =
-            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        let (mut client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
         tokio::spawn(client_conn);
 
         let tx = client.transaction().await.unwrap();
-        tx.execute(
-            "INSERT INTO tests (id, text) VALUES (320, 'first')",
-            &[],
-        )
-        .await
-        .unwrap();
+        tx.execute("INSERT INTO tests (id, text) VALUES (320, 'first')", &[])
+            .await
+            .unwrap();
 
         tx.execute(
             "INSERT INTO tests (id, text) VALUES (320, 'duplicate')",
@@ -448,10 +427,7 @@ async fn test_pg_constraint_error_aborts_explicit_transaction() {
 
         let affected = tokio::time::timeout(
             Duration::from_secs(5),
-            client.execute(
-                "INSERT INTO tests (id, text) VALUES (321, 'recovery')",
-                &[],
-            ),
+            client.execute("INSERT INTO tests (id, text) VALUES (321, 'recovery')", &[]),
         )
         .await
         .expect("writer remained blocked after explicit rollback")
@@ -476,8 +452,7 @@ async fn test_pg_canonical_upgrade_error_rolls_back_and_releases_writer() {
     );
 
     {
-        let (mut client, client_conn) =
-            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        let (mut client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
         tokio::spawn(client_conn);
 
         client
@@ -538,10 +513,7 @@ async fn test_pg_canonical_upgrade_error_rolls_back_and_releases_writer() {
 
         let affected = tokio::time::timeout(
             Duration::from_secs(5),
-            client.execute(
-                "INSERT INTO tests (id, text) VALUES (331, 'recovery')",
-                &[],
-            ),
+            client.execute("INSERT INTO tests (id, text) VALUES (331, 'recovery')", &[]),
         )
         .await
         .expect("writer remained blocked after canonical rollback")
@@ -596,8 +568,7 @@ async fn test_pg_disconnect_rolls_back_and_releases_writer() {
             .expect("PG connection task panicked")
             .expect("PG connection closed with an error");
 
-        let (recovery, recovery_conn) =
-            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        let (recovery, recovery_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
         tokio::spawn(recovery_conn);
 
         let tracked_rows = recovery
@@ -606,10 +577,7 @@ async fn test_pg_disconnect_rolls_back_and_releases_writer() {
             .unwrap()
             .get::<_, i64>(0);
         let side_rows = recovery
-            .query_one(
-                "SELECT COUNT(*) FROM pg_disconnect_side WHERE id = 1",
-                &[],
-            )
+            .query_one("SELECT COUNT(*) FROM pg_disconnect_side WHERE id = 1", &[])
             .await
             .unwrap()
             .get::<_, i64>(0);
@@ -618,10 +586,7 @@ async fn test_pg_disconnect_rolls_back_and_releases_writer() {
 
         let affected = tokio::time::timeout(
             Duration::from_secs(5),
-            recovery.execute(
-                "INSERT INTO pg_disconnect_side (id) VALUES (2)",
-                &[],
-            ),
+            recovery.execute("INSERT INTO pg_disconnect_side (id) VALUES (2)", &[]),
         )
         .await
         .expect("writer remained blocked after PG disconnect")

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -557,7 +557,7 @@ async fn test_pg_canonical_upgrade_error_rolls_back_and_releases_writer() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pg_disconnect_rolls_back_and_releases_writer() {
     let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
-    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
 
     let conn_str = format!(
         "host={} port={} user=testuser",
@@ -586,6 +586,8 @@ async fn test_pg_disconnect_rolls_back_and_releases_writer() {
             )
             .await
             .unwrap();
+
+        assert_eq!(ta.agent.write_sema().available_permits(), 0);
 
         drop(client);
         tokio::time::timeout(Duration::from_secs(5), client_conn)

--- a/crates/corro-pg/tests/tests.rs
+++ b/crates/corro-pg/tests/tests.rs
@@ -244,6 +244,25 @@ async fn test_pg_temp_table_shadow_is_not_silently_rolled_back() {
             .unwrap()
             .get::<_, i64>(0);
         assert_eq!(main_count, 0);
+
+        let affected = client
+            .execute(
+                "INSERT INTO main.tests (id, text) VALUES (303, 'qualified-main')",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(affected, 1);
+
+        let qualified_main_count = client
+            .query_one(
+                "SELECT COUNT(*) FROM main.tests WHERE id = 303",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(qualified_main_count, 1);
     }
 
     tripwire_tx.send(()).await.ok();
@@ -269,7 +288,7 @@ async fn test_pg_upgrade_acquire_failure_remains_rollbackable() {
 
         client
             .batch_execute(
-                "CREATE TEMP TABLE upgrade_target (
+                "CREATE TABLE upgrade_target (
                     id BIGINT PRIMARY KEY NOT NULL
                 )",
             )
@@ -286,7 +305,7 @@ async fn test_pg_upgrade_acquire_failure_remains_rollbackable() {
 
         ta.agent.write_sema().close();
 
-        tx.execute("INSERT INTO temp.upgrade_target (id) VALUES (1)", &[])
+        tx.execute("INSERT INTO upgrade_target (id) VALUES (1)", &[])
             .await
             .expect_err("canonical upgrade must fail after the write semaphore closes");
 
@@ -314,6 +333,220 @@ async fn test_pg_upgrade_acquire_failure_remains_rollbackable() {
         assert_eq!(main_count, 0);
 
         client.simple_query("SELECT 1").await.unwrap();
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_simple_query_error_rolls_back_implicit_transaction() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (_ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    {
+        let (client, client_conn) = tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        tokio::spawn(client_conn);
+
+        client
+            .batch_execute(
+                "INSERT INTO tests (id, text) VALUES (310, 'first');
+                 INSERT INTO tests (id, text) VALUES (310, 'duplicate');",
+            )
+            .await
+            .expect_err("the duplicate statement must fail");
+
+        let rows = client
+            .query_one("SELECT COUNT(*) FROM tests WHERE id = 310", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(rows, 0);
+
+        let affected = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.execute(
+                "INSERT INTO tests (id, text) VALUES (311, 'recovery')",
+                &[],
+            ),
+        )
+        .await
+        .expect("writer remained blocked after implicit rollback")
+        .unwrap();
+        assert_eq!(affected, 1);
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_constraint_error_aborts_explicit_transaction() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    {
+        let (mut client, client_conn) =
+            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        tokio::spawn(client_conn);
+
+        let tx = client.transaction().await.unwrap();
+        tx.execute(
+            "INSERT INTO tests (id, text) VALUES (320, 'first')",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        tx.execute(
+            "INSERT INTO tests (id, text) VALUES (320, 'duplicate')",
+            &[],
+        )
+        .await
+        .expect_err("the duplicate statement must fail");
+
+        let aborted = tx
+            .query_one("SELECT 1", &[])
+            .await
+            .expect_err("constraint failure must abort the explicit transaction");
+        assert_eq!(
+            aborted.as_db_error().map(|error| error.code().code()),
+            Some("25P02")
+        );
+
+        tx.rollback().await.unwrap();
+
+        let rows = client
+            .query_one("SELECT COUNT(*) FROM tests WHERE id = 320", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(rows, 0);
+
+        let permit = tokio::time::timeout(
+            Duration::from_secs(5),
+            ta.agent.write_sema().clone().acquire_owned(),
+        )
+        .await
+        .expect("write permit remained blocked after explicit rollback")
+        .unwrap();
+        drop(permit);
+
+        let affected = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.execute(
+                "INSERT INTO tests (id, text) VALUES (321, 'recovery')",
+                &[],
+            ),
+        )
+        .await
+        .expect("writer remained blocked after explicit rollback")
+        .unwrap();
+        assert_eq!(affected, 1);
+    }
+
+    tripwire_tx.send(()).await.ok();
+    tripwire_worker.await;
+    wait_for_all_pending_handles().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pg_canonical_upgrade_error_rolls_back_and_releases_writer() {
+    let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+    let (ta, server) = setup_pg_test_server(tripwire, None).await;
+
+    let conn_str = format!(
+        "host={} port={} user=testuser",
+        server.local_addr.ip(),
+        server.local_addr.port()
+    );
+
+    {
+        let (mut client, client_conn) =
+            tokio_postgres::connect(&conn_str, NoTls).await.unwrap();
+        tokio::spawn(client_conn);
+
+        client
+            .batch_execute(
+                "CREATE TABLE pg_canonical_side (
+                    id BIGINT PRIMARY KEY NOT NULL
+                )",
+            )
+            .await
+            .unwrap();
+
+        let tx = client.transaction().await.unwrap();
+        tx.execute(
+            "INSERT INTO tests (id, text) VALUES (330, 'before-upgrade')",
+            &[],
+        )
+        .await
+        .unwrap();
+        tx.execute("INSERT INTO pg_canonical_side (id) VALUES (1)", &[])
+            .await
+            .unwrap();
+        tx.execute("INSERT INTO pg_canonical_side (id) VALUES (1)", &[])
+            .await
+            .expect_err("the duplicate canonical statement must fail");
+
+        let aborted = tx
+            .query_one("SELECT 1", &[])
+            .await
+            .expect_err("canonical failure must abort the explicit transaction");
+        assert_eq!(
+            aborted.as_db_error().map(|error| error.code().code()),
+            Some("25P02")
+        );
+
+        tx.rollback().await.unwrap();
+
+        let tracked_rows = client
+            .query_one("SELECT COUNT(*) FROM tests WHERE id = 330", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        let side_rows = client
+            .query_one("SELECT COUNT(*) FROM pg_canonical_side WHERE id = 1", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0);
+        assert_eq!(tracked_rows, 0);
+        assert_eq!(side_rows, 0);
+
+        let permit = tokio::time::timeout(
+            Duration::from_secs(5),
+            ta.agent.write_sema().clone().acquire_owned(),
+        )
+        .await
+        .expect("write permit remained blocked after canonical rollback")
+        .unwrap();
+        drop(permit);
+
+        let affected = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.execute(
+                "INSERT INTO tests (id, text) VALUES (331, 'recovery')",
+                &[],
+            ),
+        )
+        .await
+        .expect("writer remained blocked after canonical rollback")
+        .unwrap();
+        assert_eq!(affected, 1);
     }
 
     tripwire_tx.send(()).await.ok();

--- a/crates/corro-types/src/agent.rs
+++ b/crates/corro-types/src/agent.rs
@@ -470,6 +470,10 @@ pub enum ChangeError {
     },
     #[error("non-contiguous empties range delete")]
     NonContiguousDelete,
+    #[error(
+        "database schema changed during speculative transaction (expected version {expected}, found {actual})"
+    )]
+    SchemaChanged { expected: i64, actual: i64 },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -189,6 +189,10 @@ pub struct InsertChangesInfo {
     pub snap: VersionsSnapshot,
 }
 
+pub fn database_schema_version(conn: &Connection) -> rusqlite::Result<i64> {
+    conn.query_row("PRAGMA main.schema_version", (), |row| row.get(0))
+}
+
 pub fn database_has_user_triggers(conn: &Connection) -> rusqlite::Result<bool> {
     conn.query_row(
         r#"

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -218,7 +218,7 @@ impl PendingLocalChanges {
                 site_id,
                 cl,
                 ts
-            FROM crsql_changes
+            FROM main.crsql_changes
             WHERE site_id = ?
               AND db_version = ?
             ORDER BY seq
@@ -251,7 +251,7 @@ impl PendingLocalChanges {
 
         let mut stmt = conn.prepare_cached(
             r#"
-            INSERT INTO crsql_changes
+            INSERT INTO main.crsql_changes
                 ("table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
@@ -301,7 +301,7 @@ pub fn insert_local_changes(
 
     let version_info: (Option<CrsqlSeq>, Option<Timestamp>) = tx
         .prepare_cached(
-            "SELECT MAX(seq), MAX(ts) FROM crsql_changes WHERE site_id = ? AND db_version = ?;",
+            "SELECT MAX(seq), MAX(ts) FROM main.crsql_changes WHERE site_id = ? AND db_version = ?;",
         )
         .map_err(|source| ChangeError::Rusqlite {
             source,

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -482,7 +482,7 @@ mod tests {
         conn.execute_batch(
             "
             CREATE TABLE tracked (
-                id INTEGER PRIMARY KEY,
+                id INTEGER NOT NULL PRIMARY KEY,
                 value TEXT NOT NULL DEFAULT ''
             );
             SELECT crsql_as_crr('tracked');
@@ -513,7 +513,7 @@ mod tests {
         conn.execute_batch(
             "
             CREATE TABLE tracked (
-                id INTEGER PRIMARY KEY,
+                id INTEGER NOT NULL PRIMARY KEY,
                 value TEXT NOT NULL DEFAULT ''
             );
             SELECT crsql_as_crr('tracked');

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -4,13 +4,14 @@ use antithesis_sdk::assert_always;
 pub use corro_api_types::SqliteValue;
 use corro_api_types::{ColumnName, TableName};
 use corro_base_types::{CrsqlDbVersion, CrsqlSeqRange};
-use rusqlite::{Connection, Row};
+use rusqlite::{params, Connection, Row};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use speedy::{Readable, Writable};
 use tracing::{debug, trace, warn};
 
 use crate::{
+    actor::ActorId,
     agent::{Agent, BookedVersions, ChangeError, VersionsSnapshot},
     base::CrsqlSeq,
     broadcast::{ChangesetPerTable, Timestamp},
@@ -188,6 +189,95 @@ pub struct InsertChangesInfo {
     pub snap: VersionsSnapshot,
 }
 
+#[derive(Debug, Clone)]
+struct PendingLocalChange {
+    change: Change,
+    ts: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PendingLocalChanges {
+    changes: Vec<PendingLocalChange>,
+}
+
+impl PendingLocalChanges {
+    pub fn capture(conn: &Connection, actor_id: ActorId) -> rusqlite::Result<Self> {
+        let db_version: CrsqlDbVersion =
+            conn.query_row("SELECT crsql_peek_next_db_version()", (), |row| row.get(0))?;
+
+        let mut stmt = conn.prepare_cached(
+            r#"
+            SELECT
+                "table",
+                pk,
+                cid,
+                val,
+                col_version,
+                db_version,
+                seq,
+                site_id,
+                cl,
+                ts
+            FROM crsql_changes
+            WHERE site_id = ?
+              AND db_version = ?
+            ORDER BY seq
+            "#,
+        )?;
+
+        let changes = stmt
+            .query_map((actor_id, db_version), |row| {
+                Ok(PendingLocalChange {
+                    change: row_to_change(row)?,
+                    ts: row.get(9)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(Self { changes })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+
+    pub fn replay(&self, conn: &Connection) -> rusqlite::Result<Option<CrsqlDbVersion>> {
+        if self.changes.is_empty() {
+            return Ok(None);
+        }
+
+        let db_version: CrsqlDbVersion =
+            conn.query_row("SELECT crsql_next_db_version()", (), |row| row.get(0))?;
+
+        let mut stmt = conn.prepare_cached(
+            r#"
+            INSERT INTO crsql_changes
+                ("table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )?;
+
+        for pending in &self.changes {
+            let change = &pending.change;
+
+            stmt.execute(params![
+                &change.table,
+                &change.pk,
+                &change.cid,
+                &change.val,
+                change.col_version,
+                db_version,
+                &change.site_id,
+                change.cl,
+                change.seq,
+                &pending.ts,
+            ])?;
+        }
+
+        Ok(Some(db_version))
+    }
+}
+
 pub fn insert_local_changes(
     agent: &Agent,
     tx: &Connection,
@@ -265,6 +355,63 @@ pub fn insert_local_changes(
 mod tests {
     use super::*;
     use crate::base::dbsr;
+
+    #[test]
+    fn test_pending_local_changes_capture_and_replay() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("pending-local-changes.db");
+
+        let speculative = crate::sqlite::rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        speculative.execute_batch(
+            "
+            CREATE TABLE foo (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT ''
+            );
+            SELECT crsql_as_crr('foo');
+            BEGIN CONCURRENT;
+            ",
+        )?;
+
+        let actor_id: ActorId =
+            speculative.query_row("SELECT crsql_site_id()", (), |row| row.get(0))?;
+
+        let _: String =
+            speculative.query_row("SELECT crsql_set_ts('401')", (), |row| row.get(0))?;
+
+        speculative.execute("INSERT INTO foo (id, value) VALUES (1, 'speculative')", ())?;
+
+        let pending = PendingLocalChanges::capture(&speculative, actor_id)?;
+        assert!(!pending.is_empty());
+
+        speculative.execute_batch("ROLLBACK;")?;
+
+        let canonical = crate::sqlite::rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        canonical.execute_batch("BEGIN IMMEDIATE;")?;
+
+        let db_version = pending
+            .replay(&canonical)?
+            .expect("expected a reserved db version");
+
+        let rows: i64 = canonical.query_row(
+            "SELECT COUNT(*) FROM crsql_changes WHERE site_id = ? AND db_version = ?",
+            (actor_id, db_version),
+            |row| row.get(0),
+        )?;
+
+        assert_eq!(rows, 1);
+
+        canonical.execute_batch("COMMIT;")?;
+
+        let value: String =
+            canonical.query_row("SELECT value FROM foo WHERE id = 1", (), |row| row.get(0))?;
+
+        assert_eq!(value, "speculative");
+
+        Ok(())
+    }
 
     #[test]
     fn test_change_chunker() {

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -193,6 +193,52 @@ pub fn database_schema_version(conn: &Connection) -> rusqlite::Result<i64> {
     conn.query_row("PRAGMA main.schema_version", (), |row| row.get(0))
 }
 
+pub fn database_table_is_crr(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    conn.query_row(
+        r#"
+        SELECT
+            EXISTS (
+                SELECT 1
+                FROM main.sqlite_schema
+                WHERE type = 'table'
+                  AND name = ?1 COLLATE NOCASE
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM main.sqlite_schema
+                WHERE type = 'table'
+                  AND name = (?1 || '__crsql_clock') COLLATE NOCASE
+            )
+            AND 3 = (
+                SELECT COUNT(*)
+                FROM main.sqlite_schema AS trg
+                WHERE trg.type = 'trigger'
+                  AND trg.tbl_name = ?1 COLLATE NOCASE
+                  AND instr(
+                      lower(coalesce(trg.sql, '')),
+                      'crsql_internal_sync_bit()'
+                  ) > 0
+                  AND (
+                      (
+                          trg.name = (?1 || '__crsql_itrig') COLLATE NOCASE
+                          AND instr(lower(trg.sql), 'crsql_after_insert(') > 0
+                      )
+                      OR (
+                          trg.name = (?1 || '__crsql_utrig') COLLATE NOCASE
+                          AND instr(lower(trg.sql), 'crsql_after_update(') > 0
+                      )
+                      OR (
+                          trg.name = (?1 || '__crsql_dtrig') COLLATE NOCASE
+                          AND instr(lower(trg.sql), 'crsql_after_delete(') > 0
+                      )
+                  )
+            )
+        "#,
+        [table],
+        |row| row.get(0),
+    )
+}
+
 pub fn database_has_user_triggers(conn: &Connection) -> rusqlite::Result<bool> {
     conn.query_row(
         r#"
@@ -428,6 +474,37 @@ pub fn insert_local_changes(
 mod tests {
     use super::*;
     use crate::base::dbsr;
+
+    #[test]
+    fn test_database_table_is_crr_uses_live_schema() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = crate::sqlite::rusqlite_to_crsqlite(Connection::open_in_memory()?)?;
+
+        conn.execute_batch(
+            "
+            CREATE TABLE tracked (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT ''
+            );
+            SELECT crsql_as_crr('tracked');
+            ",
+        )?;
+
+        assert!(database_table_is_crr(&conn, "tracked")?);
+
+        conn.execute_batch(
+            "
+            DROP TABLE tracked;
+            CREATE TABLE tracked (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT ''
+            );
+            ",
+        )?;
+
+        assert!(!database_table_is_crr(&conn, "tracked")?);
+
+        Ok(())
+    }
 
     #[test]
     fn test_replay_side_effect_detection() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -194,21 +194,46 @@ pub fn database_has_user_triggers(conn: &Connection) -> rusqlite::Result<bool> {
         r#"
         SELECT EXISTS (
             SELECT 1
-            FROM main.sqlite_schema
-            WHERE type = 'trigger'
+            FROM main.sqlite_schema AS trg
+            WHERE trg.type = 'trigger'
               AND NOT (
-                  name IN (
-                      tbl_name || '__crsql_itrig',
-                      tbl_name || '__crsql_utrig',
-                      tbl_name || '__crsql_dtrig'
+                  (
+                      EXISTS (
+                          SELECT 1
+                          FROM main.sqlite_schema AS clock
+                          WHERE clock.type = 'table'
+                            AND clock.name = trg.tbl_name || '__crsql_clock'
+                      )
+                      AND instr(
+                          lower(coalesce(trg.sql, '')),
+                          'crsql_internal_sync_bit()'
+                      ) > 0
+                      AND (
+                          (
+                              trg.name = trg.tbl_name || '__crsql_itrig'
+                              AND instr(lower(trg.sql), 'crsql_after_insert(') > 0
+                          )
+                          OR (
+                              trg.name = trg.tbl_name || '__crsql_utrig'
+                              AND instr(lower(trg.sql), 'crsql_after_update(') > 0
+                          )
+                          OR (
+                              trg.name = trg.tbl_name || '__crsql_dtrig'
+                              AND instr(lower(trg.sql), 'crsql_after_delete(') > 0
+                          )
+                      )
                   )
                   OR (
-                      tbl_name = 'crsql_site_id'
-                      AND name IN (
+                      trg.tbl_name = 'crsql_site_id'
+                      AND trg.name IN (
                           'crsql_site_id_insert_trig',
                           'crsql_site_id_update_trig',
                           'crsql_site_id_delete_trig'
                       )
+                      AND instr(
+                          lower(coalesce(trg.sql, '')),
+                          'crsql_update_site_id('
+                      ) > 0
                   )
               )
         )
@@ -219,24 +244,18 @@ pub fn database_has_user_triggers(conn: &Connection) -> rusqlite::Result<bool> {
 }
 
 pub fn database_has_foreign_keys(conn: &Connection) -> rusqlite::Result<bool> {
-    let tables = {
-        let mut stmt = conn.prepare_cached(
-            "SELECT name FROM main.sqlite_schema WHERE type = 'table' AND name IS NOT NULL",
-        )?;
-        let rows = stmt.query_map((), |row| row.get::<_, String>(0))?;
-        rows.collect::<rusqlite::Result<Vec<_>>>()?
-    };
-
-    let mut stmt =
-        conn.prepare_cached("SELECT EXISTS (SELECT 1 FROM pragma_foreign_key_list(?1))")?;
-
-    for table in tables {
-        if stmt.query_row([table], |row| row.get(0))? {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
+    conn.query_row(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM main.sqlite_schema
+            WHERE type = 'table'
+              AND instr(lower(coalesce(sql, '')), 'references') > 0
+        )
+        "#,
+        (),
+        |row| row.get(0),
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -405,6 +424,53 @@ pub fn insert_local_changes(
 mod tests {
     use super::*;
     use crate::base::dbsr;
+
+    #[test]
+    fn test_replay_side_effect_detection() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = crate::sqlite::rusqlite_to_crsqlite(Connection::open_in_memory()?)?;
+
+        conn.execute_batch(
+            "
+            CREATE TABLE tracked (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT ''
+            );
+            SELECT crsql_as_crr('tracked');
+            ",
+        )?;
+
+        assert!(!database_has_user_triggers(&conn)?);
+        assert!(!database_has_foreign_keys(&conn)?);
+
+        conn.execute_batch(
+            "
+            CREATE TABLE exact_name_shadow (id INTEGER PRIMARY KEY);
+            CREATE TRIGGER exact_name_shadow__crsql_itrig
+            AFTER INSERT ON exact_name_shadow
+            BEGIN
+                SELECT 1;
+            END;
+            ",
+        )?;
+
+        assert!(database_has_user_triggers(&conn)?);
+
+        conn.execute_batch(
+            "
+            DROP TRIGGER exact_name_shadow__crsql_itrig;
+            CREATE TABLE fk_parent (id INTEGER PRIMARY KEY);
+            CREATE TABLE fk_child (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER REFERENCES fk_parent(id)
+            );
+            ",
+        )?;
+
+        assert!(!database_has_user_triggers(&conn)?);
+        assert!(database_has_foreign_keys(&conn)?);
+
+        Ok(())
+    }
 
     #[test]
     fn test_pending_local_changes_capture_and_replay() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/corro-types/src/change.rs
+++ b/crates/corro-types/src/change.rs
@@ -189,6 +189,56 @@ pub struct InsertChangesInfo {
     pub snap: VersionsSnapshot,
 }
 
+pub fn database_has_user_triggers(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM main.sqlite_schema
+            WHERE type = 'trigger'
+              AND NOT (
+                  name IN (
+                      tbl_name || '__crsql_itrig',
+                      tbl_name || '__crsql_utrig',
+                      tbl_name || '__crsql_dtrig'
+                  )
+                  OR (
+                      tbl_name = 'crsql_site_id'
+                      AND name IN (
+                          'crsql_site_id_insert_trig',
+                          'crsql_site_id_update_trig',
+                          'crsql_site_id_delete_trig'
+                      )
+                  )
+              )
+        )
+        "#,
+        (),
+        |row| row.get(0),
+    )
+}
+
+pub fn database_has_foreign_keys(conn: &Connection) -> rusqlite::Result<bool> {
+    let tables = {
+        let mut stmt = conn.prepare_cached(
+            "SELECT name FROM main.sqlite_schema WHERE type = 'table' AND name IS NOT NULL",
+        )?;
+        let rows = stmt.query_map((), |row| row.get::<_, String>(0))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+
+    let mut stmt =
+        conn.prepare_cached("SELECT EXISTS (SELECT 1 FROM pragma_foreign_key_list(?1))")?;
+
+    for table in tables {
+        if stmt.query_row([table], |row| row.get(0))? {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 #[derive(Debug, Clone)]
 struct PendingLocalChange {
     change: Change,

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use metrics::counter;
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use rusqlite::types::{ToSql, ToSqlOutput, Value};
 use rusqlite::{
@@ -13,9 +12,8 @@ use rusqlite::{
 };
 use sqlite_pool::{Committable, SqliteConn};
 use std::rc::Rc;
-use tempfile::TempDir;
 use thread_local::ThreadLocal;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, warn};
 use tripwire::Tripwire;
 
 use crate::vtab::unnest::UnnestTab;
@@ -157,30 +155,6 @@ pub fn trace_heavy_queries(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-const CRSQL_EXT_GENERIC_NAME: &str = "crsqlite";
-
-#[cfg(target_os = "macos")]
-pub const CRSQL_EXT_FILENAME: &str = "crsqlite.dylib";
-#[cfg(target_os = "linux")]
-pub const CRSQL_EXT_FILENAME: &str = "crsqlite.so";
-
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-pub const CRSQL_EXT: &[u8] = include_bytes!("../crsqlite-darwin-aarch64.dylib");
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-pub const CRSQL_EXT: &[u8] = include_bytes!("../crsqlite-linux-x86_64.so");
-#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-pub const CRSQL_EXT: &[u8] = include_bytes!("../crsqlite-linux-aarch64.so");
-
-// TODO: support windows
-
-// need to keep this alive!
-static CRSQL_EXT_DIR: Lazy<TempDir> = Lazy::new(|| {
-    let dir = TempDir::new().expect("could not create temp dir!");
-    std::fs::write(dir.path().join(CRSQL_EXT_GENERIC_NAME), CRSQL_EXT)
-        .expect("could not write crsql ext file");
-    dir
-});
-
 pub fn rusqlite_to_crsqlite_write(conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
     let conn = rusqlite_to_crsqlite(conn)?;
     conn.execute_batch("PRAGMA cache_size = -32000;")?;
@@ -188,8 +162,7 @@ pub fn rusqlite_to_crsqlite_write(conn: rusqlite::Connection) -> rusqlite::Resul
     Ok(conn)
 }
 
-pub fn rusqlite_to_crsqlite(mut conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
-    init_cr_conn(&mut conn)?;
+pub fn rusqlite_to_crsqlite(conn: rusqlite::Connection) -> rusqlite::Result<CrConn> {
     setup_conn(&conn)?;
     sqlite_functions::add_to_connection(&conn)?;
 
@@ -202,8 +175,7 @@ pub fn rusqlite_to_crsqlite(mut conn: rusqlite::Connection) -> rusqlite::Result<
 pub struct CrConn(Connection);
 
 impl CrConn {
-    pub fn init(mut conn: Connection) -> Result<Self, rusqlite::Error> {
-        init_cr_conn(&mut conn)?;
+    pub fn init(conn: Connection) -> Result<Self, rusqlite::Error> {
         Ok(Self(conn))
     }
 
@@ -251,26 +223,6 @@ impl Committable for CrConn {
             "cannot create savepoint from connection",
         )))
     }
-}
-
-fn init_cr_conn(conn: &mut Connection) -> Result<(), rusqlite::Error> {
-    let ext_dir = &CRSQL_EXT_DIR;
-    trace!(
-        "loading crsqlite extension from path: {}",
-        ext_dir.path().display()
-    );
-    unsafe {
-        trace!("enabled loading extension");
-        /*conn.load_extension_enable()?;
-        conn.load_extension(
-            ext_dir.path().join(CRSQL_EXT_GENERIC_NAME),
-            Some("sqlite3_crsqlite_init"),
-        )?;
-        conn.load_extension_disable()?;*/
-    }
-    trace!("loaded crsqlite extension");
-
-    Ok(())
 }
 
 pub fn setup_conn(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -384,6 +336,54 @@ mod tests {
     use tokio::task::block_in_place;
 
     use super::*;
+
+    #[test]
+    fn begin_concurrent_allows_independent_writers() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = tempfile::tempdir()?;
+        let path = tmpdir.path().join("begin-concurrent.db");
+
+        let conn1 = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        let auto_vacuum: i64 = conn1.query_row("PRAGMA auto_vacuum", (), |row| row.get(0))?;
+        assert_eq!(auto_vacuum, 0);
+
+        conn1.execute_batch(
+            "
+            CREATE TABLE left_writes (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE right_writes (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            ",
+        )?;
+
+        let conn2 = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        conn1.execute_batch("BEGIN CONCURRENT;")?;
+
+        conn1.execute_batch("INSERT INTO left_writes (id, value) VALUES (1, 'left');")?;
+
+        conn2.execute_batch("BEGIN CONCURRENT;")?;
+
+        conn2.execute_batch("INSERT INTO right_writes (id, value) VALUES (1, 'right');")?;
+
+        conn1.execute_batch("COMMIT;")?;
+
+        conn2.execute_batch("COMMIT;")?;
+
+        let left_count: i64 =
+            conn1.query_row("SELECT COUNT(*) FROM left_writes", (), |row| row.get(0))?;
+        let right_count: i64 =
+            conn1.query_row("SELECT COUNT(*) FROM right_writes", (), |row| row.get(0))?;
+
+        assert_eq!(left_count, 1);
+        assert_eq!(right_count, 1);
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_writes() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/corro-types/src/sqlite.rs
+++ b/crates/corro-types/src/sqlite.rs
@@ -385,6 +385,222 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn losing_speculative_replay_rolls_back_reserved_version(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        fn replay(
+            conn: &Connection,
+            pending: &crate::change::PendingLocalChanges,
+            actor_id: crate::actor::ActorId,
+        ) -> rusqlite::Result<Option<crate::base::CrsqlDbVersion>> {
+            conn.execute_batch("BEGIN IMMEDIATE;")?;
+
+            let Some(version) = pending.replay(conn)? else {
+                conn.execute_batch("ROLLBACK;")?;
+                return Ok(None);
+            };
+
+            let produced: bool = conn.query_row(
+                "
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM crsql_changes
+                    WHERE site_id = ?
+                      AND db_version = ?
+                )
+                ",
+                (actor_id, version),
+                |row| row.get(0),
+            )?;
+
+            if produced {
+                conn.execute_batch("COMMIT;")?;
+                Ok(Some(version))
+            } else {
+                conn.execute_batch("ROLLBACK;")?;
+                Ok(None)
+            }
+        }
+
+        let tmpdir = tempfile::tempdir()?;
+        let path = tmpdir.path().join("conflicting-speculative-replay.db");
+
+        let writer1 = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        writer1.execute_batch(
+            "
+            CREATE TABLE foo (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT ''
+            );
+            SELECT crsql_as_crr('foo');
+            INSERT INTO foo (id, value) VALUES (1, 'base');
+            ",
+        )?;
+
+        let writer2 = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+        let actor_id: crate::actor::ActorId =
+            writer1.query_row("SELECT crsql_site_id()", (), |row| row.get(0))?;
+
+        writer1.execute_batch("BEGIN CONCURRENT;")?;
+        writer2.execute_batch("BEGIN CONCURRENT;")?;
+
+        let _: String = writer1.query_row("SELECT crsql_set_ts('201')", (), |row| row.get(0))?;
+        let _: String = writer2.query_row("SELECT crsql_set_ts('202')", (), |row| row.get(0))?;
+
+        writer1.execute("UPDATE foo SET value = 'zulu' WHERE id = 1", ())?;
+        writer2.execute("UPDATE foo SET value = 'alpha' WHERE id = 1", ())?;
+
+        let pending1 = crate::change::PendingLocalChanges::capture(&writer1, actor_id)?;
+        let pending2 = crate::change::PendingLocalChanges::capture(&writer2, actor_id)?;
+
+        writer1.execute_batch("ROLLBACK;")?;
+        writer2.execute_batch("ROLLBACK;")?;
+
+        let canonical = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        assert_eq!(
+            replay(&canonical, &pending1, actor_id)?,
+            Some(crate::base::CrsqlDbVersion(2))
+        );
+
+        let value: String =
+            canonical.query_row("SELECT value FROM foo WHERE id = 1", (), |row| row.get(0))?;
+        assert_eq!(value, "zulu");
+
+        assert_eq!(replay(&canonical, &pending2, actor_id)?, None);
+
+        let version: i64 =
+            canonical.query_row("SELECT crsql_db_version()", (), |row| row.get(0))?;
+        assert_eq!(version, 2);
+
+        canonical.execute_batch("BEGIN IMMEDIATE;")?;
+        let _: String = canonical.query_row("SELECT crsql_set_ts('203')", (), |row| row.get(0))?;
+        canonical.execute("UPDATE foo SET value = 'zzzz' WHERE id = 1", ())?;
+        canonical.execute_batch("COMMIT;")?;
+
+        let version: i64 =
+            canonical.query_row("SELECT crsql_db_version()", (), |row| row.get(0))?;
+        assert_eq!(version, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn unreserved_future_local_version_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = tempfile::tempdir()?;
+        let path = tmpdir.path().join("unreserved-self-replay.db");
+
+        let speculative = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        speculative.execute_batch(
+            "
+            CREATE TABLE foo (
+                id INTEGER NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL DEFAULT ''
+            );
+            SELECT crsql_as_crr('foo');
+            ",
+        )?;
+
+        let site_id: Vec<u8> =
+            speculative.query_row("SELECT crsql_site_id()", (), |row| row.get(0))?;
+
+        speculative.execute_batch("BEGIN CONCURRENT;")?;
+
+        let _: String =
+            speculative.query_row("SELECT crsql_set_ts('301')", (), |row| row.get(0))?;
+
+        speculative.execute("INSERT INTO foo (id, value) VALUES (1, 'speculative')", ())?;
+
+        let speculative_version: i64 =
+            speculative.query_row("SELECT crsql_peek_next_db_version()", (), |row| row.get(0))?;
+
+        let change = speculative.query_row(
+            r#"
+            SELECT
+                "table",
+                pk,
+                cid,
+                val,
+                col_version,
+                db_version,
+                site_id,
+                cl,
+                seq,
+                ts
+            FROM crsql_changes
+            WHERE site_id = ?
+              AND db_version = ?
+            ORDER BY seq ASC
+            LIMIT 1
+            "#,
+            (&site_id, speculative_version),
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Value>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, Vec<u8>>(6)?,
+                    row.get::<_, i64>(7)?,
+                    row.get::<_, i64>(8)?,
+                    row.get::<_, String>(9)?,
+                ))
+            },
+        )?;
+
+        speculative.execute_batch("ROLLBACK;")?;
+
+        let canonical = rusqlite_to_crsqlite(Connection::open(&path)?)?;
+
+        let before_version: i64 =
+            canonical.query_row("SELECT crsql_db_version()", (), |row| row.get(0))?;
+        assert_eq!(before_version, 0);
+
+        let (table, pk, cid, val, col_version, captured_version, captured_site_id, cl, seq, ts) =
+            change;
+
+        assert_eq!(captured_version, speculative_version);
+
+        let replay = canonical.execute(
+            r#"
+            INSERT INTO crsql_changes
+                ("table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+            params![
+                table,
+                pk,
+                cid,
+                val,
+                col_version,
+                speculative_version,
+                captured_site_id,
+                cl,
+                seq,
+                ts,
+            ],
+        );
+
+        assert!(
+            replay.is_err(),
+            "future local-site version must not be accepted without a pending reservation"
+        );
+
+        let after_version: i64 =
+            canonical.query_row("SELECT crsql_db_version()", (), |row| row.get(0))?;
+        assert_eq!(after_version, 0);
+
+        let row_count: i64 =
+            canonical.query_row("SELECT COUNT(*) FROM foo", (), |row| row.get(0))?;
+        assert_eq!(row_count, 0);
+
+        Ok(())
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_writes() -> Result<(), Box<dyn std::error::Error>> {
         let tmpdir = tempfile::TempDir::new()?;

--- a/crates/sqlite3-restore/src/lib.rs
+++ b/crates/sqlite3-restore/src/lib.rs
@@ -350,6 +350,7 @@ mod tests {
                 conn.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
 
             assert_eq!(journal_mode, "wal");
+            conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
         }
 
         let restored = restore(src, &dst, Duration::from_secs(2))?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.89"
 components = ["rustfmt", "clippy"]

--- a/vendor/libsqlite3-sys/Cargo.toml
+++ b/vendor/libsqlite3-sys/Cargo.toml
@@ -14,8 +14,8 @@ exclude = ["**/*.sh"]
 
 [features]
 default = ["min_sqlite_version_3_34_1"]
-bundled = ["cc", "bundled_bindings"]
-bundled-windows = ["cc", "bundled_bindings"]
+bundled = ["cc", "bundled_bindings", "dep:crsql_bundle"]
+bundled-windows = ["cc", "bundled_bindings", "dep:crsql_bundle"]
 bundled-sqlcipher = ["bundled"]
 bundled-sqlcipher-vendored-openssl = [
     "bundled-sqlcipher",
@@ -41,6 +41,7 @@ wasm32-wasi-vfs = []
 
 [dependencies]
 openssl-sys = { version = "0.9.103", optional = true }
+crsql_bundle = { path = "vendor/cr-sqlite/core/rs/bundle", optional = true, features = ["static", "omit_load_extension", "host"] }
 
 [build-dependencies]
 bindgen = { version = "0.72", optional = true, default-features = false, features = [

--- a/vendor/libsqlite3-sys/build.rs
+++ b/vendor/libsqlite3-sys/build.rs
@@ -97,72 +97,8 @@ mod build_bundled {
     use std::env;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
 
     use super::{is_compiler, win_target};
-
-    fn build_crsqlite_rust_lib(_out_dir: &str) -> PathBuf {
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let crsqlite_bundle_dir = PathBuf::from(manifest_dir)
-            .join("vendor/cr-sqlite/core/rs/bundle_static");
-        
-        println!("cargo:rerun-if-changed={}", crsqlite_bundle_dir.join("src").display());
-        println!("cargo:rerun-if-changed={}", crsqlite_bundle_dir.join("Cargo.toml").display());
-        
-        let target = env::var("TARGET").unwrap();
-        let profile = if env::var("PROFILE").unwrap() == "release" {
-            "release"
-        } else {
-            "debug"
-        };
-        
-        // Determine the crsqlite commit SHA from the vendored cr-sqlite directory
-        let crsqlite_dir = PathBuf::from(manifest_dir).join("vendor/cr-sqlite");
-        let commit_sha = Command::new("git")
-            .args(["-C", crsqlite_dir.to_str().unwrap(), "log", "-1", "--format=%H"])
-            .output()
-            .ok()
-            .and_then(|output| {
-                if output.status.success() {
-                    String::from_utf8(output.stdout).ok()
-                } else {
-                    None
-                }
-            })
-            .map(|s| s.trim().to_string())
-            .unwrap_or_else(|| "unknown".to_string());
-        
-        let mut cargo = Command::new("cargo");
-        cargo
-            .current_dir(&crsqlite_bundle_dir)
-            .env("CRSQLITE_COMMIT_SHA", &commit_sha)
-            .arg("build")
-            .arg("--target")
-            .arg(&target)
-            .arg("--features")
-            .arg("static,omit_load_extension");
-        
-        if profile == "release" {
-            cargo.arg("--release");
-        }
-        
-        let status = cargo.status().expect("Failed to build crsqlite Rust library");
-        if !status.success() {
-            panic!("Failed to build crsqlite Rust library");
-        }
-        
-        let lib_path = crsqlite_bundle_dir
-            .join("target")
-            .join(&target)
-            .join(profile)
-            .join("libcrsql_bundle_static.a");
-        
-        if !lib_path.exists() {
-            panic!("crsqlite Rust library not found at: {}", lib_path.display());
-        }
-        
-        lib_path
-    }
 
     #[expect(clippy::assertions_on_constants)] // https://github.com/rust-lang/rust-clippy/issues/16242
     pub fn main(out_dir: &str, out_path: &Path) {
@@ -205,7 +141,6 @@ mod build_bundled {
             .flag("-DSQLITE_USE_URI")
             .flag("-DHAVE_USLEEP=1")
             .flag("-DHAVE_ISNAN")
-            .flag("-DSQLITE_DEFAULT_AUTOVACUUM=2")
             .flag("-D_POSIX_THREAD_SAFE_FUNCTIONS") // cross compile with MinGW
             .warnings(false);
 
@@ -373,8 +308,6 @@ mod build_bundled {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         let crsqlite_src_dir = PathBuf::from(manifest_dir).join("vendor/cr-sqlite/core/src");
         
-        let crsqlite_rust_lib = build_crsqlite_rust_lib(out_dir);
-        
         cfg.file(crsqlite_src_dir.join("crsqlite.c"))
             .file(crsqlite_src_dir.join("changes-vtab.c"))
             .file(crsqlite_src_dir.join("ext-data.c"))
@@ -387,10 +320,8 @@ mod build_bundled {
         println!("cargo:rerun-if-changed={}", crsqlite_src_dir.join("ext-data.c").display());
         println!("cargo:rerun-if-changed={}", crsqlite_src_dir.join("core_init.c").display());
 
+        cfg.link_lib_modifier("+whole-archive");
         cfg.compile(lib_name);
-        
-        println!("cargo:rustc-link-search=native={}", crsqlite_rust_lib.parent().unwrap().display());
-        println!("cargo:rustc-link-lib=static=crsql_bundle_static");
 
         println!("cargo:lib_dir={out_dir}");
     }

--- a/vendor/libsqlite3-sys/src/lib.rs
+++ b/vendor/libsqlite3-sys/src/lib.rs
@@ -4,6 +4,13 @@
 #[cfg(feature = "bundled-sqlcipher-vendored-openssl")]
 extern crate openssl_sys;
 
+#[cfg(any(
+    feature = "bundled",
+    feature = "bundled-windows",
+    feature = "bundled-sqlcipher"
+))]
+extern crate crsql_bundle as _;
+
 pub use self::error::*;
 
 use core::mem;

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/Cargo.toml
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/Cargo.toml
@@ -42,3 +42,4 @@ omit_load_extension = [
   "crsql_fractindex_core/omit_load_extension",
   "crsql_core/omit_load_extension"
 ]
+host = ["sqlite_nostd/host"]

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/src/lib.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/bundle/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use core::ffi::c_char;
+#[cfg(not(feature = "host"))]
 use core::panic::PanicInfo;
 use crsql_core;
 use crsql_core::sqlite3_crsqlcore_init;
@@ -12,16 +13,18 @@ use crsql_fractindex_core::sqlite3_crsqlfractionalindex_init;
 #[cfg(feature = "test")]
 use libc_print::std_name::println;
 use sqlite_nostd as sqlite;
+#[cfg(not(feature = "host"))]
 use sqlite_nostd::SQLite3Allocator;
 
 // This must be our allocator so we can transfer ownership of memory to SQLite and have SQLite free that memory for us.
 // This drastically reduces copies when passing strings and blobs back and forth between Rust and C.
+#[cfg(not(feature = "host"))]
 #[global_allocator]
 static ALLOCATOR: SQLite3Allocator = SQLite3Allocator {};
 
 // This must be our panic handler for WASM builds. For simplicity, we make it our panic handler for
 // all builds. Abort is also more portable than unwind, enabling us to go to more embedded use cases.
-#[cfg(not(feature = "test"))]
+#[cfg(all(not(feature = "test"), not(feature = "host")))]
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     //core::intrinsics::abort()

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/bootstrap.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/bootstrap.rs
@@ -180,7 +180,7 @@ fn maybe_update_db_inner(
     if recorded_version < consts::CRSQLITE_VERSION_0_17_0 && !is_blank_slate {
         let cstring = CString::new(format!("Opening a db created with cr-sqlite version {} is not supported. Upcoming release 0.17.0 is a breaking change.", recorded_version))?;
         unsafe {
-            (*err_msg) = cstring.into_raw();
+            (*err_msg) = sqlite::into_sqlite_owned_cstring(cstring);
             return Err(ResultCode::ERROR);
         }
     }

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab.rs
@@ -170,10 +170,11 @@ fn changes_best_index(
     unsafe {
         (*index_info).idxNum = idx_num;
         (*index_info).orderByConsumed = if order_by_consumed { 1 } else { 0 };
-        // forget str
-        let (ptr, _, _) = str.into_raw_parts();
-        // pass to c. We've manually null terminated the string.
-        // sqlite will free it for us.
+        // Pass ownership to SQLite. We've manually null terminated the string.
+        let ptr = sqlite::into_sqlite_owned_bytes(str.into_bytes());
+        if ptr.is_null() {
+            return Err(ResultCode::NOMEM);
+        }
         (*index_info).idxStr = ptr as *mut c_char;
         (*index_info).needToFreeIdxStr = 1;
     }
@@ -324,7 +325,7 @@ unsafe fn changes_next(
 ) -> Result<ResultCode, ResultCode> {
     if (*cursor).pChangesStmt.is_null() {
         let err = CString::new("pChangesStmt is null in changes_next")?;
-        (*vtab).zErrMsg = err.into_raw();
+        (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ABORT);
     }
 
@@ -370,7 +371,7 @@ unsafe fn changes_next(
 
     if tbl_info_index.is_none() {
         let err = CString::new(format!("could not find schema for table {}", tbl))?;
-        (*vtab).zErrMsg = err.into_raw();
+        (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
     // TODO: technically safe since we checked `is_none` but this should be more idiomatic
@@ -382,7 +383,7 @@ unsafe fn changes_next(
 
     if tbl_info.pks.is_empty() {
         let err = CString::new(format!("crr {} is missing primary keys", tbl))?;
-        (*vtab).zErrMsg = err.into_raw();
+        (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -542,7 +543,7 @@ pub extern "C" fn crsql_changes_update(
         "Only INSERT and SELECT statements are allowed against the crsql changes table",
     ) {
         unsafe {
-            (*vtab).zErrMsg = err.into_raw();
+            (*vtab).zErrMsg = sqlite::into_sqlite_owned_cstring(err);
         }
         ResultCode::MISUSE as c_int
     } else {

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab_write.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/changes_vtab_write.rs
@@ -70,7 +70,7 @@ fn did_cid_win(
         Ok(rc) | Err(rc) => {
             reset_cached_stmt(col_vrsn_stmt.stmt)?;
             let err = CString::new("Bad return code when selecting local column version")?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(rc);
         }
     }
@@ -115,7 +115,7 @@ fn did_cid_win(
                 "could not find row to merge with for tbl {}",
                 insert_tbl
             ))?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(ResultCode::ERROR);
         }
     }
@@ -154,13 +154,13 @@ fn did_site_id_win(
                 "could not find site_id for previous change, cr-sqlite clock table might be corrupt for tbl {}",
                 insert_tbl
             ))?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(ResultCode::ERROR);
         }
         Ok(rc) | Err(rc) => {
             reset_cached_stmt(col_site_id_stmt.stmt)?;
             let err = CString::new("Bad return code when selecting local column site_id")?;
-            unsafe { *errmsg = err.into_raw() };
+            unsafe { *errmsg = sqlite::into_sqlite_owned_cstring(err) };
             return Err(rc);
         }
     }
@@ -434,7 +434,7 @@ unsafe fn merge_insert(
     let rc = crsql_ensure_table_infos_are_up_to_date(db, (*tab).pExtData, errmsg);
     if rc != ResultCode::OK as i32 {
         let err = CString::new("Failed to update CRR table information")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -442,7 +442,7 @@ unsafe fn merge_insert(
     let insert_tbl = args[2 + CrsqlChangesColumn::Tbl as usize];
     if insert_tbl.bytes() > crate::consts::MAX_TBL_NAME_LEN {
         let err = CString::new("crsql - table name exceeded max length")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -451,7 +451,7 @@ unsafe fn merge_insert(
     let insert_col = args[2 + CrsqlChangesColumn::Cid as usize];
     if insert_col.bytes() > crate::consts::MAX_TBL_NAME_LEN {
         let err = CString::new("crsql - column name exceeded max length")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -462,11 +462,16 @@ unsafe fn merge_insert(
     let insert_site_id = args[2 + CrsqlChangesColumn::SiteId as usize];
     let insert_cl = args[2 + CrsqlChangesColumn::Cl as usize].int64();
     let insert_seq = args[2 + CrsqlChangesColumn::Seq as usize].int64();
-    let insert_ts = args[2 + CrsqlChangesColumn::Ts as usize].text();
+    let insert_ts = args[2 + CrsqlChangesColumn::Ts as usize];
+    let insert_ts = if insert_ts.value_type() == sqlite::ColumnType::Null {
+        "0"
+    } else {
+        insert_ts.text()
+    };
 
     if insert_site_id.bytes() > crate::consts::SITE_ID_LEN {
         let err = CString::new("crsql - site id exceeded max length")?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
 
@@ -484,7 +489,7 @@ unsafe fn merge_insert(
             "crsql - could not find the schema information for table {}",
             insert_tbl
         ))?;
-        *errmsg = err.into_raw();
+        *errmsg = sqlite::into_sqlite_owned_cstring(err);
         return Err(ResultCode::ERROR);
     }
     // TODO: technically safe since we checked `is_none` but this should be more idiomatic
@@ -717,7 +722,7 @@ unsafe fn merge_insert(
                 "Unable to insert db version {} for site id {:?}",
                 insert_db_vrsn, insert_site_id
             ))?;
-            *errmsg = err.into_raw();
+            *errmsg = sqlite::into_sqlite_owned_cstring(err);
             return Err(rc);
         }
 

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/db_version.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/db_version.rs
@@ -235,8 +235,9 @@ pub fn insert_db_version(
         if ordinal == 0 {
             // we manage our own db_version internally but only error if we get a bigger db_version
             // cause we can get our own rows from other nodes but the version should never be greater than our own.
-            let db_version = (*ext_data).dbVersion;
-            if insert_db_vrsn > db_version {
+            if insert_db_vrsn > (*ext_data).dbVersion
+                && insert_db_vrsn != (*ext_data).pendingDbVersion
+            {
                 return Err(ResultCode::ERROR);
             }
             return Ok(());

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/sha.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/sha.rs
@@ -1,2 +1,5 @@
 // The sha of the commit that this version of crsqlite was built from.
-pub const SHA: &'static str = core::env!("CRSQLITE_COMMIT_SHA");
+pub const SHA: &str = match core::option_env!("CRSQLITE_COMMIT_SHA") {
+    Some(sha) => sha,
+    None => "unknown",
+};

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/unpack_columns_vtab.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/core/src/unpack_columns_vtab.rs
@@ -78,7 +78,7 @@ extern "C" fn best_index(vtab: *mut sqlite::vtab, index_info: *mut sqlite::index
                     "no package column specified. Got {:?} instead",
                     Columns::PACKAGE
                 ))
-                .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
             }
             return ResultCode::MISUSE as c_int;
         } else {
@@ -134,7 +134,7 @@ extern "C" fn filter(
     if args.len() < 1 {
         unsafe {
             (*(*cursor).pVtab).zErrMsg = CString::new("Zero args passed to filter")
-                .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
         }
         return ResultCode::MISUSE as c_int;
     }
@@ -210,7 +210,7 @@ extern "C" fn column(
                 ResultCode::OK as c_int
             } else {
                 (*(*cursor).pVtab).zErrMsg = CString::new("No columns to unpack!")
-                    .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                    .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
                 ResultCode::ABORT as c_int
             }
         }
@@ -218,7 +218,7 @@ extern "C" fn column(
         unsafe {
             (*(*cursor).pVtab).zErrMsg =
                 CString::new(format!("Selected a column besides cell! {}", col_num))
-                    .map_or(core::ptr::null_mut(), |f| f.into_raw());
+                    .map_or(core::ptr::null_mut(), sqlite::into_sqlite_owned_cstring);
         }
         ResultCode::MISUSE as c_int
     }

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite3_capi/src/capi.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite3_capi/src/capi.rs
@@ -563,6 +563,9 @@ pub fn value_bytes(arg1: *mut value) -> c_int {
 pub fn value_blob<'a>(value: *mut value) -> &'a [u8] {
     unsafe {
         let n = value_bytes(value);
+        if n == 0 {
+            return &[];
+        }
         let b = invoke_sqlite!(value_blob, value);
         core::slice::from_raw_parts(b.cast::<u8>(), n as usize)
     }

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/Cargo.toml
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/Cargo.toml
@@ -17,3 +17,4 @@ num-derive = "0.4.1"
 loadable_extension = ["sqlite3_capi/loadable_extension"]
 static = ["sqlite3_capi/static"]
 omit_load_extension = ["sqlite3_capi/omit_load_extension"]
+host = []

--- a/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/src/nostd.rs
+++ b/vendor/libsqlite3-sys/vendor/cr-sqlite/core/rs/sqlite-rs-embedded/sqlite_nostd/src/nostd.rs
@@ -693,6 +693,14 @@ impl ManagedStmt {
     #[inline]
     pub fn column_blob(&self, i: i32) -> Result<&[u8], ResultCode> {
         let len = column_bytes(self.stmt, i);
+        if len == 0 {
+            return if self.column_type(i)? == ColumnType::Null {
+                Err(ResultCode::NULL)
+            } else {
+                Ok(&[])
+            };
+        }
+
         let ptr = column_blob(self.stmt, i);
         if ptr.is_null() {
             Err(ResultCode::NULL)
@@ -823,15 +831,24 @@ impl Context for *mut context {
     /// The blob must have been allocated with `sqlite3_malloc`!
     #[inline]
     fn result_text_owned(&self, text: String) {
-        let (ptr, len, _) = text.into_raw_parts();
+        #[cfg(feature = "host")]
         result_text(
             *self,
-            ptr as *const c_char,
-            len as i32,
-            // TODO: this drop code does not seem to work
-            // Valgrind tells us we have a memory leak when using `result_text_owned`
-            Destructor::CUSTOM(droprust),
+            text.as_ptr() as *const c_char,
+            text.len() as i32,
+            Destructor::TRANSIENT,
         );
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = text.into_raw_parts();
+            result_text(
+                *self,
+                ptr as *const c_char,
+                len as i32,
+                Destructor::CUSTOM(droprust),
+            );
+        }
     }
 
     /// Takes a reference to a string, has SQLite copy the contents
@@ -862,8 +879,19 @@ impl Context for *mut context {
     /// The blob must have been allocated with `sqlite3_malloc`!
     #[inline]
     fn result_blob_owned(&self, blob: Vec<u8>) {
-        let (ptr, len, _) = blob.into_raw_parts();
-        result_blob(*self, ptr, len as i32, Destructor::CUSTOM(droprust));
+        #[cfg(feature = "host")]
+        result_blob(
+            *self,
+            blob.as_ptr(),
+            blob.len() as i32,
+            Destructor::TRANSIENT,
+        );
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = blob.into_raw_parts();
+            result_blob(*self, ptr, len as i32, Destructor::CUSTOM(droprust));
+        }
     }
 
     /// SQLite will make a copy of the blob
@@ -970,14 +998,28 @@ impl Stmt for *mut stmt {
 
     #[inline]
     fn bind_blob_owned(&self, i: i32, val: Vec<u8>) -> Result<ResultCode, ResultCode> {
-        let (ptr, len, _) = val.into_raw_parts();
-        convert_rc(bind_blob(
-            *self,
-            i,
-            ptr as *const c_void,
-            len as i32,
-            Destructor::CUSTOM(droprust),
-        ))
+        #[cfg(feature = "host")]
+        {
+            return convert_rc(bind_blob(
+                *self,
+                i,
+                val.as_ptr() as *const c_void,
+                val.len() as i32,
+                Destructor::TRANSIENT,
+            ));
+        }
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = val.into_raw_parts();
+            convert_rc(bind_blob(
+                *self,
+                i,
+                ptr as *const c_void,
+                len as i32,
+                Destructor::CUSTOM(droprust),
+            ))
+        }
     }
 
     #[inline]
@@ -1003,14 +1045,28 @@ impl Stmt for *mut stmt {
 
     #[inline]
     fn bind_text_owned(&self, i: i32, text: String) -> Result<ResultCode, ResultCode> {
-        let (ptr, len, _) = text.into_raw_parts();
-        convert_rc(bind_text(
-            *self,
-            i,
-            ptr as *const c_char,
-            len as i32,
-            Destructor::CUSTOM(droprust),
-        ))
+        #[cfg(feature = "host")]
+        {
+            return convert_rc(bind_text(
+                *self,
+                i,
+                text.as_ptr() as *const c_char,
+                text.len() as i32,
+                Destructor::TRANSIENT,
+            ));
+        }
+
+        #[cfg(not(feature = "host"))]
+        {
+            let (ptr, len, _) = text.into_raw_parts();
+            convert_rc(bind_text(
+                *self,
+                i,
+                ptr as *const c_char,
+                len as i32,
+                Destructor::CUSTOM(droprust),
+            ))
+        }
     }
 
     #[inline]
@@ -1051,6 +1107,10 @@ impl Stmt for *mut stmt {
     #[inline]
     fn column_blob(&self, i: i32) -> &[u8] {
         let len = column_bytes(*self, i);
+        if len == 0 {
+            return &[];
+        }
+
         let ptr = column_blob(*self, i);
         unsafe { core::slice::from_raw_parts(ptr as *const u8, len as usize) }
     }
@@ -1142,6 +1202,50 @@ impl Value for *mut value {
     }
 }
 
+pub fn into_sqlite_owned_cstring(value: CString) -> *mut c_char {
+    #[cfg(feature = "host")]
+    {
+        let bytes = value.as_bytes_with_nul();
+        let ptr = malloc(bytes.len());
+        if ptr.is_null() {
+            return null_mut();
+        }
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
+        }
+
+        ptr as *mut c_char
+    }
+
+    #[cfg(not(feature = "host"))]
+    {
+        value.into_raw()
+    }
+}
+
+pub fn into_sqlite_owned_bytes(value: Vec<u8>) -> *mut u8 {
+    #[cfg(feature = "host")]
+    {
+        let ptr = malloc(value.len());
+        if ptr.is_null() {
+            return null_mut();
+        }
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(value.as_ptr(), ptr, value.len());
+        }
+
+        ptr
+    }
+
+    #[cfg(not(feature = "host"))]
+    {
+        let (ptr, _, _) = value.into_raw_parts();
+        ptr
+    }
+}
+
 pub trait StrRef {
     fn set(&self, val: &str);
 }
@@ -1157,11 +1261,9 @@ impl StrRef for *mut *mut c_char {
                 return;
             }
             if let Ok(cstring) = CString::new(val) {
-                **self = cstring.into_raw();
-            } else {
-                if let Ok(s) = CString::new("Failed setting error message.") {
-                    **self = s.into_raw();
-                }
+                **self = into_sqlite_owned_cstring(cstring);
+            } else if let Ok(s) = CString::new("Failed setting error message.") {
+                **self = into_sqlite_owned_cstring(s);
             }
         }
     }
@@ -1209,7 +1311,7 @@ impl VTab for *mut vtab {
                 return;
             }
             if let Ok(e) = CString::new(val) {
-                (**self).zErrMsg = e.into_raw();
+                (**self).zErrMsg = into_sqlite_owned_cstring(e);
             }
         }
     }


### PR DESCRIPTION
Stacked on #522 and addresses #503.

Replayable API and Postgres writes now run in `BEGIN CONCURRENT`, capture their local `crsql_changes`, roll back the speculative transaction, and replay those changes under a short canonical write before broadcasting. DDL and other unsupported HTTP statements stay canonical, and PG transactions can upgrade without losing earlier CRR changes.

Replay is deliberately conservative. Targets are rechecked as live CRRs in the same SQLite snapshot, while user triggers, foreign keys, or temporary-schema state force canonical execution. If the schema version changes before replay, the transaction is rejected instead of being applied against a different schema. Failed explicit PG transactions accept only `ROLLBACK`; `COMMIT` remains `25P02`, nested `BEGIN` returns `25001`, and writer-permit ownership is retained through commit, rollback, and disconnect cleanup.

Known availability follow-ups are bounding the in-memory pending-change buffer and making canonical permit/replay waits cooperatively cancellable.

[Run 32598353717](https://github.com/onurata26/corrosion/actions/runs/32598353717) tested source head [69e9568](https://github.com/onurata26/corrosion/commit/69e9568bea05310bc25807d3fbdd1ab8f4591924) on Linux and macOS. Follow-up [8c5a021](https://github.com/onurata26/corrosion/commit/8c5a02133c62fdbeaadc6c7f65c4536a0e50304c) passed the targeted transaction regression, Rust 1.89 workspace clippy, and formatting locally; upstream CI has not started for this head.

Land #520 first, then refresh #414 and land #522. Rebase this PR onto that result, preserve #520's transaction-finalization behavior, drop the duplicate fixture commit `91d5806`, and rerun full CI before merging.