### PR TITLE
Prevent HTTP reads from retaining SQLite connection state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rangemap = { version = "1.5.1", features = ["serde1"] }
 rcgen = { version = "0.11.1", features = ["x509-parser"] }
 reqwest = { version = "0.12", default-features = false, features = ["http2", "rustls-tls", "rustls-tls-webpki-roots"] }
 rhai = { version = "1.15.1", features = ["sync"] }
-rusqlite = { version = "0.38.0", features = ["serde_json", "time", "bundled", "uuid", "array", "load_extension", "column_decltype", "vtab", "functions", "chrono", "series", "trace", "cache", "fallible_uint"] }
+rusqlite = { version = "0.38.0", features = ["serde_json", "time", "bundled", "uuid", "array", "load_extension", "column_decltype", "vtab", "functions", "chrono", "series", "trace", "cache", "fallible_uint", "hooks"] }
 rustls = { version = "0.23.0", default-features = false, features = ["ring"] }
 seahash = "4.1.0"
 serde = "1.0.159"

--- a/crates/corro-agent/src/api/public/mod.rs
+++ b/crates/corro-agent/src/api/public/mod.rs
@@ -28,7 +28,10 @@ use corro_types::{
 };
 use hyper::StatusCode;
 use metrics::{counter, histogram};
-use rusqlite::{params_from_iter, ToSql, Transaction};
+use rusqlite::{
+    hooks::{AuthAction, AuthContext, Authorization},
+    params_from_iter, ToSql, Transaction,
+};
 use serde::Deserialize;
 use spawn::spawn_counted;
 use sqlite_pool::{Committable, InterruptibleTransaction, SqliteConn};
@@ -271,6 +274,90 @@ pub enum QueryError {
     Rusqlite(#[from] rusqlite::Error),
 }
 
+fn is_safe_crsql_function(function_name: &str) -> bool {
+    matches!(
+        function_name.to_ascii_lowercase().as_str(),
+        "crsql_config_get"
+            | "crsql_db_version"
+            | "crsql_fract_key_between"
+            | "crsql_get_seq"
+            | "crsql_get_ts"
+            | "crsql_pack_columns"
+            | "crsql_peek_next_db_version"
+            | "crsql_rows_impacted"
+            | "crsql_sha"
+            | "crsql_site_id"
+            | "crsql_version"
+    )
+}
+
+fn is_effectful_read_pragma(pragma_name: &str) -> bool {
+    matches!(
+        pragma_name.to_ascii_lowercase().as_str(),
+        "incremental_vacuum" | "optimize" | "shrink_memory" | "wal_checkpoint"
+    )
+}
+
+fn is_effectful_pragma_table(table_name: &str) -> bool {
+    table_name
+        .to_ascii_lowercase()
+        .strip_prefix("pragma_")
+        .is_some_and(is_effectful_read_pragma)
+}
+
+fn is_safe_read_pragma(pragma_name: &str, pragma_value: Option<&str>) -> bool {
+    match pragma_name.to_ascii_lowercase().as_str() {
+        // These accept a target as SQLite's second authorizer argument but do
+        // not change connection or database state.
+        "foreign_key_check" | "foreign_key_list" | "index_info" | "index_list" | "index_xinfo"
+        | "integrity_check" | "quick_check" | "table_info" | "table_list" | "table_xinfo" => true,
+        // These execute work even without an assignment argument.
+        name if is_effectful_read_pragma(name) => false,
+        // Other argument-free PRAGMAs are getters or introspection queries.
+        _ => pragma_value.is_none(),
+    }
+}
+
+fn authorize_read_query(context: AuthContext<'_>) -> Authorization {
+    match context.action {
+        AuthAction::Read { table_name, .. } if !is_effectful_pragma_table(table_name) => {
+            Authorization::Allow
+        }
+        AuthAction::Select | AuthAction::Recursive => Authorization::Allow,
+        AuthAction::Pragma {
+            pragma_name,
+            pragma_value,
+        } if is_safe_read_pragma(pragma_name, pragma_value) => Authorization::Allow,
+        AuthAction::Function { function_name }
+            if !function_name.eq_ignore_ascii_case("load_extension")
+                && (!function_name
+                    .get(..6)
+                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case("crsql_"))
+                    || is_safe_crsql_function(function_name)) =>
+        {
+            Authorization::Allow
+        }
+        _ => Authorization::Deny,
+    }
+}
+
+struct ReadQueryAuthorizer<'conn>(&'conn rusqlite::Connection);
+
+impl<'conn> ReadQueryAuthorizer<'conn> {
+    fn install(conn: &'conn rusqlite::Connection) -> rusqlite::Result<Self> {
+        conn.authorizer(Some(authorize_read_query))?;
+        Ok(Self(conn))
+    }
+}
+
+impl Drop for ReadQueryAuthorizer<'_> {
+    fn drop(&mut self) {
+        let _ = self
+            .0
+            .authorizer(None::<fn(AuthContext<'_>) -> Authorization>);
+    }
+}
+
 async fn build_query_rows_response(
     agent: &Agent,
     client_addr: SocketAddr,
@@ -303,6 +390,19 @@ async fn build_query_rows_response(
 
         let conn = InterruptibleTransaction::new(conn.conn(), timeout, "query");
         trace!(%client_addr, "Preparing statement {}", stmt.query());
+
+        let _authorizer = match ReadQueryAuthorizer::install(&conn) {
+            Ok(authorizer) => authorizer,
+            Err(e) => {
+                _ = res_tx.send(Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ExecResult::Error {
+                        error: e.to_string(),
+                    },
+                )));
+                return;
+            }
+        };
 
         let prepped_res = block_in_place(|| conn.prepare(stmt.query()));
 
@@ -679,6 +779,344 @@ mod tests {
     use super::*;
 
     use crate::{agent::setup, agent::util::execute_schema};
+
+    const VALID_READ_QUERY_CASES: &[&str] = &[
+        "SELECT 1",
+        "WITH value(x) AS (VALUES (1)) SELECT x FROM value",
+        "VALUES (1)",
+        "EXPLAIN SELECT 1",
+        "EXPLAIN QUERY PLAN SELECT 1",
+        "PRAGMA foreign_keys",
+        "PRAGMA compile_options",
+        "PRAGMA integrity_check",
+        "PRAGMA table_info('freshness')",
+        "PRAGMA table_list('freshness')",
+        "SELECT count(*) FROM pragma_function_list",
+        "SELECT count(*) FROM pragma_module_list",
+        "SELECT count(*) FROM pragma_table_info('freshness')",
+        "SELECT count(*) FROM pragma_table_list('freshness')",
+    ];
+
+    const REJECTED_READ_QUERY_CASES: &[&str] = &[
+        "BEGIN",
+        "SAVEPOINT leaked",
+        "PRAGMA query_only = ON",
+        "PRAGMA read_uncommitted = ON",
+        "PRAGMA locking_mode = EXCLUSIVE",
+        "EXPLAIN PRAGMA query_only = ON",
+        "ATTACH DATABASE ':memory:' AS leaked",
+        "PRAGMA incremental_vacuum",
+        "PRAGMA optimize",
+        "PRAGMA shrink_memory",
+        "PRAGMA wal_checkpoint",
+        "SELECT * FROM pragma_optimize(0x10002)",
+        "SELECT crsql_finalize()",
+        "UPDATE freshness SET value = 9",
+    ];
+
+    #[test]
+    fn read_query_authorizer_rejects_connection_state_statements_before_prepare() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE freshness (value INTEGER)", ())
+            .unwrap();
+
+        for sql in VALID_READ_QUERY_CASES
+            .iter()
+            .copied()
+            .chain(["SELECT 1_000"])
+        {
+            let _authorizer = ReadQueryAuthorizer::install(&conn).unwrap();
+            let _: rusqlite::types::Value = conn
+                .query_row(sql, (), |row| row.get(0))
+                .unwrap_or_else(|error| panic!("expected a read query: {sql}: {error}"));
+        }
+
+        for sql in REJECTED_READ_QUERY_CASES.iter().copied().chain([
+            "COMMIT",
+            "ROLLBACK",
+            "RELEASE leaked",
+            "EXPLAIN QUERY PLAN PRAGMA read_uncommitted = ON",
+            "DETACH DATABASE leaked",
+            "SELECT load_extension('not-present')",
+        ]) {
+            let _authorizer = ReadQueryAuthorizer::install(&conn).unwrap();
+            assert!(conn.prepare(sql).is_err(), "expected rejection: {sql}");
+        }
+
+        assert!(conn.is_autocommit());
+        assert_eq!(
+            conn.query_row("PRAGMA query_only", (), |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+
+        {
+            let _authorizer = ReadQueryAuthorizer::install(&conn).unwrap();
+            let column_name = conn
+                .query_row("PRAGMA table_info('freshness')", (), |row| {
+                    row.get::<_, String>(1)
+                })
+                .unwrap();
+            assert_eq!(column_name, "value");
+        }
+        {
+            let _authorizer = ReadQueryAuthorizer::install(&conn).unwrap();
+            let count = conn
+                .query_row(
+                    "SELECT count(*) FROM pragma_table_info('freshness')",
+                    (),
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1);
+        }
+        assert_eq!(
+            conn.query_row("PRAGMA read_uncommitted", (), |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            conn.query_row("PRAGMA locking_mode", (), |row| row.get::<_, String>(0))
+                .unwrap(),
+            "normal"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT count(*) FROM pragma_database_list WHERE name = 'leaked'",
+                (),
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
+        conn.execute_batch("BEGIN; ROLLBACK")
+            .expect("the request authorizer should be removed on drop");
+    }
+
+    #[test]
+    fn read_query_authorizer_blocks_mutation_during_automatic_reprepare() -> eyre::Result<()> {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+
+        fn open_mutating_reader(
+            path: &std::path::Path,
+            mutated: &Arc<AtomicBool>,
+        ) -> eyre::Result<rusqlite::Connection> {
+            let reader = rusqlite::Connection::open(path)?;
+            reader.pragma_update(None, "trusted_schema", true)?;
+            let mutated = mutated.clone();
+            reader.create_scalar_function(
+                "crsql_mutate",
+                0,
+                rusqlite::functions::FunctionFlags::SQLITE_UTF8,
+                move |_| {
+                    mutated.store(true, Ordering::SeqCst);
+                    Ok(2_i64)
+                },
+            )?;
+            Ok(reader)
+        }
+
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("reprepare.db");
+        let writer = rusqlite::Connection::open(&path)?;
+        writer.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             CREATE VIEW guarded AS SELECT 1 AS value;",
+        )?;
+
+        let mutated = Arc::new(AtomicBool::new(false));
+        let unguarded_reader = open_mutating_reader(&path, &mutated)?;
+
+        let mut unguarded_statement = unguarded_reader.prepare("SELECT value FROM guarded")?;
+        writer.execute_batch(
+            "DROP VIEW guarded;
+             CREATE VIEW guarded AS SELECT crsql_mutate() AS value;",
+        )?;
+        assert_eq!(
+            unguarded_statement.query_row((), |row| row.get::<_, i64>(0))?,
+            2
+        );
+        assert!(mutated.swap(false, Ordering::SeqCst));
+        drop(unguarded_statement);
+        drop(unguarded_reader);
+
+        writer.execute_batch(
+            "DROP VIEW guarded;
+             CREATE VIEW guarded AS SELECT 1 AS value;",
+        )?;
+
+        let reader = open_mutating_reader(&path, &mutated)?;
+
+        let _authorizer = ReadQueryAuthorizer::install(&reader)?;
+        let mut statement = reader.prepare("SELECT value FROM guarded")?;
+
+        writer.execute_batch(
+            "DROP VIEW guarded;
+             CREATE VIEW guarded AS SELECT crsql_mutate() AS value;",
+        )?;
+
+        let error = statement
+            .query_row((), |row| row.get::<_, i64>(0))
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                rusqlite::Error::SqliteFailure(_, Some(ref message))
+                    if message == "not authorized to use function: crsql_mutate"
+            ),
+            "unexpected reprepare error: {error:?}"
+        );
+        assert!(!mutated.load(Ordering::SeqCst));
+
+        Ok(())
+    }
+
+    async fn query_events(agent: &Agent, sql: &str) -> eyre::Result<(StatusCode, Vec<QueryEvent>)> {
+        let response = api_v1_queries(
+            Extension(agent.clone()),
+            ConnectInfo("127.0.0.1:22000".parse()?),
+            axum::extract::Query(TimeoutParams { timeout: None }),
+            axum::Json(Statement::Simple(sql.into())),
+        )
+        .await
+        .into_response();
+
+        let status = response.status();
+        let mut body = response.into_body().into_data_stream();
+        let mut bytes = BytesMut::new();
+        while let Some(chunk) = body.next().await {
+            bytes.extend_from_slice(&chunk?);
+        }
+
+        if !status.is_success() {
+            return Ok((status, Vec::new()));
+        }
+
+        let events = std::str::from_utf8(&bytes)?
+            .lines()
+            .map(serde_json::from_str)
+            .collect::<Result<Vec<QueryEvent>, _>>()?;
+        Ok((status, events))
+    }
+
+    async fn query_integer(agent: &Agent, sql: &str) -> eyre::Result<i64> {
+        let (status, events) = query_events(agent, sql).await?;
+        assert_eq!(status, StatusCode::OK);
+        events
+            .into_iter()
+            .find_map(|event| match event {
+                QueryEvent::Row(_, mut values) => match values.remove(0) {
+                    SqliteValue::Integer(value) => Some(value),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .ok_or_else(|| eyre::eyre!("query returned no integer row: {sql}"))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn query_handler_cannot_recycle_connection_state() -> eyre::Result<()> {
+        let (tripwire, _tripwire_worker, _tripwire_tx) = Tripwire::new_simple();
+        let dir = tempfile::tempdir()?;
+        let (agent, _agent_options) = setup(
+            Config::builder()
+                .db_path(dir.path().join("corrosion.db").display().to_string())
+                .gossip_addr("127.0.0.1:0".parse()?)
+                .api_addr("127.0.0.1:0".parse()?)
+                .build()?,
+            tripwire,
+        )
+        .await?;
+
+        {
+            let conn = agent.pool().write_priority().await?;
+            conn.execute_batch(
+                "CREATE TABLE freshness (
+                    id INTEGER PRIMARY KEY NOT NULL,
+                    value INTEGER NOT NULL DEFAULT 0
+                 );
+                 SELECT crsql_as_crr('freshness');
+                 INSERT INTO freshness VALUES (1, 1);",
+            )?;
+        }
+
+        for sql in VALID_READ_QUERY_CASES
+            .iter()
+            .copied()
+            .chain(["SELECT corro_json_contains('{}', '{}')"])
+        {
+            assert_eq!(
+                query_events(&agent, sql).await?.0,
+                StatusCode::OK,
+                "rejected {sql}"
+            );
+        }
+
+        let begin_status = query_events(&agent, "BEGIN").await?.0;
+        let change_value_sql = "SELECT val FROM crsql_changes
+            WHERE \"table\" = 'freshness' AND cid = 'value'
+            ORDER BY db_version DESC, seq DESC LIMIT 1";
+
+        assert_eq!(
+            query_integer(&agent, "SELECT value FROM freshness WHERE id = 1").await?,
+            1
+        );
+        assert_eq!(query_integer(&agent, change_value_sql).await?, 1);
+        {
+            let conn = agent.pool().write_priority().await?;
+            conn.execute("UPDATE freshness SET value = 2 WHERE id = 1", ())?;
+        }
+        assert_eq!(
+            query_integer(&agent, change_value_sql).await?,
+            2,
+            "the handler recycled a stale crsql_changes snapshot"
+        );
+        assert_eq!(
+            query_integer(&agent, "SELECT value FROM freshness WHERE id = 1").await?,
+            2
+        );
+        assert_eq!(begin_status, StatusCode::BAD_REQUEST, "accepted BEGIN");
+
+        for sql in REJECTED_READ_QUERY_CASES
+            .iter()
+            .copied()
+            .filter(|sql| *sql != "BEGIN")
+            .chain([
+                "SELECT crsql_set_ts(1)",
+                "SELECT crsql_as_crr('freshness')",
+                "SELECT crsql_as_table('freshness')",
+            ])
+        {
+            assert_eq!(
+                query_events(&agent, sql).await?.0,
+                StatusCode::BAD_REQUEST,
+                "accepted {sql}"
+            );
+        }
+
+        assert!(query_integer(&agent, "SELECT crsql_db_version()").await? >= 0);
+
+        let conn = agent.pool().read().await?;
+        assert!(conn.is_autocommit());
+        assert_eq!(
+            conn.query_row("PRAGMA query_only", (), |row| row.get::<_, i64>(0))?,
+            0
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT count(*) FROM pragma_database_list WHERE name = 'leaked'",
+                (),
+                |row| row.get::<_, i64>(0),
+            )?,
+            0
+        );
+        conn.execute_batch("BEGIN; ROLLBACK")?;
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_api_db_execute() -> eyre::Result<()> {

--- a/crates/sqlite-pool/src/lib.rs
+++ b/crates/sqlite-pool/src/lib.rs
@@ -101,9 +101,14 @@ where
 
     async fn recycle(
         &self,
-        _conn: &mut Self::Type,
+        conn: &mut Self::Type,
         _: &Metrics,
     ) -> managed::RecycleResult<Self::Error> {
+        if !conn.conn().is_autocommit() {
+            return Err(managed::RecycleError::message(
+                "connection has an active transaction",
+            ));
+        }
         let _ = self.recycle_count.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }

--- a/crates/sqlite-pool/tests/connection_lifecycle.rs
+++ b/crates/sqlite-pool/tests/connection_lifecycle.rs
@@ -1,0 +1,162 @@
+use rusqlite::Connection;
+use sqlite_pool::Config;
+
+fn run_to_completion(conn: &Connection, sql: &str) -> rusqlite::Result<(bool, usize)> {
+    let mut statement = conn.prepare(sql)?;
+    let readonly = statement.readonly();
+    let column_count = statement.column_count();
+    let mut rows = statement.query(())?;
+    while rows.next()?.is_some() {}
+    Ok((readonly, column_count))
+}
+
+#[test]
+fn readonly_pragmas_change_connection_state_during_prepare() -> eyre::Result<()> {
+    let conn = Connection::open_in_memory()?;
+
+    for sql in ["PRAGMA query_only = ON", "EXPLAIN PRAGMA query_only = ON"] {
+        let statement = conn.prepare(sql)?;
+        assert!(statement.readonly());
+        assert_eq!(
+            conn.query_row("PRAGMA query_only", (), |row| row.get::<_, i64>(0))?,
+            1,
+            "{sql:?} did not take effect during prepare"
+        );
+        eprintln!("prepare_applied={sql:?} readonly=true query_only=1");
+        drop(statement);
+        conn.execute_batch("PRAGMA query_only = OFF")?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn classify_readonly_statements_that_change_connection_state() -> eyre::Result<()> {
+    let conn = Connection::open_in_memory()?;
+    eprintln!("sqlite_version={}", rusqlite::version());
+
+    for sql in ["BEGIN", "SAVEPOINT leaked"] {
+        let (readonly, column_count) = run_to_completion(&conn, sql)?;
+        eprintln!(
+            "sql={sql:?} readonly={readonly} column_count={column_count} autocommit={}",
+            conn.is_autocommit()
+        );
+        assert!(readonly, "SQLite classifies {sql:?} as readonly");
+        assert_eq!(column_count, 0);
+        assert!(!conn.is_autocommit(), "{sql:?} opens a transaction");
+        conn.execute_batch("ROLLBACK")?;
+    }
+
+    for sql in [
+        "PRAGMA query_only = ON",
+        "PRAGMA read_uncommitted = ON",
+        "ATTACH DATABASE ':memory:' AS leaked",
+    ] {
+        let (readonly, column_count) = run_to_completion(&conn, sql)?;
+        eprintln!(
+            "sql={sql:?} readonly={readonly} column_count={column_count} autocommit={}",
+            conn.is_autocommit()
+        );
+        assert!(readonly, "SQLite classifies {sql:?} as readonly");
+        assert_eq!(column_count, 0);
+
+        match sql {
+            "PRAGMA query_only = ON" => {
+                assert_eq!(
+                    conn.query_row("PRAGMA query_only", (), |row| row.get::<_, i64>(0))?,
+                    1
+                );
+                conn.execute_batch("PRAGMA query_only = OFF")?;
+            }
+            "PRAGMA read_uncommitted = ON" => {
+                assert_eq!(
+                    conn.query_row("PRAGMA read_uncommitted", (), |row| row.get::<_, i64>(0))?,
+                    1
+                );
+                conn.execute_batch("PRAGMA read_uncommitted = OFF")?;
+            }
+            "ATTACH DATABASE ':memory:' AS leaked" => {
+                let attached: i64 = conn.query_row(
+                    "SELECT count(*) FROM pragma_database_list WHERE name = 'leaked'",
+                    (),
+                    |row| row.get(0),
+                )?;
+                assert_eq!(attached, 1);
+                conn.execute_batch("DETACH DATABASE leaked")?;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    let sql = "PRAGMA locking_mode = EXCLUSIVE";
+    let (readonly, column_count) = run_to_completion(&conn, sql)?;
+    eprintln!(
+        "sql={sql:?} readonly={readonly} column_count={column_count} autocommit={}",
+        conn.is_autocommit()
+    );
+    assert!(readonly, "SQLite classifies {sql:?} as readonly");
+    assert_eq!(column_count, 1, "stateful pragmas can return rows");
+    assert_eq!(
+        conn.query_row("PRAGMA locking_mode", (), |row| row.get::<_, String>(0))?,
+        "exclusive"
+    );
+    conn.execute_batch("PRAGMA locking_mode = NORMAL")?;
+
+    Ok(())
+}
+
+async fn freshness_trial(transaction_start: Option<&str>, trial: usize) -> eyre::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("fresh.db");
+    let writer = Connection::open(&path)?;
+    writer.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         CREATE TABLE freshness (value INTEGER NOT NULL);
+         INSERT INTO freshness VALUES (1);",
+    )?;
+
+    let pool = Config::new(&path).read_only().max_size(1).create_pool()?;
+
+    if let Some(sql) = transaction_start {
+        let conn = pool.get().await?;
+        let (readonly, column_count) = run_to_completion(&conn, sql)?;
+        assert!(readonly);
+        assert_eq!(column_count, 0);
+        assert!(!conn.is_autocommit());
+    }
+
+    {
+        let conn = pool.get().await?;
+        let value: i64 = conn.query_row("SELECT value FROM freshness", (), |row| row.get(0))?;
+        assert_eq!(value, 1);
+    }
+
+    writer.execute("UPDATE freshness SET value = 2", ())?;
+
+    let conn = pool.get().await?;
+    let value: i64 = conn.query_row("SELECT value FROM freshness", (), |row| row.get(0))?;
+    assert_eq!(
+        value, 2,
+        "trial {trial} recycled a stale snapshot after {transaction_start:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn recycled_connections_do_not_keep_transaction_snapshots() -> eyre::Result<()> {
+    for transaction_start in ["BEGIN", "SAVEPOINT leaked"] {
+        for trial in 0..5 {
+            freshness_trial(Some(transaction_start), trial).await?;
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn autocommit_connections_observe_fresh_writes() -> eyre::Result<()> {
+    for trial in 0..5 {
+        freshness_trial(None, trial).await?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- authorize `/v1/queries` statements before SQLite prepares them
- keep the authorizer active through row production and automatic reprepare
- retain compatibility with normal reads and read-only Corrosion/CR-SQLite functions
- reject and discard non-autocommit SQLite connections at their next checkout
- add deterministic handler, authorizer, and pool lifecycle regressions
- share the portable allow/deny contract and reprepare fixture across test layers

## Why

`sqlite3_stmt_readonly()` is not a read-query security or lifecycle boundary. SQLite
reports `BEGIN`, `SAVEPOINT`, `ATTACH`, and connection-state PRAGMAs as read-only. The
endpoint accepted those statements, and the read pool recycled the resulting state.
With a one-connection WAL read pool, a leaked transaction deterministically pins a stale
snapshot.

Some PRAGMA assignments, including `query_only`, take effect during prepare. The
authorizer must therefore be installed before preparation rather than validating only
the prepared statement or its result columns.

## Implementation

The endpoint uses rusqlite's authorizer hook to allow read/select actions, ordinary
functions, explicit read-only `crsql_*` functions, and read-only PRAGMA forms. It denies
transaction control, attach/detach, DDL/DML, state-changing PRAGMAs (including
table-valued `pragma_optimize`), `load_extension`, and side-effecting or unknown
`crsql_*` functions. An RAII guard removes the hook on all exits.

Installing the non-null authorizer expires existing prepared statements, which SQLite
may transparently reprepare. The guard stays active through reprepare. DML is denied
during `prepare`; `Statement::readonly()` remains a defense-in-depth check after
successful preparation.

Deadpool invokes recycle validation on the next checkout. The pool hook rejects a
non-autocommit object and Deadpool discards it before it reaches the borrower;
validation is not immediate when the object is returned.

## Compatibility

The real handler regression exercises plain selects, CTEs, `VALUES`, `EXPLAIN`, getter
and targeted introspection PRAGMAs, table-valued PRAGMAs, `crsql_changes`,
`crsql_db_version()`, and `corro_json_contains()`. Its fixture calls
`crsql_as_crr('freshness')` and proves the latest actual `crsql_changes.val` advances
from `1` to `2` after a committed write. It also confirms that request cleanup removes
the authorizer.

## Tests

- 2 authorizer unit tests passed, including schema-reprepare protection
- 1 actual async query-handler regression passed
- 4 SQLite pool lifecycle tests passed
- relevant package nextest suites: 58 passed, 2 skipped, 0 failed
- default workspace nextest: 160 passed, 10 skipped, 0 failed
- full workspace CI-profile nextest: 160 passed, 10 skipped, 0 failed
- workspace clippy with warnings denied passed
- formatting, mdBook/linkcheck, and whitespace checks passed

Closes #543
