### PR TITLE
Evict dropped changes from the seen cache under their own actor id

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -924,7 +924,7 @@ impl HandleChangesState {
     fn maybe_drop_old_change(&mut self) -> Option<ChangeV1> {
         let mut dropped_count = 0;
 
-        let maybe_dropped_change = if self.queue.len() >= self.max_queue_len {
+        if self.queue.len() >= self.max_queue_len {
             if let Some((dropped_change, _, _)) = self.queue.pop_front() {
                 self.buf_cost -= dropped_change.processing_cost();
                 dropped_count += 1;
@@ -937,9 +937,7 @@ impl HandleChangesState {
             }
         } else {
             None
-        };
-
-        maybe_dropped_change
+        }
     }
 
     /// Handle new change arrival - check if we should spawn immediately
@@ -1438,8 +1436,7 @@ mod tests {
         let partial = |actor: ActorId, version: u64, seq: u64| {
             let crsql_row = Change {
                 table: TableName("tests".into()),
-                pk: pack_columns(&vec![(seq as i64 + 1 + version as i64 * 100).into()])
-                    .unwrap(),
+                pk: pack_columns(&vec![(seq as i64 + 1 + version as i64 * 100).into()]).unwrap(),
                 cid: ColumnName("text".into()),
                 val: "partial".into(),
                 col_version: 1,

--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -1126,7 +1126,7 @@ pub async fn handle_changes(
         // If we need to drop an old change, drop it from the seen cache aswell
         while let Some(dropped_change) = state.maybe_drop_old_change() {
             for v in dropped_change.versions() {
-                if let Entry::Occupied(mut entry) = seen.entry((change.actor_id, v)) {
+                if let Entry::Occupied(mut entry) = seen.entry((dropped_change.actor_id, v)) {
                     if let Some(seqs) = dropped_change.seqs() {
                         entry.get_mut().remove(seqs.into());
                     } else {
@@ -1397,6 +1397,141 @@ mod tests {
         assert!(!booked.contains_version(&CrsqlDbVersion(7)));
         assert!(!booked.contains_version(&CrsqlDbVersion(8)));
         assert!(!booked.contains_version(&CrsqlDbVersion(9)));
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_loadshed_seen_cache_evicts_dropped_actor() -> eyre::Result<()> {
+        _ = tracing_subscriber::fmt::try_init();
+        let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+        let dir = tempfile::tempdir()?;
+
+        let mut config = Config::builder()
+            .db_path(dir.path().join("corrosion.db").display().to_string())
+            .gossip_addr("127.0.0.1:0".parse()?)
+            .api_addr("127.0.0.1:0".parse()?)
+            .build()?;
+        config.perf.processing_queue_len = 4;
+        // batch size 2 so batch_threshold() stays >= 1: with batch size 1 the
+        // threshold truncates to 0 and handle_task_completion hits its
+        // unreachable!() on an empty queue, killing the task
+        config.perf.apply_queue_min_batch_size = 2;
+        config.perf.apply_queue_max_batch_size = 2;
+        config.perf.apply_queue_step_base = 0;
+        config.perf.changes_channel_len = 1;
+
+        let (agent, agent_options) = setup(config, tripwire.clone()).await?;
+
+        execute_schema(&agent, vec![TEST_SCHEMA.to_owned()]).await?;
+
+        let actor_a = ActorId(uuid::Uuid::new_v4());
+        let actor_b = ActorId(uuid::Uuid::new_v4());
+        let bookie = Bookie::new(Default::default());
+        tokio::spawn(handle_changes(
+            agent.clone(),
+            bookie.clone(),
+            agent_options.rx_changes,
+            tripwire,
+        ));
+
+        let partial = |actor: ActorId, version: u64, seq: u64| {
+            let crsql_row = Change {
+                table: TableName("tests".into()),
+                pk: pack_columns(&vec![(seq as i64 + 1 + version as i64 * 100).into()])
+                    .unwrap(),
+                cid: ColumnName("text".into()),
+                val: "partial".into(),
+                col_version: 1,
+                db_version: CrsqlDbVersion(version),
+                seq: CrsqlSeq(seq),
+                site_id: actor.to_bytes(),
+                cl: 1,
+            };
+            (
+                ChangeV1 {
+                    actor_id: actor,
+                    changeset: Changeset::Full {
+                        version: CrsqlDbVersion(version),
+                        changes: vec![crsql_row],
+                        seqs: (CrsqlSeq(seq)..=CrsqlSeq(seq)).into(),
+                        // last_seq beyond the sent seqs => incomplete (buffered) changeset
+                        last_seq: CrsqlSeq(3),
+                        ts: agent.clock().new_timestamp().into(),
+                    },
+                },
+                ChangeSource::Broadcast,
+                None,
+            )
+        };
+
+        {
+            // hold the write connection so the first processed change blocks
+            let _conn = agent.pool().write_normal().await?;
+
+            // a complete change from B: gets drained immediately and blocks on the
+            // write connection, leaving the queue free to fill up
+            let crsql_row = Change {
+                table: TableName("tests".into()),
+                pk: pack_columns(&vec![1i64.into()])?,
+                cid: ColumnName("text".into()),
+                val: "b ten".into(),
+                col_version: 1,
+                db_version: CrsqlDbVersion(10),
+                seq: CrsqlSeq(0),
+                site_id: actor_b.to_bytes(),
+                cl: 1,
+            };
+            agent
+                .tx_changes()
+                .send((
+                    ChangeV1 {
+                        actor_id: actor_b,
+                        changeset: Changeset::Full {
+                            version: CrsqlDbVersion(10),
+                            changes: vec![crsql_row],
+                            seqs: dbsr!(0, 0),
+                            last_seq: CrsqlSeq(0),
+                            ts: agent.clock().new_timestamp().into(),
+                        },
+                    },
+                    ChangeSource::Broadcast,
+                    None,
+                ))
+                .await?;
+
+            // fill the queue (len 4) with actor A's partial seqs 0..=3 of version 1
+            for seq in 0u64..=3 {
+                agent.tx_changes().send(partial(actor_a, 1, seq)).await?;
+            }
+
+            // actor B's change arrives with the queue full: A's seq 0 gets dropped.
+            // Its seen-cache entry must be evicted under (actor_a, v1).
+            agent.tx_changes().send(partial(actor_b, 1, 0)).await?;
+        }
+
+        sleep(Duration::from_secs(2)).await;
+
+        {
+            let booked_a = bookie.get(&actor_a).unwrap().read();
+            // sanity: seqs 1..=3 of A's v1 were processed, seq 0 was dropped
+            assert!(booked_a.contains_all(dbvr!(1, 1), Some(dbsr!(1, 3))));
+            assert!(!booked_a.contains_all(dbvr!(1, 1), Some(dbsr!(0, 0))));
+        }
+
+        // the dropped change arrives again (another peer rebroadcasts it); with the
+        // seen-cache entry properly evicted it must be accepted and processed
+        agent.tx_changes().send(partial(actor_a, 1, 0)).await?;
+
+        sleep(Duration::from_secs(2)).await;
+
+        let booked_a = bookie.get(&actor_a).unwrap().read();
+        assert!(
+            booked_a.contains_all(dbvr!(1, 1), Some(dbsr!(0, 0))),
+            "re-sent copy of the dropped change was filtered as a duplicate: \
+             the seen cache still holds the entry that should have been evicted \
+             when the change was dropped from the full queue"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #530.

When the queue is full and `handle_changes` drops the oldest change, the seen
cache eviction looks up `(change.actor_id, v)`, where `change` is the change
that just arrived, while `v` iterates the versions of the change being
dropped. With more than one actor in the queue the dropped change keeps its
seen entry, so rebroadcasts of it get filtered as duplicates and the shed data
cannot re-enter the queue. Full analysis and a 4 node cluster repro are in the
issue.

The fix is to evict under `dropped_change.actor_id`.

The new test runs two actors: A fills the queue with partial changes, B's
arrival displaces A's seq 0, then A's seq 0 is delivered again and must be
accepted instead of being filtered as a duplicate. It fails on main and passes
with this change:

```
cargo test -p corro-agent --lib test_loadshed
```

One note on the test setup: it pins the batch size to 2 because with a min
batch size of 1 the batch threshold truncates to 0 and `handle_task_completion`
hits its `unreachable!()` on an empty queue. #527 already takes care of that
with `.max(1)`.

Happy to rebase if #527 lands first, the fix is the same line either way.
