### PR TITLE
Prevent deletes and immediate re-insert of peers to plumtree

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -443,9 +443,16 @@ pub async fn handle_notifications(
                     (del_res, add_res)
                 };
 
+                // we've just re-inserted the same id, no plumtree updates needed
+                if a.id() == b.id() && del_res && matches!(add_res, MemberAddedResult::NewMember(_))
+                {
+                    continue;
+                }
+
                 if del_res {
                     send_plumtree_member_update(&agent, &a, MemberAddedResult::Removed).await;
                 }
+
                 send_plumtree_member_update(&agent, &b, add_res).await;
             }
             OwnedNotification::Active => {

--- a/crates/plum-foca/tests/sim.rs
+++ b/crates/plum-foca/tests/sim.rs
@@ -2250,6 +2250,7 @@ fn sim_small_flap_recovery() {
 /// is its churn counterpart. Both must fully explain their delivery gap as
 /// crash-caused, not as an unexplained protocol miss.
 #[test]
+#[ignore = "slow; run in release mode"]
 fn sim_gossip_vs_plumtree_failures() {
     const N: usize = 500;
     const CRASH_COUNT: usize = 20;


### PR DESCRIPTION
Member Renames from Foca basically delete and insert the same actor id, in this case we don't want plumtree updates