### PR TITLE
fix: fail `consul sync` without configuration

### DIFF
--- a/crates/corrosion/src/main.rs
+++ b/crates/corrosion/src/main.rs
@@ -395,9 +395,7 @@ async fn process_cli(cli: Cli) -> eyre::Result<()> {
                 Some(consul) => {
                     command::consul::sync::run(consul, cli.api_addr()?, cli.db_path()?).await?
                 }
-                None => {
-                    error!("missing `consul` block in corrosion config");
-                }
+                None => eyre::bail!("missing `consul` block in corrosion config"),
             },
         },
         Command::Query {

--- a/integration-tests/tests/cli_test.rs
+++ b/integration-tests/tests/cli_test.rs
@@ -20,6 +20,21 @@ fn test_help() {
     cmd.arg("--help").assert().success();
 }
 
+#[test]
+fn test_consul_sync_requires_consul_config() {
+    let mut cmd = CORROSION_BIN.command();
+    let config_path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../config.example.toml");
+
+    cmd.arg("--config")
+        .arg(config_path)
+        .arg("consul")
+        .arg("sync")
+        .assert()
+        .failure()
+        .stderr("missing `consul` block in corrosion config\n");
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_query() {
     _ = tracing_subscriber::fmt::try_init();


### PR DESCRIPTION
Attempts to fix https://github.com/superfly/corrosion/issues/556

Now the `corrosion consul sync` returns the missing configuration error, so the CLI exits with a non zero status instead of reporting success

PS: the regression test runs the command with `config.example.toml` and checks both the exit status and error message.
