### PR TITLE
Run change-handler maintenance independently of batch timeout

### DIFF
--- a/crates/corro-agent/src/agent/handlers.rs
+++ b/crates/corro-agent/src/agent/handlers.rs
@@ -991,6 +991,8 @@ pub async fn handle_changes(
     mut tripwire: Tripwire,
 ) {
     let max_queue_len: usize = agent.config().perf.processing_queue_len;
+    let maintenance_duration =
+        Duration::from_millis(agent.config().perf.apply_queue_timeout.max(1) as u64);
 
     // Initialize batch processor state
     let mut state = HandleChangesState::new(
@@ -1014,10 +1016,27 @@ pub async fn handle_changes(
         0
     };
     let mut seen: IndexMap<_, RangeInclusiveSet<CrsqlSeq>> = IndexMap::new();
+    let mut maintenance_interval = tokio::time::interval(maintenance_duration);
+    maintenance_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {
         let (change, src, original_bcast) = tokio::select! {
             biased;
+
+            // Queue metrics and cache maintenance must keep running while a
+            // processing task and its backlog keep the batching timeout disabled.
+            _ = maintenance_interval.tick() => {
+                gauge!("corro.agent.changes.in_queue").set(state.buf_cost as f64);
+                gauge!("corro.agent.changesets.in_queue").set(state.queue.len() as f64);
+                gauge!("corro.agent.changes.processing.jobs").set(if state.processing_task.is_some() { 1.0 } else { 0.0 });
+                metrics_tracker.observe_queue_size(state.queue.len() as u64);
+
+                if seen.len() > max_seen_cache_len {
+                    seen.drain(..seen.len() - keep_seen_cache_size);
+                }
+
+                continue;
+            },
 
             // Processing task finished
             res = async { state.processing_task.as_mut().unwrap().await }, if state.processing_task.is_some() => {
@@ -1033,18 +1052,7 @@ pub async fn handle_changes(
 
             // Timeout fires
             _ = async { state.max_wait.as_mut().unwrap().await }, if state.max_wait.is_some() => {
-                // Emit metrics
-                gauge!("corro.agent.changes.in_queue").set(state.buf_cost as f64);
-                gauge!("corro.agent.changesets.in_queue").set(state.queue.len() as f64);
-                gauge!("corro.agent.changes.processing.jobs").set(if state.processing_task.is_some() { 1.0 } else { 0.0 });
-                metrics_tracker.observe_queue_size(state.queue.len() as u64);
-
                 state.handle_timeout(&agent, &bookie);
-
-                // Cleanup seen cache
-                if seen.len() > max_seen_cache_len {
-                    seen.drain(..seen.len() - keep_seen_cache_size);
-                }
 
                 continue;
             },
@@ -1534,6 +1542,134 @@ mod tests {
              the seen cache still holds the entry that should have been evicted \
              when the change was dropped from the full queue"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_seen_cache_trim_runs_while_backlogged() -> eyre::Result<()> {
+        _ = tracing_subscriber::fmt::try_init();
+        let (tripwire, tripwire_worker, tripwire_tx) = Tripwire::new_simple();
+        let dir = tempfile::tempdir()?;
+
+        let mut config = Config::builder()
+            .db_path(dir.path().join("corrosion.db").display().to_string())
+            .gossip_addr("127.0.0.1:0".parse()?)
+            .api_addr("127.0.0.1:0".parse()?)
+            .build()?;
+        config.perf.processing_queue_len = 4;
+        config.perf.apply_queue_min_batch_size = 2;
+        config.perf.apply_queue_max_batch_size = 2;
+        config.perf.apply_queue_step_base = 0;
+        config.perf.apply_queue_batch_threshold_ratio = 1.0;
+        config.perf.apply_queue_timeout = 20;
+        // A one-slot channel: every send below returns only once the handler has
+        // taken the previous change, so the queue and the seen cache are already
+        // built up by the time the test sleeps.
+        config.perf.changes_channel_len = 1;
+
+        let (agent, agent_options) = setup(config, tripwire.clone()).await?;
+        execute_schema(&agent, vec![TEST_SCHEMA.to_owned()]).await?;
+
+        // Hold the only write permit. Every batch the handler spawns blocks on
+        // it before it reaches SQLite, so the queue stays backlogged and the
+        // batching timeout stays disarmed for as long as this is held. Nothing
+        // here depends on how long a SQLite busy handler waits.
+        let permit = agent.write_permit().await?;
+
+        let other_actor = ActorId(uuid::Uuid::new_v4());
+        let bookie = Bookie::new(Default::default());
+        let handler = tokio::spawn(handle_changes(
+            agent.clone(),
+            bookie.clone(),
+            agent_options.rx_changes,
+            tripwire,
+        ));
+
+        let change = |version: u64| -> eyre::Result<_> {
+            let crsql_row = Change {
+                table: TableName("tests".into()),
+                pk: pack_columns(&vec![(version as i64).into()])?,
+                cid: ColumnName("text".into()),
+                val: format!("version {version}").into(),
+                col_version: 1,
+                db_version: CrsqlDbVersion(version),
+                seq: CrsqlSeq(0),
+                site_id: other_actor.to_bytes(),
+                cl: 1,
+            };
+            Ok((
+                ChangeV1 {
+                    actor_id: other_actor,
+                    changeset: Changeset::Full {
+                        version: CrsqlDbVersion(version),
+                        changes: vec![crsql_row],
+                        seqs: dbsr!(0, 0),
+                        last_seq: CrsqlSeq(0),
+                        ts: agent.clock().new_timestamp().into(),
+                    },
+                },
+                ChangeSource::Sync,
+                None,
+            ))
+        };
+
+        // Versions 1 and 2 are drained into the blocked batch. Versions 3 and 4
+        // are then pushed out of the four-slot queue by 7 and 8. Dropping a full
+        // change takes its sequences out of the seen cache but keeps its key, so
+        // the cache now holds eight keys against a cap of four.
+        for version in 1..=8 {
+            agent.tx_changes().send(change(version)?).await?;
+        }
+
+        // Ten apply timeouts. The batch is still blocked and the queue is still
+        // backlogged for every one of them, so max_wait stays disarmed and only
+        // the maintenance tick can trim the cache.
+        sleep(Duration::from_millis(200)).await;
+        assert!(
+            !bookie
+                .get(&other_actor)
+                .is_some_and(|booked| booked.read().contains_version(&CrsqlDbVersion(3))),
+            "the write permit should keep every batch out of SQLite"
+        );
+
+        // Version 3 was dropped from the queue and is in no batch, so nothing
+        // will ever book it. An empty changeset is deduplicated on the seen-cache
+        // key alone, so this copy survives only if maintenance trimmed the cache
+        // during the backlog.
+        agent
+            .tx_changes()
+            .send((
+                ChangeV1 {
+                    actor_id: other_actor,
+                    changeset: Changeset::Empty {
+                        versions: dbvr!(3, 3),
+                        ts: Some(agent.clock().new_timestamp().into()),
+                    },
+                },
+                ChangeSource::Sync,
+                None,
+            ))
+            .await?;
+
+        drop(permit);
+
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if bookie
+                    .get(&other_actor)
+                    .is_some_and(|booked| booked.read().contains_version(&CrsqlDbVersion(3)))
+                {
+                    break;
+                }
+                sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await?;
+
+        tripwire_tx.send(()).await.ok();
+        tripwire_worker.await;
+        handler.await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- add a dedicated maintenance interval to `handle_changes`;
- move seen-cache trimming and queue metric updates to that interval; and
- cover failed-version retry under sustained backlog with a real-handler regression test.

## Why

The burst scheduler disables its optional `max_wait` sleep while processing full batches. Cache trimming and metric updates were attached to that same sleep, so both stopped for as long as enough work remained queued.

That can suppress recovery from a failed batch: the version is absent from the bookie but still present in the recent-`seen` cache, and subsequent copies are discarded as duplicates.

## Implementation

`handle_changes` now owns a Tokio interval at the configured `apply_queue_timeout` cadence. Maintenance is the first branch of the biased `select!`, which ensures a ready tick wins over completed jobs and a hot inbound channel. Missed ticks use `Skip`, and the maintenance duration has a 1 ms floor because Tokio rejects zero-duration intervals.

The existing cache threshold and retention calculation are unchanged. The optional `max_wait` sleep remains responsible only for flushing sub-threshold batches.

## Coordination

This may have a mechanical conflict with #527, which refactors `handle_changes`. If #527 lands first, I am happy to port this fix to the new actor layout.

## Test

`test_seen_cache_trim_runs_while_backlogged`:

- starts the real handler and SQLite processing path;
- forces the first two versions to fail with a bounded SQLite busy lock;
- sends enough later versions to exceed the seen-cache cap while work remains backlogged;
- releases SQLite; and
- verifies that a second copy of the failed version is accepted and applied.

The test fails on `936de111` with a retry deadline and passes with this change.

## Validation

- targeted regression: passed, including five consecutive runs;
- `cargo test -p corro-agent`: 51 passed, 2 ignored;
- `cargo clippy --all-targets -- -D warnings`: passed;
- `cargo fmt --all -- --check`: passed;
- `RUSTFLAGS='--cfg tokio_unstable' cargo nextest run --profile ci --workspace --target x86_64-unknown-linux-gnu`: 154 passed, 10 skipped.
- final verification on the committed tree: 154/154 executed CI-profile tests
  passed, with 10 configured skips; clippy, formatting, and diff checks passed.

## Performance and risk

This restores maintenance independence that existed before burst batching and does not
alter batch sizing, queue shedding, deduplication keys, or cache retention amounts. It
does add a periodic wake-up alongside the batching timeout. At the default 10 ms
cadence, the branch performs three gauge updates, one queue-size observation, and a
constant-time cache-size check; an actual trim is linear in entries removed. Missed
ticks are skipped. No throughput benchmark was run, so this draft does not characterize
the runtime cost as zero or negligible.

Fixes #552