### PR TITLE
Remove unnecessary clones

### DIFF
--- a/crates/corro-agent/src/agent/util.rs
+++ b/crates/corro-agent/src/agent/util.rs
@@ -1192,8 +1192,9 @@ pub async fn process_multiple_changes(
 
         unknown_changes
             .entry(change.actor_id)
-            .and_modify(|(_, per_actor_changes)| per_actor_changes.push((change.clone(), src)))
-            .or_insert_with(|| (booked, vec![(change, src)]));
+            .or_insert_with(|| (booked, vec![]))
+            .1
+            .push((change, src));
     }
     let elapsed = start.elapsed();
     if elapsed >= PROCESSING_WARN_THRESHOLD {

--- a/crates/corro-types/src/bookie.rs
+++ b/crates/corro-types/src/bookie.rs
@@ -466,9 +466,9 @@ impl BookedVersions {
                     if let Some(p) = partial {
                         acc.entry(versions.start())
                             .and_modify(|existing: &mut PartialVersion| {
-                                existing.seqs.extend(p.seqs.clone());
+                                existing.seqs.extend(p.seqs.iter().cloned());
                             })
-                            .or_insert(p.clone());
+                            .or_insert_with(|| p.clone());
                     }
                     acc
                 });

--- a/crates/corro-types/src/gauge.rs
+++ b/crates/corro-types/src/gauge.rs
@@ -46,7 +46,7 @@ impl PersistentGauge {
 impl GaugeRegistry {
     pub fn register(&self, gauge: Gauge, key: u64, persistent: bool) -> PersistentGauge {
         let mut guard = self.gauges.lock().unwrap();
-        let stored_gauge = guard.entry(key).or_insert(StoredGauge {
+        let stored_gauge = guard.entry(key).or_insert_with(|| StoredGauge {
             persistent,
             gauge: Arc::new(gauge),
         });


### PR DESCRIPTION
Hey, first time contributor here! While exploring the codebase, I came across a simple `clone` removal win and check out the rest of the places where we do `and_modify` and `or_insert`.