### PR TITLE
Size sync send-buffer flushes to the QUIC congestion window

### DIFF
--- a/crates/corro-agent/src/agent/bi.rs
+++ b/crates/corro-agent/src/agent/bi.rs
@@ -55,6 +55,7 @@ pub fn spawn_bipayload_handler(
             tokio::spawn({
                 let agent = agent.clone();
                 let bookie = bookie.clone();
+                let conn = conn.clone();
                 async move {
                     let mut framed = FramedRead::new(
                         rx,
@@ -101,6 +102,7 @@ pub fn spawn_bipayload_handler(
                                                             cluster_id,
                                                             framed,
                                                             tx,
+                                                            &conn,
                                                         )
                                                         .await
                                                         {

--- a/crates/corro-agent/src/api/peer/mod.rs
+++ b/crates/corro-agent/src/api/peer/mod.rs
@@ -374,6 +374,34 @@ const MIN_CHANGES_BYTES_PER_MESSAGE: usize = 1024;
 
 const ADAPT_CHUNK_SIZE_THRESHOLD: Duration = Duration::from_millis(500);
 
+/// Never flush on buffers smaller than this, even if the reported congestion
+/// window is tiny (e.g. right after a loss event) — flushing single-digit-KB
+/// chunks would spend most of the time on per-write overhead instead of on
+/// the wire.
+const MIN_SEND_BUF_FLUSH_BYTES: u64 = 4 * 1024;
+
+/// Cap how large a single flush can grow to even if cwnd is large, so one
+/// write_chunk() call can't monopolize the stream for too long and so we
+/// keep responding to backpressure at a reasonable cadence.
+const MAX_SEND_BUF_FLUSH_BYTES: u64 = 256 * 1024;
+
+/// Pick how many bytes to accumulate in `send_buf` before flushing it to the
+/// QUIC stream, based on the connection's current congestion window.
+///
+/// `ConnectionStats.path.cwnd` (see quinn_proto) is the total number of bytes
+/// the congestion controller currently allows in flight on this path; it
+/// grows as the connection proves it can sustain more (slow start / cubic
+/// probing) and shrinks on loss/congestion signals. Sizing our flush against
+/// it means we stop handing `write_chunk` more data than the path can
+/// currently absorb in one round: if `write_chunk` doesn't return quickly,
+/// we've queued more than the peer's receive/congestion window allows, which
+/// is exactly the backpressure signal described in
+/// https://github.com/superfly/corrosion/issues/61.
+fn send_buf_flush_threshold(conn: &quinn::Connection) -> u64 {
+    let cwnd = conn.stats().path.cwnd;
+    cwnd.clamp(MIN_SEND_BUF_FLUSH_BYTES, MAX_SEND_BUF_FLUSH_BYTES)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_need(
     conn: &mut Connection,
@@ -1423,7 +1451,7 @@ pub async fn parallel_sync(
         .sum::<usize>())
 }
 
-#[tracing::instrument(skip(agent, bookie, their_actor_id, read, write), fields(actor_id = %their_actor_id), err)]
+#[tracing::instrument(skip(agent, bookie, their_actor_id, read, write, conn), fields(actor_id = %their_actor_id), err)]
 #[allow(clippy::too_many_arguments)]
 pub async fn serve_sync(
     agent: &Agent,
@@ -1434,6 +1462,7 @@ pub async fn serve_sync(
     cluster_id: ClusterId,
     mut read: FramedRead<RecvStream, LengthDelimitedCodec>,
     mut write: SendStream,
+    conn: &quinn::Connection,
 ) -> Result<usize, SyncError> {
     // only compress if the peer can decode it AND we're locally configured to
     let compression_config = agent.config().gossip.compression_config();
@@ -1608,7 +1637,7 @@ pub async fn serve_sync(
                             };
                             encode_sync_msg(&mut codec, &mut encode_buf, &mut send_buf, msg)?;
 
-                            if send_buf.len() >= 16 * 1024 {
+                            if send_buf.len() as u64 >= send_buf_flush_threshold(conn) {
                                 write_buf(&mut send_buf, &mut write).await.map_err(SyncSendError::from)?;
                             }
                         },


### PR DESCRIPTION
## What changed

The sync send loop in `serve_sync` (`crates/corro-agent/src/api/peer/mod.rs`) accumulates encoded changesets into `send_buf` and flushes to the QUIC stream via `write_chunk` once the buffer hits a fixed `16 * 1024` byte threshold, regardless of what the peer connection's congestion controller currently allows in flight.

This PR replaces that fixed threshold with one derived from the connection's current congestion window (`ConnectionStats.path.cwnd`, via `quinn::Connection::stats()`), clamped to a `[4KB, 256KB]` range:

- `send_buf_flush_threshold()` (new, `api/peer/mod.rs`) reads `conn.stats().path.cwnd` and clamps it.
- `serve_sync` now takes `conn: &quinn::Connection` so it can call the above. Its only caller, `spawn_bipayload_handler` in `crates/corro-agent/src/agent/bi.rs`, already holds the `quinn::Connection` (it's what `accept_bi()` came from), so this is just threading an existing value one level deeper — no new connection lookups.

## Why

From the issue and @gorbak25's follow-up: the sync send path buffers up to a fixed size before writing to the QUIC stream, without regard to the peer's congestion window, and `write_chunk` puts backpressure on the send path once in-flight data exceeds cwnd.

I read the vendored quinn/quinn-proto source this repo pins (`somtochiama/quinn`, see `Cargo.toml`) to confirm the actual mechanics before changing anything:

- `SendStream::write_chunk` (`quinn/src/send_stream.rs`) calls `write_all_chunks`, which loops calling `write_chunks` until all bytes are written or an error occurs. Internally, each `write_chunks` poll that returns `Blocked` registers a waker and yields `Poll::Pending` — i.e. `write_chunk` already loops through backpressure rather than returning early on a partial write. So the "responds to backpressure" part is handled by quinn; what wasn't happening is that the *caller* (corrosion's sync loop) had no way to avoid handing `write_chunk` a chunk far larger than the path could currently carry, which just means a single `write_chunk` call blocks for longer while cwnd catches up, rather than the send loop naturally pacing itself in units that roughly match what fits.
- `ConnectionStats.path.cwnd` (`quinn-proto/src/connection/mod.rs::stats()`, `quinn-proto/src/connection/stats.rs`) is `self.path.congestion.window()` — the *total* congestion window in bytes for the path (not just headroom), sourced from whatever congestion controller is active (this repo uses quinn's default, Cubic). It's initialized to `initial_window` (~14.7KB for Cubic's default) as soon as the path exists, so it's never `0` for a live connection — no special-casing needed for "no cwnd sample yet".

Given `write_chunk`'s internal blocking loop already handles backpressure safely, the fix here is scoped to what the issue actually asks for: making the *chunk size chosen upstream* congestion-aware, rather than reworking `write_chunk` usage itself, which already behaves correctly per quinn's docs/source.

## Verification

- `cargo build -p corro-agent` — clean, no warnings.
- `cargo build --workspace` — clean.
- `cargo clippy -p corro-agent --all-targets -- -D warnings` — clean, no lints.
- `cargo fmt --check -p corro-agent` — clean.
- `cargo test -p corro-agent` — **51 passed, 0 failed, 2 ignored** (pre-existing ignores, unrelated to this change). This includes tests that exercise the sync send path directly: `agent::tests::large_tx_sync`, `api::peer::tests::test_sync_changes_order`, `api::peer::tests::test_handle_need`, plus the broader sync/gossip integration tests (`insert_rows_and_gossip`, `stress_test`, `stress_plumtree_test`, etc.), all of which pass through `serve_sync`.

I did not add a new test asserting a specific chunk size/throughput number: doing so meaningfully would require simulating a congested path with a controlled cwnd trajectory (e.g. via a loss-injecting test harness), which is beyond what the existing test infrastructure supports and would amount to testing quinn's own congestion control rather than corrosion's logic. The existing sync tests do exercise this code path end-to-end (multi-KB/MB transfers across real QUIC connections) and continue to pass, confirming the change doesn't break correctness; the throughput/backpressure improvement itself is a property of production network conditions with real congestion, not something the local test suite can observe.

Fixes #61
