### PR TITLE
Fix change tuple order in subscription resume example

### DIFF
--- a/doc/api/subscriptions.md
+++ b/doc/api/subscriptions.md
@@ -143,8 +143,8 @@ curl http://localhost:8080/v1/subscriptions/ba247cbc-2a7f-486b-873c-8a9620e72182
 
 ```bash
 curl http://localhost:8080/v1/subscriptions/ba247cbc-2a7f-486b-873c-8a9620e72182?from=1
-{ "change": [2, "insert", ["shiitake"], 2] }
-{ "change": [3, "insert", ["grilled cheese"], 3] }
+{ "change": ["insert", 2, ["shiitake"], 2] }
+{ "change": ["insert", 3, ["grilled cheese"], 3] }
 ```
 
 ## Response


### PR DESCRIPTION
## Summary

The `GET /v1/subscriptions/:id?from=1` example currently places the row ID before the change type:

```json
{ "change": [2, "insert", ["shiitake"], 2] }
{ "change": [3, "insert", ["grilled cheese"], 3] }
```

This PR swaps the first two elements so the example matches the documented and implemented wire format:

```json
{ "change": ["insert", 2, ["shiitake"], 2] }
{ "change": ["insert", 3, ["grilled cheese"], 3] }
```

## Evidence

`TypedQueryEvent` derives `Serialize`, and its `Change` tuple variant is declared in `crates/corro-api-types/src/lib.rs:38-56` as:

```rust
#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
#[serde(rename_all = "snake_case")]
pub enum TypedQueryEvent<T> {
    // ...
    Change(ChangeType, RowId, T, ChangeId),
}
```

A fresh single-node Corrosion build produced the same field order when resuming a subscription with plain `curl`:

```console
$ curl --no-buffer --silent --show-error \
    "http://127.0.0.1:18081/v1/subscriptions/<subscription-id>?from=1"
{"change":["insert",4,[30,"inserted"],2]}
{"change":["delete",2,[20,"delete-me"],3]}
```

Both the implementation and raw wire output use:

```text
[change type, row ID, values, change ID]
```

## Impact

Clients following the incorrect resume example may swap the string change type and numeric row ID. This can cause resumed events to be rejected or leave client-side state stale until a full subscription refresh.

This is a documentation-only change. It does not modify server behavior or stored data.

## Verification

- Built Corrosion from commit `936de111d223a5e80d476bd1195e21b3eaca9762`.
- Started a fresh single-node instance with isolated ports and storage.
- Created a subscription and generated insert, update, and delete events.
- Confirmed both the initial stream and `GET ...?from=1` serialize changes as `[type, rowid, values, change_id]`.
- Ran `git diff --check` successfully.

Fixes #535
