### PR TITLE
Reconcile LEFT JOIN subscriptions on child changes

### DIFF
--- a/crates/corro-types/src/pubsub.rs
+++ b/crates/corro-types/src/pubsub.rs
@@ -606,6 +606,7 @@ pub struct Matcher {
     pub cached_statements: HashMap<String, MatcherStmt>,
     pub pks: IndexMap<String, Vec<String>>,
     pub parsed: ParsedSelect,
+    left_join_tables: IndexSet<String>,
     pub evt_tx: mpsc::Sender<QueryEvent>,
     pub col_names: Vec<ColumnName>,
     pub last_rowid: u64,
@@ -696,6 +697,7 @@ impl Matcher {
         }
 
         let mut statements = HashMap::new();
+        let mut left_join_tables = IndexSet::new();
 
         let mut pks = IndexMap::default();
 
@@ -776,18 +778,17 @@ impl Matcher {
                         Some(FromClause {
                             joins: Some(joins), ..
                         }) if idx > 0 => {
-                            // Replace LEFT JOIN with INNER join if the target is the joined table
+                            // Changes from the nullable side cannot be reconciled by child PK.
                             if let Some(JoinedSelectTable {
                                 operator:
                                     JoinOperator::TypedJoin {
-                                        join_type:
-                                            join_type @ Some(JoinType::LeftOuter | JoinType::Left),
+                                        join_type: Some(JoinType::LeftOuter | JoinType::Left),
                                         ..
                                     },
                                 ..
-                            }) = joins.get_mut(idx - 1)
+                            }) = joins.get(idx - 1)
                             {
-                                *join_type = Some(JoinType::Inner);
+                                left_join_tables.insert(tbl_name.clone());
                             };
 
                             // Remove all custom INDEXED BY clauses for the table as the most efficient
@@ -892,6 +893,7 @@ impl Matcher {
             cached_statements: statements,
             pks,
             parsed,
+            left_join_tables,
             evt_tx,
             col_names,
             last_rowid: 0,
@@ -1531,51 +1533,64 @@ impl Matcher {
             return Ok(());
         }
 
+        // A cached row from the nullable side of a LEFT JOIN has no child PK.
+        // A child-PK slice therefore cannot include rows that appear or disappear
+        // as the join changes, so reconcile the complete subscription result.
+        let full_recompute_table = candidates
+            .keys()
+            .find(|table| self.left_join_tables.contains(table.as_str()))
+            .cloned();
+
         trace!(
             "got some candidates! {:?}",
             candidates.keys().collect::<Vec<_>>()
         );
 
-        let tx = self.conn.transaction()?;
-        for (table, pks) in candidates {
-            let pks = pks
-                .iter()
-                .map(|(pk, _)| unpack_columns(pk))
-                .collect::<Result<Vec<Vec<SqliteValueRef>>, _>>()?;
+        if let Some(table) = &full_recompute_table {
+            tables.insert(table.clone());
+        } else {
+            let tx = self.conn.transaction()?;
+            for (table, pks) in candidates {
+                let pks = pks
+                    .iter()
+                    .map(|(pk, _)| unpack_columns(pk))
+                    .collect::<Result<Vec<Vec<SqliteValueRef>>, _>>()?;
 
-            let tmp_table_name = format!("temp_{table}");
-            if tables.insert(table.clone()) {
-                // create a temporary table to mix and match the data
-                tx.prepare_cached(
-                    // TODO: cache the statement's string somewhere, it's always the same!
-                    // NOTE: this can't be an actual CREATE TEMP TABLE or it won't be visible
-                    //       from the state db
-                    &format!(
-                        "CREATE TABLE IF NOT EXISTS {tmp_table_name} ({})",
-                        self.pks
-                            .get(table.as_str())
-                            .ok_or_else(|| MatcherError::MissingPrimaryKeys)?
-                            .to_vec()
+                let tmp_table_name = format!("temp_{table}");
+                if tables.insert(table.clone()) {
+                    // create a temporary table to mix and match the data
+                    tx.prepare_cached(
+                        // TODO: cache the statement's string somewhere, it's always the same!
+                        // NOTE: this can't be an actual CREATE TEMP TABLE or it won't be visible
+                        //       from the state db
+                        &format!(
+                            "CREATE TABLE IF NOT EXISTS {tmp_table_name} ({})",
+                            self.pks
+                                .get(table.as_str())
+                                .ok_or_else(|| MatcherError::MissingPrimaryKeys)?
+                                .to_vec()
+                                .join(",")
+                        ),
+                    )?
+                    .execute(())?;
+                }
+
+                for pks in pks {
+                    tx.prepare_cached(&format!(
+                        "INSERT INTO {tmp_table_name} VALUES ({})",
+                        (0..pks.len())
+                            .map(|_i| "coalesce(?, \"\")")
+                            .collect::<Vec<_>>()
                             .join(",")
-                    ),
-                )?
-                .execute(())?;
+                    ))?
+                    .execute(params_from_iter(pks))?;
+                }
             }
 
-            for pks in pks {
-                tx.prepare_cached(&format!(
-                    "INSERT INTO {tmp_table_name} VALUES ({})",
-                    (0..pks.len())
-                        .map(|_i| "coalesce(?, \"\")")
-                        .collect::<Vec<_>>()
-                        .join(",")
-                ))?
-                .execute(params_from_iter(pks))?;
-            }
+            // commit so the temporary PK tables are visible to the state connection
+            tx.commit()?;
+            trace!("committed temp pk tables");
         }
-        // commit so it is visible to the other db!
-        tx.commit()?;
-        trace!("committed temp pk tables");
 
         let mut query_cols = vec![];
 
@@ -1592,6 +1607,22 @@ impl Matcher {
             all_cols.push(col_name.clone());
             query_cols.push(col_name);
         }
+
+        let full_recompute_stmt = full_recompute_table.as_ref().map(|table| {
+            let mut new_query = Cmd::Stmt(self.query.clone()).to_string();
+            new_query.pop();
+
+            debug!(
+                sub_id = %self.id,
+                %table,
+                "fully recomputing subscription for left join dependency"
+            );
+
+            MatcherStmt {
+                new_query,
+                temp_query: format!("SELECT {} FROM query", all_cols.join(",")),
+            }
+        });
 
         // start a new tx
         let tx = self.conn.transaction()?;
@@ -1617,12 +1648,15 @@ impl Matcher {
 
             for table in tables.iter() {
                 let start = Instant::now();
-                let stmt = match self.cached_statements.get(table.as_str()) {
+                let stmt = match &full_recompute_stmt {
                     Some(stmt) => stmt,
-                    None => {
-                        warn!(sub_id = %self.id, "no statements pre-computed for table {table}");
-                        continue;
-                    }
+                    None => match self.cached_statements.get(table.as_str()) {
+                        Some(stmt) => stmt,
+                        None => {
+                            warn!(sub_id = %self.id, "no statements pre-computed for table {table}");
+                            continue;
+                        }
+                    },
                 };
 
                 trace!("SELECT SQL: {}", stmt.new_query);
@@ -1775,12 +1809,14 @@ impl Matcher {
                 histogram!("corro.subs.changes.processing.table.duration.seconds", "sql_hash" => self.hash.clone(), "table" => table.0.to_string()).record(elapsed);
             }
 
-            // clean up temporary tables immediately
-            for table in tables {
-                // TODO: reduce mistakes by computing this table name once
-                tx.prepare_cached(&format!("DELETE FROM temp_{table}",))?
-                    .execute(())?;
-                trace!("cleaned up temp_{table}");
+            if full_recompute_stmt.is_none() {
+                // clean up temporary tables immediately
+                for table in tables {
+                    // TODO: reduce mistakes by computing this table name once
+                    tx.prepare_cached(&format!("DELETE FROM temp_{table}",))?
+                        .execute(())?;
+                    trace!("cleaned up temp_{table}");
+                }
             }
         }
 
@@ -2619,6 +2655,102 @@ mod tests {
         tripwire_tx.send(()).await.ok();
         tripwire_worker.await;
         wait_for_all_pending_handles().await;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_left_anti_join_reacts_to_child_insert(
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        _ = tracing_subscriber::fmt::try_init();
+        let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+        let schema_sql = "
+            CREATE TABLE services (
+                id INTEGER NOT NULL PRIMARY KEY
+            );
+            CREATE TABLE health_checks (
+                id INTEGER NOT NULL PRIMARY KEY,
+                service_id INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'unknown'
+            );
+        ";
+        let mut schema = parse_sql(schema_sql)?;
+        let sql = "
+            SELECT s.id
+            FROM services AS s
+            LEFT JOIN health_checks AS h
+              ON h.service_id = s.id AND h.status != 'passing'
+            WHERE h.id IS NULL
+        ";
+        let subs = SubsManager::default();
+        let tmpdir = TempDir::new(tempfile::tempdir()?);
+        let db_path = tmpdir.path().join("test.db");
+        let subscriptions_path: Utf8PathBuf =
+            tmpdir.path().join("subs").display().to_string().into();
+        let pool = SplitPool::create(db_path, Arc::new(Semaphore::new(1)), -1048576).await?;
+        let clock = Arc::new(uhlc::HLC::default());
+        let mut conn = pool.write_priority().await?;
+
+        setup_conn(&conn)?;
+        migrate(clock, &mut conn)?;
+        let tx = conn.transaction()?;
+        apply_schema(&tx, &Schema::default(), &mut schema)?;
+        tx.commit()?;
+
+        let tx = conn.transaction()?;
+        tx.execute("INSERT INTO services (id) VALUES (1)", ())?;
+        tx.commit()?;
+
+        let (handle, created) = subs.get_or_insert(
+            sql,
+            subscriptions_path.as_path(),
+            &schema,
+            &pool,
+            tripwire.clone(),
+        )?;
+        let mut rx = created
+            .expect("new query should create a subscription")
+            .evt_rx;
+
+        assert!(matches!(rx.recv().await, Some(QueryEvent::Columns(_))));
+        assert_eq!(
+            rx.recv().await,
+            Some(QueryEvent::Row(RowId(1), vec![1_i64.into()]))
+        );
+        assert!(matches!(
+            rx.recv().await,
+            Some(QueryEvent::EndOfQuery { .. })
+        ));
+
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO health_checks (id, service_id, status) VALUES (1, 1, 'failing')",
+            (),
+        )?;
+        tx.commit()?;
+        let db_version = conn.query_row("SELECT crsql_db_version()", (), |row| row.get(0))?;
+        filter_changes_from_db(&handle, &conn, None, db_version)?;
+
+        let event = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+
+        handle.cleanup().await;
+        subs.remove(&handle.id());
+        tripwire_tx.send(()).await.ok();
+        tripwire_worker.await;
+        wait_for_all_pending_handles().await;
+
+        let event = event
+            .expect("child-table change did not produce a subscription event")
+            .expect("subscription event channel closed");
+        assert_eq!(
+            event,
+            QueryEvent::Change(
+                ChangeType::Delete,
+                RowId(1),
+                vec![1_i64.into()],
+                ChangeId(1),
+            )
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #539.

Subscriptions already treat a direct `LEFT JOIN` child as reactive, but the
child-PK-targeted diff cannot include a cached null-extended row. A matching
child insert can therefore leave an anti-join subscription stale. Projected
`LEFT JOIN` queries emit the matched-row half of the transition but miss the
null-row half.

Full reproduction and the repeated behavioral matrix are in the issue.

## What changed

- Record tables found on the nullable side of direct `LEFT` and
  `LEFT OUTER JOIN` clauses while building matcher statements.
- When a buffered batch contains a change from one of those tables, reconcile
  the complete subscription result once.
- Use the same augmented query shape as the initial snapshot and compare it
  with the complete cached `query` table.
- Reuse the existing insert, update, and delete classification.
- Keep the existing primary-key-targeted path for root-only and inner-join
  batches.
- Stop rewriting the now-unused nullable-child statement from `LEFT JOIN` to
  `INNER JOIN`.
- Add a regression for an anti-join child insert.

## Why this path uses a full diff

The cached null-extended row has a `NULL` hidden child primary key. It cannot
match the real primary key of a newly inserted, updated, or deleted child.
Removing the current `LEFT JOIN` to `INNER JOIN` rewrite does not fix that
slice boundary.

Hidden root PKs already exist in the cache, but they do not identify the root
for the minimal child-insert case: the cached row has a `NULL` child PK and the
current anti-join result restricted by the new child PK is empty. A selective
implementation would need to derive root keys from the join inputs before the
final query filter, or retain another child-to-root mapping. The complete diff
is the conservative correctness path with the metadata currently available.

If a batch contains both root and nullable-side child changes, the full diff
subsumes the root-targeted work. It runs once for that buffered batch.

## Regression test

`test_left_anti_join_reacts_to_child_insert` starts with service `1` visible,
inserts one matching child, and requires:

~~~text
Change(Delete, RowId(1), [1], ChangeId(1))
~~~

The test alone on unpatched upstream `main` times out after five seconds. With
the implementation, it receives the exact delete and passes.

## Behavioral verification

Five isolated trials per build covered:

- anti-join insert, update in both directions, and delete;
- projected null-to-matched and matched-to-null transitions;
- two matching children in one batch;
- a mixed root and child batch;
- a child change on a second `LEFT JOIN`;
- inner-join, root-update, and nonmatching-child controls.

All failing cases reproduced in 5/5 runs on `main` at `936de111` and were
correct in 5/5 runs with the patch. Every initial snapshot, direct SQL result,
and quiet pre-mutation window matched its expectation. All controls retained
their expected behavior.

A two-node runner wrote on node A, proved replication through a direct query on
node B, and then checked the subscription on B. The remote anti join and
projected `LEFT JOIN` failed in 5/5 unpatched runs and were correct in 5/5
patched runs. The remote inner join control remained reactive.

## Verification

~~~text
cargo fmt -- --check --color always
git diff --check
RUSTFLAGS='--cfg tokio_unstable' cargo test --locked -p corro-types --lib --release
  42 passed; 0 failed
RUSTFLAGS='--cfg tokio_unstable' cargo clippy --locked --all-targets -- -D warnings
  passed
RUSTFLAGS='--cfg tokio_unstable' cargo nextest run --locked --profile ci --workspace --target x86_64-unknown-linux-gnu
  154 passed; 0 failed; 10 skipped by profile
RUSTFLAGS='--cfg tokio_unstable' cargo build --locked --release --bin corrosion
  passed
mdbook build
  passed
~~~

I also ran the workspace through plain `cargo test`. The `corro-pg` integration
tests `test_pg_readonly` and `test_pg_corrrosion_shutdown` conflict over a
process-global tracing subscriber. The same integration-test binary fails with
the same two errors on an upstream-main worktree. Each test passes alone, and
both pass under the nextest CI run above.

I repeated the workspace run with `--no-fail-fast` so every standard test
target ran. `corro-pg::tests` was the only failed target, with 8 passed and the
same 2 failures. The same target reports 8 passed and 2 failed from a clean
main worktree.

## Performance characteristics

The full-result path was measured with one indexed anti-join subscription.
These are matcher-processing times for one child-driven batch:

| Result rows | Median | Observed range |
| ---: | ---: | ---: |
| 1,000 | 4.132 ms | 3.943 to 4.542 ms |
| 10,000 | 39.790 ms | 39.070 to 40.444 ms |
| 50,000 | 200.300 ms | 199.026 to 200.711 ms |
| 100,000 | 403.754 ms | 402.197 to 415.535 ms |
| 250,000 | 1,018.066 ms | 1,007.310 to 1,026.454 ms |

The measurement used a release build on a shared development host with an
overclocked AMD Ryzen 7 5700G, eight physical cores, SMT disabled, boost
enabled, and a kernel-reported maximum frequency of 5.658 GHz.

Candidate processing already starts after a 600 ms deadline or when the buffer
reaches 1,000 distinct table and primary-key entries. A nullable-side child
batch can cause one full-result diff. The candidate channel holds 20,480
items. When it is full, `match_changes` spawns an awaited send instead of
deliberately dropping that candidate. Sustained overload can still grow
matcher lag and the number of waiting tasks.

Sustained write throughput, concurrent subscription load, and peak temporary
memory were not measured.

## Interaction with #538

This branch is based directly on `main` and is independent of #538. Both
changes need a full-result path in `handle_candidates`. If #538 lands first,
this branch can reuse that path during rebase instead of retaining duplicate
control flow.

`RIGHT JOIN` and `FULL JOIN` remain outside this patch.
