### PR TITLE
Reject inverted synchronization ranges before processing

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -1055,6 +1055,11 @@ pub async fn handle_changes(
             }
         };
 
+        if let Err(error) = change.validate() {
+            warn!(actor_id = %change.actor_id, %error, "dropping change with an invalid range");
+            continue;
+        }
+
         let change_len = change.len();
         counter!("corro.agent.changes.recv").increment(std::cmp::max(change_len, 1) as u64); // count empties...
 

--- a/crates/corro-agent/src/api/peer/mod.rs
+++ b/crates/corro-agent/src/api/peer/mod.rs
@@ -15,8 +15,9 @@ use corro_types::broadcast::{
 use corro_types::change::{row_to_change, Change, ChunkedChanges};
 use corro_types::config::GossipConfig;
 use corro_types::sync::{
-    generate_sync, SyncMessage, SyncMessageEncodeError, SyncMessageV1, SyncNeedV1, SyncRejectionV1,
-    SyncRequestV1, SyncStateV1, SyncTraceContextV1,
+    generate_sync, SyncMessage, SyncMessageEncodeError, SyncMessageV1, SyncNeedV1,
+    SyncNeedValidationError, SyncRejectionV1, SyncRequestV1, SyncStateV1, SyncStateValidationError,
+    SyncTraceContextV1,
 };
 use eyre::{ContextCompat, WrapErr};
 use futures::stream::FuturesUnordered;
@@ -58,6 +59,8 @@ pub enum SyncError {
     Rejection(#[from] SyncRejectionV1),
     #[error(transparent)]
     Transport(#[from] TransportError),
+    #[error(transparent)]
+    InvalidState(#[from] SyncStateValidationError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -381,6 +384,7 @@ fn handle_need(
     need: SyncNeedV1,
     sender: &Sender<SyncMessage>,
 ) -> eyre::Result<()> {
+    need.validate()?;
     debug!(%actor_id, "handle known versions! need: {need:?}");
 
     let mut empties: RangeInclusiveSet<CrsqlDbVersion> = RangeInclusiveSet::new();
@@ -808,6 +812,15 @@ fn send_change_chunks<I: Iterator<Item = rusqlite::Result<Change>>>(
     Ok(())
 }
 
+fn validate_sync_needs(
+    requests: &[(ActorId, Vec<SyncNeedV1>)],
+) -> Result<(), SyncNeedValidationError> {
+    requests
+        .iter()
+        .flat_map(|(_, needs)| needs)
+        .try_for_each(SyncNeedV1::validate)
+}
+
 async fn process_sync(
     pool: SplitPool,
     bookie: Bookie,
@@ -856,6 +869,8 @@ async fn process_sync(
                     .into_iter()
                     .map(|(actor_id, reqs)| (actor_id, reqs.flat_map(|(_, reqs)| reqs).collect()))
                     .collect::<Vec<(ActorId, Vec<SyncNeedV1>)>>();
+
+                validate_sync_needs(&agg)?;
 
                 for (actor_id, needs) in agg {
                     let booked = bookie.get(&actor_id);
@@ -1098,7 +1113,7 @@ pub async fn parallel_sync(
 
                     counter!("corro.sync.client.member", "traffic" => "sync").increment(1);
 
-                    let needs = our_sync_state.compute_available_needs(&their_sync_state);
+                    let needs = our_sync_state.compute_available_needs(&their_sync_state)?;
 
                     debug!(%actor_id, self_actor_id = %agent.actor_id(), "computed needs: {:?}, their_sync_state: {:?}", needs, their_sync_state);
 
@@ -1737,6 +1752,36 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn range_validation_checks_all_direct_needs_before_processing() {
+        let actor_id = ActorId(uuid::Uuid::new_v4());
+        let other_actor_id = ActorId(uuid::Uuid::new_v4());
+        let requests = vec![
+            (
+                actor_id,
+                vec![SyncNeedV1::Full {
+                    versions: dbvr!(5, 5),
+                }],
+            ),
+            (
+                other_actor_id,
+                vec![SyncNeedV1::Full {
+                    versions: dbvr!(10, 5),
+                }],
+            ),
+        ];
+
+        assert_eq!(
+            validate_sync_needs(&requests),
+            Err(SyncNeedValidationError::InvertedFull {
+                start: CrsqlDbVersion(10),
+                end: CrsqlDbVersion(5),
+            })
+        );
+
+        assert!(validate_sync_needs(&requests[..1]).is_ok());
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sync_changes_order() -> eyre::Result<()> {

--- a/crates/corro-types/src/broadcast.rs
+++ b/crates/corro-types/src/broadcast.rs
@@ -263,10 +263,87 @@ pub enum ChangeSource {
     Sync,
 }
 
-#[derive(Debug, Clone, PartialEq, Readable, Writable)]
+#[derive(Debug, Clone, PartialEq, Writable)]
 pub struct ChangeV1 {
     pub actor_id: ActorId,
     pub changeset: Changeset,
+}
+
+#[derive(Readable)]
+struct UnvalidatedChangeV1 {
+    actor_id: ActorId,
+    changeset: Changeset,
+}
+
+impl<'a, C> Readable<'a, C> for ChangeV1
+where
+    C: Context,
+{
+    fn read_from<R: Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+        let change = UnvalidatedChangeV1::read_from(reader)?;
+        let change = Self {
+            actor_id: change.actor_id,
+            changeset: change.changeset,
+        };
+
+        change
+            .validate()
+            .map_err(|error| speedy::Error::custom(error.to_string()))?;
+
+        Ok(change)
+    }
+
+    #[inline]
+    fn minimum_bytes_needed() -> usize {
+        <UnvalidatedChangeV1 as Readable<'a, C>>::minimum_bytes_needed()
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum ChangeValidationError {
+    #[error("invalid changeset version range: start {start} is greater than end {end}")]
+    InvertedVersions {
+        start: CrsqlDbVersion,
+        end: CrsqlDbVersion,
+    },
+    #[error("invalid changeset sequence range: start {start} is greater than end {end}")]
+    InvertedSeqs { start: CrsqlSeq, end: CrsqlSeq },
+}
+
+impl ChangeV1 {
+    pub fn validate(&self) -> Result<(), ChangeValidationError> {
+        match &self.changeset {
+            Changeset::Empty { versions, .. } => validate_versions(*versions)?,
+            Changeset::EmptySet { versions, .. } => {
+                for versions in versions {
+                    validate_versions(*versions)?;
+                }
+            }
+            Changeset::Full { .. } | Changeset::FullV2 { .. } => {}
+        }
+
+        if let Some(seqs) = self.seqs() {
+            if seqs.start() > seqs.end() {
+                return Err(ChangeValidationError::InvertedSeqs {
+                    start: seqs.start(),
+                    end: seqs.end(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_versions(versions: CrsqlDbVersionRange) -> Result<(), ChangeValidationError> {
+    if versions.start() > versions.end() {
+        return Err(ChangeValidationError::InvertedVersions {
+            start: versions.start(),
+            end: versions.end(),
+        });
+    }
+
+    Ok(())
 }
 
 impl Deref for ChangeV1 {

--- a/crates/corro-types/src/sync.rs
+++ b/crates/corro-types/src/sync.rs
@@ -81,7 +81,7 @@ pub enum SyncRejectionV1 {
     DifferentCluster,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Readable, Writable, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Writable, Serialize, Deserialize)]
 pub struct SyncStateV1 {
     pub actor_id: ActorId,
     pub heads: HashMap<ActorId, CrsqlDbVersion>,
@@ -91,7 +91,97 @@ pub struct SyncStateV1 {
     pub last_cleared_ts: Option<Timestamp>,
 }
 
+// Keep the generated wire decoder separate from the validated public type. The
+// wire layout is identical to `SyncStateV1`, but conversion into the public
+// type only succeeds after every inclusive range has been checked.
+#[derive(Readable)]
+struct UnvalidatedSyncStateV1 {
+    actor_id: ActorId,
+    heads: HashMap<ActorId, CrsqlDbVersion>,
+    need: HashMap<ActorId, Vec<RangeInclusive<CrsqlDbVersion>>>,
+    partial_need: HashMap<ActorId, HashMap<CrsqlDbVersion, Vec<RangeInclusive<CrsqlSeq>>>>,
+    #[speedy(default_on_eof)]
+    last_cleared_ts: Option<Timestamp>,
+}
+
+impl<'a, C> Readable<'a, C> for SyncStateV1
+where
+    C: speedy::Context,
+{
+    fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+        let state = UnvalidatedSyncStateV1::read_from(reader)?;
+        let state = Self {
+            actor_id: state.actor_id,
+            heads: state.heads,
+            need: state.need,
+            partial_need: state.partial_need,
+            last_cleared_ts: state.last_cleared_ts,
+        };
+
+        state
+            .validate()
+            .map_err(|error| speedy::Error::custom(error.to_string()))?;
+
+        Ok(state)
+    }
+
+    #[inline]
+    fn minimum_bytes_needed() -> usize {
+        <UnvalidatedSyncStateV1 as Readable<'a, C>>::minimum_bytes_needed()
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum SyncStateValidationError {
+    #[error("invalid need range for actor {actor_id}: start {start} is greater than end {end}")]
+    InvertedNeed {
+        actor_id: ActorId,
+        start: CrsqlDbVersion,
+        end: CrsqlDbVersion,
+    },
+    #[error(
+        "invalid partial need range for actor {actor_id} at version {version}: start {start} is greater than end {end}"
+    )]
+    InvertedPartialNeed {
+        actor_id: ActorId,
+        version: CrsqlDbVersion,
+        start: CrsqlSeq,
+        end: CrsqlSeq,
+    },
+}
+
 impl SyncStateV1 {
+    pub fn validate(&self) -> Result<(), SyncStateValidationError> {
+        for (actor_id, ranges) in &self.need {
+            for range in ranges {
+                if range.start() > range.end() {
+                    return Err(SyncStateValidationError::InvertedNeed {
+                        actor_id: *actor_id,
+                        start: *range.start(),
+                        end: *range.end(),
+                    });
+                }
+            }
+        }
+
+        for (actor_id, partials) in &self.partial_need {
+            for (version, ranges) in partials {
+                for range in ranges {
+                    if range.start() > range.end() {
+                        return Err(SyncStateValidationError::InvertedPartialNeed {
+                            actor_id: *actor_id,
+                            version: *version,
+                            start: *range.start(),
+                            end: *range.end(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn need_len(&self) -> u64 {
         self.need
             .values()
@@ -132,7 +222,10 @@ impl SyncStateV1 {
     pub fn compute_available_needs(
         &self,
         other: &SyncStateV1,
-    ) -> HashMap<ActorId, Vec<SyncNeedV1>> {
+    ) -> Result<HashMap<ActorId, Vec<SyncNeedV1>>, SyncStateValidationError> {
+        self.validate()?;
+        other.validate()?;
+
         let mut needs: HashMap<ActorId, Vec<SyncNeedV1>> = HashMap::new();
 
         for (actor_id, head) in other.heads.iter() {
@@ -246,11 +339,11 @@ impl SyncStateV1 {
             }
         }
 
-        needs
+        Ok(needs)
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Readable, Writable)]
+#[derive(Debug, Clone, PartialEq, Writable)]
 pub enum SyncNeedV1 {
     Full {
         versions: CrsqlDbVersionRange,
@@ -264,7 +357,85 @@ pub enum SyncNeedV1 {
     },
 }
 
+#[derive(Readable)]
+enum UnvalidatedSyncNeedV1 {
+    Full {
+        versions: CrsqlDbVersionRange,
+    },
+    Partial {
+        version: CrsqlDbVersion,
+        seqs: Vec<CrsqlSeqRange>,
+    },
+    Empty {
+        ts: Option<Timestamp>,
+    },
+}
+
+impl<'a, C> Readable<'a, C> for SyncNeedV1
+where
+    C: speedy::Context,
+{
+    fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+        let need = match UnvalidatedSyncNeedV1::read_from(reader)? {
+            UnvalidatedSyncNeedV1::Full { versions } => Self::Full { versions },
+            UnvalidatedSyncNeedV1::Partial { version, seqs } => Self::Partial { version, seqs },
+            UnvalidatedSyncNeedV1::Empty { ts } => Self::Empty { ts },
+        };
+
+        need.validate()
+            .map_err(|error| speedy::Error::custom(error.to_string()))?;
+
+        Ok(need)
+    }
+
+    #[inline]
+    fn minimum_bytes_needed() -> usize {
+        <UnvalidatedSyncNeedV1 as Readable<'a, C>>::minimum_bytes_needed()
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum SyncNeedValidationError {
+    #[error("invalid full sync range: start {start} is greater than end {end}")]
+    InvertedFull {
+        start: CrsqlDbVersion,
+        end: CrsqlDbVersion,
+    },
+    #[error(
+        "invalid partial sync range at version {version}: start {start} is greater than end {end}"
+    )]
+    InvertedPartial {
+        version: CrsqlDbVersion,
+        start: CrsqlSeq,
+        end: CrsqlSeq,
+    },
+}
+
 impl SyncNeedV1 {
+    pub fn validate(&self) -> Result<(), SyncNeedValidationError> {
+        match self {
+            Self::Full { versions } if versions.start() > versions.end() => {
+                Err(SyncNeedValidationError::InvertedFull {
+                    start: versions.start(),
+                    end: versions.end(),
+                })
+            }
+            Self::Partial { version, seqs } => {
+                for range in seqs {
+                    if range.start() > range.end() {
+                        return Err(SyncNeedValidationError::InvertedPartial {
+                            version: *version,
+                            start: range.start(),
+                            end: range.end(),
+                        });
+                    }
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
     #[inline]
     pub fn count(&self) -> usize {
         match self {
@@ -420,7 +591,7 @@ mod tests {
         other_state.heads.insert(actor1, CrsqlDbVersion(13));
 
         assert_eq!(
-            our_state.compute_available_needs(&other_state),
+            our_state.compute_available_needs(&other_state).unwrap(),
             [(
                 actor1,
                 vec![SyncNeedV1::Full {
@@ -434,7 +605,7 @@ mod tests {
         our_state.need.entry(actor1).or_default().push(dbvri!(7, 7));
 
         assert_eq!(
-            our_state.compute_available_needs(&other_state),
+            our_state.compute_available_needs(&other_state).unwrap(),
             [(
                 actor1,
                 vec![
@@ -458,7 +629,7 @@ mod tests {
         );
 
         assert_eq!(
-            our_state.compute_available_needs(&other_state),
+            our_state.compute_available_needs(&other_state).unwrap(),
             [(
                 actor1,
                 vec![
@@ -486,7 +657,7 @@ mod tests {
         );
 
         assert_eq!(
-            our_state.compute_available_needs(&other_state),
+            our_state.compute_available_needs(&other_state).unwrap(),
             [(
                 actor1,
                 vec![
@@ -554,5 +725,283 @@ mod tests {
         let decoded = SyncMessage::from_buf(&mut buf).unwrap();
 
         assert_eq!(decoded, SyncMessage::V1(SyncMessageV1::Changeset(change)));
+    }
+}
+
+#[cfg(test)]
+mod wire_range_validation_tests {
+    use super::*;
+    use crate::{
+        base::{dbsr, dbsri, dbvr, dbvri, CrsqlSeqRange},
+        broadcast::{BroadcastV1, ChangeValidationError, Changeset, ChangesetPerTable},
+    };
+    use rangemap::RangeInclusiveSet;
+    use speedy::{Readable, Writable};
+    use uuid::Uuid;
+
+    fn actor() -> ActorId {
+        ActorId(Uuid::from_u128(1))
+    }
+
+    fn assert_wire_rejects(message: SyncMessage, expected: &str) {
+        let bytes = message.write_to_vec().unwrap();
+        let error = SyncMessage::read_from_buffer(&bytes).unwrap_err();
+
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected decode error: {error}"
+        );
+    }
+
+    fn assert_wire_roundtrip(message: SyncMessage) {
+        let bytes = message.write_to_vec().unwrap();
+        assert_eq!(SyncMessage::read_from_buffer(&bytes).unwrap(), message);
+    }
+
+    fn request(need: SyncNeedV1) -> SyncMessage {
+        SyncMessage::V1(SyncMessageV1::Request(vec![(actor(), vec![need])]))
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_need_range() {
+        let target = actor();
+        let mut state = SyncStateV1::default();
+        state.heads.insert(target, CrsqlDbVersion(20));
+        state.need.insert(target, vec![dbvri!(10, 5)]);
+
+        assert_wire_rejects(
+            SyncMessage::V1(SyncMessageV1::State(state)),
+            "invalid need range for actor",
+        );
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_partial_need_range() {
+        let target = actor();
+        let mut state = SyncStateV1::default();
+        state.heads.insert(target, CrsqlDbVersion(20));
+        state
+            .partial_need
+            .insert(target, [(CrsqlDbVersion(11), vec![dbsri!(60, 50)])].into());
+
+        assert_wire_rejects(
+            SyncMessage::V1(SyncMessageV1::State(state)),
+            "invalid partial need range for actor",
+        );
+    }
+
+    #[test]
+    fn wire_decode_accepts_valid_need_and_partial_ranges() {
+        let target = actor();
+        let mut state = SyncStateV1::default();
+        state.heads.insert(target, CrsqlDbVersion(20));
+        state.need.insert(target, vec![dbvri!(5, 10)]);
+        state
+            .partial_need
+            .insert(target, [(CrsqlDbVersion(11), vec![dbsri!(50, 60)])].into());
+
+        assert_wire_roundtrip(SyncMessage::V1(SyncMessageV1::State(state)));
+    }
+
+    #[test]
+    fn compute_available_needs_returns_error_on_inverted_need() {
+        let target = actor();
+        let our = SyncStateV1::default();
+        let mut theirs = SyncStateV1::default();
+        theirs.heads.insert(target, CrsqlDbVersion(20));
+        theirs.need.insert(target, vec![dbvri!(10, 5)]);
+
+        assert_eq!(
+            our.compute_available_needs(&theirs).unwrap_err(),
+            SyncStateValidationError::InvertedNeed {
+                actor_id: target,
+                start: CrsqlDbVersion(10),
+                end: CrsqlDbVersion(5),
+            }
+        );
+    }
+
+    #[test]
+    fn compute_available_needs_returns_error_on_inverted_partial_need() {
+        let target = actor();
+        let mut our = SyncStateV1::default();
+        our.partial_need
+            .insert(target, [(CrsqlDbVersion(9), vec![dbsri!(100, 120)])].into());
+
+        let mut theirs = SyncStateV1::default();
+        theirs.heads.insert(target, CrsqlDbVersion(20));
+        theirs
+            .partial_need
+            .insert(target, [(CrsqlDbVersion(9), vec![dbsri!(50, 10)])].into());
+
+        assert_eq!(
+            our.compute_available_needs(&theirs).unwrap_err(),
+            SyncStateValidationError::InvertedPartialNeed {
+                actor_id: target,
+                version: CrsqlDbVersion(9),
+                start: CrsqlSeq(50),
+                end: CrsqlSeq(10),
+            }
+        );
+    }
+
+    #[test]
+    fn compute_available_needs_accepts_valid_ranges() {
+        let target = actor();
+        let mut our = SyncStateV1::default();
+        our.need.insert(target, vec![dbvri!(5, 10)]);
+        let mut theirs = SyncStateV1::default();
+        theirs.heads.insert(target, CrsqlDbVersion(20));
+
+        assert!(our.compute_available_needs(&theirs).is_ok());
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_full_sync_request() {
+        assert_wire_rejects(
+            request(SyncNeedV1::Full {
+                versions: dbvr!(10, 5),
+            }),
+            "invalid full sync range",
+        );
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_partial_sync_request() {
+        assert_wire_rejects(
+            request(SyncNeedV1::Partial {
+                version: CrsqlDbVersion(10),
+                seqs: vec![dbsr!(10, 5)],
+            }),
+            "invalid partial sync range",
+        );
+    }
+
+    #[test]
+    fn wire_decode_accepts_valid_sync_request_ranges() {
+        let message = SyncMessage::V1(SyncMessageV1::Request(vec![(
+            actor(),
+            vec![
+                SyncNeedV1::Full {
+                    versions: dbvr!(5, 10),
+                },
+                SyncNeedV1::Partial {
+                    version: CrsqlDbVersion(11),
+                    seqs: vec![dbsr!(50, 60)],
+                },
+            ],
+        )]));
+
+        assert_wire_roundtrip(message);
+    }
+
+    fn full_v2_change(seqs: CrsqlSeqRange) -> ChangeV1 {
+        let actor_id = actor();
+        ChangeV1 {
+            actor_id,
+            changeset: Changeset::FullV2 {
+                actor_id,
+                version: CrsqlDbVersion(7),
+                changes: ChangesetPerTable::default(),
+                seqs,
+                last_seq: CrsqlSeq(20),
+                ts: Timestamp::zero(),
+            },
+        }
+    }
+
+    fn decode_sync_change(change: ChangeV1) -> Result<ChangeV1, String> {
+        let bytes = SyncMessage::V1(SyncMessageV1::Changeset(change))
+            .write_to_vec()
+            .unwrap();
+        match SyncMessage::read_from_buffer(&bytes).map_err(|error| error.to_string())? {
+            SyncMessage::V1(SyncMessageV1::Changeset(change)) => Ok(change),
+            message => Err(format!("expected a changeset, got {message:?}")),
+        }
+    }
+
+    fn decode_broadcast_change(change: ChangeV1) -> Result<ChangeV1, String> {
+        let bytes = BroadcastV1::Change(change).write_to_vec().unwrap();
+        BroadcastV1::read_from_buffer(&bytes)
+            .map_err(|error| error.to_string())?
+            .into_change(None)
+            .map_err(|error| error.to_string())
+    }
+
+    fn assert_decode_error(result: Result<ChangeV1, String>, expected: &str) {
+        let error = result.unwrap_err();
+        assert!(error.contains(expected), "unexpected decode error: {error}");
+    }
+
+    fn assert_invalid_versions(changeset: Changeset) {
+        let change = ChangeV1 {
+            actor_id: actor(),
+            changeset,
+        };
+
+        assert_eq!(
+            change.validate().unwrap_err(),
+            ChangeValidationError::InvertedVersions {
+                start: CrsqlDbVersion(10),
+                end: CrsqlDbVersion(5),
+            }
+        );
+        assert_decode_error(
+            decode_broadcast_change(change),
+            "invalid changeset version range",
+        );
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_empty_changeset_versions() {
+        assert_invalid_versions(Changeset::Empty {
+            versions: dbvr!(10, 5),
+            ts: None,
+        });
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_empty_set_changeset_versions() {
+        assert_invalid_versions(Changeset::EmptySet {
+            versions: vec![dbvr!(10, 5)],
+            ts: Timestamp::zero(),
+        });
+    }
+
+    #[test]
+    fn wire_decode_rejects_inverted_changeset_seqs() {
+        let change = full_v2_change(dbsr!(10, 5));
+
+        assert_eq!(
+            change.validate().unwrap_err(),
+            ChangeValidationError::InvertedSeqs {
+                start: CrsqlSeq(10),
+                end: CrsqlSeq(5),
+            }
+        );
+
+        assert_decode_error(
+            decode_sync_change(change.clone()),
+            "invalid changeset sequence range",
+        );
+        assert_decode_error(
+            decode_broadcast_change(change),
+            "invalid changeset sequence range",
+        );
+    }
+
+    #[test]
+    fn wire_decode_accepts_valid_changeset_seqs_for_seen_cache() {
+        let change = full_v2_change(dbsr!(5, 10));
+        let decoded = decode_sync_change(change.clone()).unwrap();
+
+        let seqs = decoded.seqs().unwrap();
+        let mut entry: RangeInclusiveSet<CrsqlSeq> = RangeInclusiveSet::new();
+        entry.extend([seqs.into()]);
+        assert!(entry.contains(&CrsqlSeq(5)));
+        assert!(entry.contains(&CrsqlSeq(10)));
+
+        let decoded = decode_broadcast_change(change).unwrap();
+        assert_eq!(decoded.seqs(), Some(dbsr!(5, 10)));
     }
 }


### PR DESCRIPTION

## Summary

- Validate sync-state, sync-request, and change ranges as they are decoded.
- Return typed errors when in-memory sync state reaches `compute_available_needs` with an invalid range.
- Validate every aggregated in-memory sync request before actor and range filtering.
- Recheck requests at `handle_need` for callers that bypass the normal batch path.
- Log and drop invalid queued changes before they reach metrics, deduplication, clock handling, or the seen cache.

The custom Speedy readers decode into private unvalidated representations and construct the existing public types only after validation. Their field order, enum variant order, and minimum-size hints remain unchanged, so valid serialized messages keep the same representation.

`ChangeV1` validation covers sequence ranges in full changesets and every version range in empty and empty-set changesets.

## Tests

- Added rejection tests for full and partial sync state.
- Added rejection tests for full and partial sync requests.
- Added sync computation controls for valid and invalid in-memory state.
- Added sync and broadcast tests for invalid change version and sequence ranges.
- Added valid round-trip and seen-cache controls.
- Added a batch preflight control that validates all direct requests before filtering.
- Compared valid state, request, and change encodings from the exact base and fixed source byte-for-byte.
- `cargo test --locked -p corro-types range_validation_tests`
- `cargo test --locked -p corro-agent range_validation_checks_all_direct_needs_before_processing`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo nextest run --locked --profile ci --workspace --target x86_64-unknown-linux-gnu`
- `mdbook build`

Results: 14 of 14 focused tests passed. Valid baseline and fixed encodings produced the same SHA-256. The exact CI run passed 167 of 167 tests with 10 upstream skips; one existing pubsub test passed on its second configured attempt. Clippy, formatting, mdBook, linkcheck, and diff checks passed.

## Compatibility

Valid messages are unchanged on the wire. The behavioral change is limited to rejecting ranges whose start is greater than their end.

Closes #548
